### PR TITLE
Pass backend-related ctx to TorchDynamo Optimize Context

### DIFF
--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -130,10 +130,13 @@ def optimize(backend, nopython=False):
     backend() to optimize extracted graphs.
 
     Args:
-        backend: One of two things:
-            - Either, a function taking a torch.fx.GraphModule and
+        backend: One of the two things:
+            - Either, a function/callable taking a torch.fx.GraphModule and
             example_inputs and returning a python callable that runs the
             graph faster.
+            One can also provide additional context for the backend, like
+            torch.jit.fuser("fuser2"), by setting the backend_ctx_ctor attribute.
+            See AOTAutogradMemoryEfficientFusionWithContext for the usage.
             - Or, a string backend name in `torchdynamo.list_backends()`
         nopython: If True, graph breaks will be errors and there will
             be a single whole-program graph.

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -143,4 +143,14 @@ class AOTAutogradMemoryEfficientFusion(AOTAutogradStrategy):
         return BACKENDS["aot_autograd"](self.gm, self.example_inputs)
 
 
-aot_autograd_speedup_strategy = AOTAutogradMemoryEfficientFusion.compile_fn
+class AOTAutogradMemoryEfficientFusionWithContext:
+    """Pass nvfuser context to TorchDynamo"""
+
+    def __init__(self):
+        self.extra_ctx = torch.jit.fuser("fuser2")
+
+    def __call__(self, gm: torch.fx.GraphModule, example_inputs):
+        return AOTAutogradMemoryEfficientFusion.compile_fn(gm, example_inputs)
+
+
+aot_autograd_speedup_strategy = AOTAutogradMemoryEfficientFusionWithContext()

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -147,7 +147,7 @@ class AOTAutogradMemoryEfficientFusionWithContext:
     """Pass nvfuser context to TorchDynamo"""
 
     def __init__(self):
-        self.extra_ctx = torch.jit.fuser("fuser2")
+        self.backend_ctx_ctor = lambda: torch.jit.fuser("fuser2")
 
     def __call__(self, gm: torch.fx.GraphModule, example_inputs):
         return AOTAutogradMemoryEfficientFusion.compile_fn(gm, example_inputs)


### PR DESCRIPTION
Background - For `aot_autograd_speedup_strategy`, the user can assume that `nvfuser` is turned on by default. But, for now, we have to wrap the model call in `with torch.jit.fuser("fuser2")` separately.

This PR extends Dynamo OptimizationCtx to accept extra ctx from the backend, and directly call `__enter__` and `__exit__`.

@Chillee @jansel 

