### PR TITLE
Skip frames when no graph is found

### DIFF
--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -12,13 +12,13 @@ import torch
 from torch.fx.graph_module import _forward_from_src as original_forward_from_src
 
 from . import config
+from . import exc
 from .bytecode_analysis import remove_dead_code
 from .bytecode_analysis import remove_pointless_jumps
 from .bytecode_transformation import is_generator
 from .bytecode_transformation import transform_code_object
 from .eval_frame import skip_code
 from .exc import InternalTorchDynamoError
-from .exc import RestartAnalysis
 from .exc import TorchRuntimeError
 from .exc import Unsupported
 from .exc import unimplemented
@@ -169,9 +169,11 @@ def convert_frame_assert(compiler_fn: Callable, one_graph=True):
                 try:
                     code = transform_code_object(frame.f_code, transform)
                     break
-                except RestartAnalysis:
+                except exc.RestartAnalysis:
                     if attempt > 100:
                         unimplemented("100+ RestartAnalysis() calls")
+                except exc.SkipFrame:
+                    return None
             output_codes.add(code)
             if config.debug:
                 debug_print("ORIGINAL BYTECODE")

--- a/torchdynamo/exc.py
+++ b/torchdynamo/exc.py
@@ -12,6 +12,10 @@ class RestartAnalysis(RuntimeError):
     pass
 
 
+class SkipFrame(RuntimeError):
+    pass
+
+
 class TorchRuntimeError(RuntimeError):
     pass
 

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -25,6 +25,7 @@ from torchdynamo.source import LocalSource
 from torchdynamo.variables.builder import VariableBuilder
 
 from . import config
+from . import exc
 from . import skipfiles
 from .allowed_functions import is_allowed
 from .allowed_functions import is_builtin
@@ -35,8 +36,6 @@ from .bytecode_transformation import create_instruction
 from .bytecode_transformation import is_generator
 from .bytecode_transformation import unique_id
 from .codegen import PyCodegen
-from .exc import RestartAnalysis
-from .exc import TorchRuntimeError
 from .exc import Unsupported
 from .exc import unimplemented
 from .output_graph import OutputGraph
@@ -278,7 +277,12 @@ class InstructionTranslatorBase(object):
                 and self.step()
             ):
                 pass
-        except (Unsupported, RestartAnalysis, TorchRuntimeError):
+        except (
+            exc.Unsupported,
+            exc.RestartAnalysis,
+            exc.TorchRuntimeError,
+            exc.SkipFrame,
+        ):
             raise
         except Exception as e:
             sys.stderr.write(
@@ -1189,7 +1193,7 @@ class InstructionTranslator(InstructionTranslatorBase):
 
     def RETURN_VALUE(self, inst):
         if self.output.count_calls() == 0:
-            unimplemented("no graph found")
+            raise exc.SkipFrame()
         self.instruction_pointer = None
         self.output.compile_subgraph(self)
         self.output.add_output_instructions([create_instruction("RETURN_VALUE")])


### PR DESCRIPTION
I don't think the `unimplemented("no graph found")` logic was actually working properly in the case where there was a checkpointed state.  It would rollback and still do codegen.