### PR TITLE
add configuration for modules/functions eligible for inlining

### DIFF
--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -12,6 +12,8 @@ from functools import lru_cache
 import numpy
 import torch
 
+from . import config
+
 
 @lru_cache(None)
 def _disallowed_function_ids():
@@ -51,9 +53,10 @@ def _allowed_function_ids():
     torch_object_ids = dict()
 
     def _find_torch_objects(module):
-        if module.__name__.startswith("torch.distributions"):
-            return
-        if module.__name__.startswith("torch.testing"):
+        if any(
+            module.__name__.startswith(mod_name)
+            for mod_name in config.allowed_functions_module_string_ignorelist
+        ):
             return
         torch_object_ids[id(module)] = module.__name__
         for name, obj in list(module.__dict__.items()):

--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -47,3 +47,19 @@ traceable_tensor_subclasses = set()
 
 # Propagate backend exceptions up to torchdynamo.optimize
 raise_on_backend_error = True
+
+# If a PyTorch module is in this allowlist, torchdynamo will be allowed
+# to inline objects from it or its children.
+skipfiles_inline_module_allowlist = {
+    torch.nn,
+    torch.distributions,
+}
+
+# If a string representing a PyTorch module is in this ignorelist,
+# the `allowed_functions.is_allowed` function will not consider it
+# when creating a list of PyTorch functions that will appear in
+# FX IR.
+allowed_functions_module_string_ignorelist = {
+    "torch.distributions",
+    "torch.testing",
+}

--- a/torchdynamo/skipfiles.py
+++ b/torchdynamo/skipfiles.py
@@ -31,6 +31,8 @@ import _collections_abc
 import _weakrefset
 import torch
 
+from . import config
+
 
 def _strip_init_py(s):
     return re.sub(r"__init__.py$", "", s)
@@ -148,8 +150,9 @@ _recompile_re()
 
 
 def is_torch_inline_allowed(filename):
-    return filename.startswith(_module_dir(torch.nn)) or filename.startswith(
-        _module_dir(torch.distributions)
+    return any(
+        filename.startswith(_module_dir(mod))
+        for mod in config.skipfiles_inline_module_allowlist
     )
 
 


### PR DESCRIPTION
Summary:

Makes the source modules/functions for `skipfiles.is_torch_inline_allowed` and `allowed_functions.is_allowed` configurable.

This is needed for DBR quant integration exploration, we can now override this
config to allow torchdynamo to inline DBR quant utility functions.

Test plan:

Run this: https://gist.github.com/vkuzo/f901e9ebf788fb3d23d7f04babf840ca
it now advances past the error of "inlining in skipfiles", and the DBR quant utility functions now appear as `UserFunctionVariable` instead of `TorchVariable`