### PR TITLE
Add xarray to skipfiles

### DIFF
--- a/torchdynamo/skipfiles.py
+++ b/torchdynamo/skipfiles.py
@@ -140,6 +140,7 @@ for _name in (
     "tree",
     "tvm",
     "fx2trt_oss",
+    "xarray",
 ):
     add(_name)
 


### PR DESCRIPTION
This is a temporary workaround for errors in pplbench_beanmachine.  I suspect #171 will also fix it, though we might want to debug the issues it hit as well.

Note I disabled `pplbench_beanmachine` in my [torchbench fork](https://github.com/jansel/benchmark) because of https://github.com/pytorch/benchmark/issues/898

