### PR TITLE
Handle mutation propagated by getitem

### DIFF
--- a/torchdynamo/optimizations/normalize.py
+++ b/torchdynamo/optimizations/normalize.py
@@ -333,7 +333,7 @@ class Functionalization(Transformer):
 
         if (
             not n.meta["is_input_mutation"]
-            and not n.meta["indirect_mutation"]
+            and not n.meta["partial_mutation"]
             and issubclass(n.meta["type"], torch.Tensor)
         ):
             if "inplace" in n.kwargs:


### PR DESCRIPTION
https://github.com/facebookresearch/torchdynamo/commit/a9a894b8c514b1a0f239d4441fcb01e26f340870 commit was quite conservative in handling mutation. This PR restricts the handling to just getitem operator.