### PR TITLE
support inlining __torch_function__ with reading from closure

### DIFF
--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -320,6 +320,7 @@ class VariableBuilder:
                 subclass_type = type(value)
                 return TensorWithTFOverrideVariable(
                     tensor_variable,
+                    self.get_source(),
                     subclass_torch_function__func,
                     subclass_type,
                 )

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -13,6 +13,7 @@ from .. import config
 from .. import variables
 from ..exc import TorchRuntimeError
 from ..exc import unimplemented
+from ..source import AttrSource
 from ..utils import clone_tensor
 from ..utils import istype
 from ..utils import product
@@ -366,12 +367,14 @@ class TensorWithTFOverrideVariable(VariableTracker):
     def __init__(
         self,
         tensor_variable,
+        orig_tensor_variable_source,
         subclass_torch_function__func,
         subclass_type,
         **kwargs,
     ):
         super(TensorWithTFOverrideVariable, self).__init__(**kwargs)
         self.tensor_variable = tensor_variable
+        self.orig_tensor_variable_source = orig_tensor_variable_source
         self.subclass_torch_function__func = subclass_torch_function__func
         self.subclass_type = subclass_type
 
@@ -395,6 +398,7 @@ class TensorWithTFOverrideVariable(VariableTracker):
         unwrapped = TensorWithTFOverrideVariable.inline_torch_function_unwrapped(
             tx,
             func_var,
+            self.orig_tensor_variable_source,
             self.subclass_torch_function__func,
             self.subclass_type,
             options,
@@ -409,6 +413,7 @@ class TensorWithTFOverrideVariable(VariableTracker):
 
         return TensorWithTFOverrideVariable(
             unwrapped,
+            self.orig_tensor_variable_source,
             self.subclass_torch_function__func,
             self.subclass_type,
         )
@@ -417,6 +422,7 @@ class TensorWithTFOverrideVariable(VariableTracker):
     def inline_torch_function_unwrapped(
         tx,
         original_func_var,
+        tensor_with_tf_override_source,
         tf_func,
         subclass_type,
         options,
@@ -431,6 +437,8 @@ class TensorWithTFOverrideVariable(VariableTracker):
 
         And `x0` has an override, then:
         * `original_func_var` will be a `VariableTracker` object wrapping `torch.sigmoid`
+        * `tensor_with_tf_override_source` will be the `Source` object from
+          the original tensor override instance in the beginning of the program
         * `tf_func` will be the custom `__torch_function__` function
         * `subclass_type` will be `type(x0)`
 
@@ -440,10 +448,14 @@ class TensorWithTFOverrideVariable(VariableTracker):
         The caller is responsible for wrapping the return value, if needed.
         """
         from torchdynamo.variables import UserDefinedClassVariable
-        from torchdynamo.variables import UserFunctionVariable
         from torchdynamo.variables.builder import TupleVariable
+        from torchdynamo.variables.builder import VariableBuilder
 
-        tf_func_var = UserFunctionVariable(tf_func, **options)
+        source = AttrSource(
+            AttrSource(tensor_with_tf_override_source, "__torch_function__"),
+            "__func__",
+        )
+        tf_func_var = VariableBuilder(tx, source)(tf_func)
         type_var = UserDefinedClassVariable(subclass_type, **options)
 
         # signature:

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -161,6 +161,7 @@ class TorchVariable(VariableTracker):
             unwrapped = TensorWithTFOverrideVariable.inline_torch_function_unwrapped(
                 tx,
                 self,
+                tensor_with_tf_override.orig_tensor_variable_source,
                 tensor_with_tf_override.subclass_torch_function__func,
                 tensor_with_tf_override.subclass_type,
                 options,
@@ -174,6 +175,7 @@ class TorchVariable(VariableTracker):
                 return unwrapped
             return TensorWithTFOverrideVariable(
                 unwrapped,
+                tensor_with_tf_override.orig_tensor_variable_source,
                 tensor_with_tf_override.subclass_torch_function__func,
                 tensor_with_tf_override.subclass_type,
             )


### PR DESCRIPTION
Summary:

The previous PRs to add `__torch_function__` support inlined through
`__torch_function__` without adding any guards for the function.

This worked for simple cases, but did not work if `__torch_function__`
needs to read a nonlocal variable, for example: https://gist.github.com/vkuzo/a3388fcaa532318d049368e96652b366
The reason it was broken is because the code which bound arguments
during inlining had to have a reference to a source in order to bind
things properly.

One way to fix this is to get the source of the `__torch_function__` attribute
of the original tensor, guard on it, and persist it through
all the rewrapping logic.

I'm flexible if there is a better alternative, lmk.

Test plan:

```
pytest -vsk test_torch_function_with_closure
```