### PR TITLE
Refine ConstDictVariable python type and add wrapper to class argument

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1157,3 +1157,18 @@ class MiscTests(torchdynamo.testing.TestCase):
         inst = dis.get_instructions(fn)
         result = bytecode_transformation.assemble(inst, fn.__code__.co_firstlineno)
         self.assertTrue(result[1] == fn.__code__.co_lnotab)
+
+    def test_const_dict_variable_python_type(self):
+        from torchdynamo.variables import ConstDictVariable
+
+        d1 = {"a": 10, "b": 20}
+        d2 = collections.OrderedDict([("x", 12), ("y", 22)])
+        # set dict_cls explicitly
+        self.assertEqual(ConstDictVariable(d1, dict).python_type(), dict)
+        self.assertEqual(
+            ConstDictVariable(d2, collections.OrderedDict).python_type(),
+            collections.OrderedDict,
+        )
+        # use default dict_cls
+        self.assertEqual(ConstDictVariable(d1).python_type(), dict)
+        self.assertEqual(ConstDictVariable(d2).python_type(), collections.OrderedDict)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -585,7 +585,7 @@ class InstructionTranslatorBase(object):
     @break_graph_if_unsupported(push=1)
     def CALL_FUNCTION_EX(self, inst):
         if inst.argval == 0:
-            kwargsvars = ConstDictVariable({})
+            kwargsvars = ConstDictVariable({}, dict)
             argsvars = self.pop()
         elif inst.argval == 1:
             kwargsvars = self.pop()
@@ -721,7 +721,11 @@ class InstructionTranslatorBase(object):
             assert isinstance(k, ConstantVariable)
             result[k.value] = v
         assert len(result) == len(items) / 2
-        self.push(ConstDictVariable(result, mutable_local=MutableLocal(), **options))
+        self.push(
+            ConstDictVariable(
+                result, collections.OrderedDict, mutable_local=MutableLocal(), **options
+            )
+        )
 
     def BUILD_CONST_KEY_MAP(self, inst):
         keys = self.pop()
@@ -734,6 +738,7 @@ class InstructionTranslatorBase(object):
         self.push(
             ConstDictVariable(
                 collections.OrderedDict(zip(keys, values)),
+                collections.OrderedDict,
                 mutable_local=MutableLocal(),
                 **options,
             )
@@ -755,6 +760,7 @@ class InstructionTranslatorBase(object):
             obj,
             ConstDictVariable(
                 items,
+                collections.OrderedDict,
                 **VariableTracker.propagate([obj, k, v]),
             ),
         )

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -168,7 +168,7 @@ class VariableBuilder:
                 )
                 for k in keys
             )
-            result = ConstDictVariable(result, guards=guards)
+            result = ConstDictVariable(result, collections.OrderedDict, guards=guards)
             if istype(value, dict):
                 return self.tx.output.side_effects.track_dict(
                     self.source, value, result

--- a/torchdynamo/variables/dicts.py
+++ b/torchdynamo/variables/dicts.py
@@ -14,11 +14,12 @@ from .base import VariableTracker
 
 
 class ConstDictVariable(VariableTracker):
-    def __init__(self, items, **kwargs):
+    def __init__(self, items, dict_cls=collections.OrderedDict, **kwargs):
         super(ConstDictVariable, self).__init__(**kwargs)
-        self._python_type = type(items)
+        self.dict_cls = dict_cls
         if not isinstance(items, collections.OrderedDict):
             assert isinstance(items, dict)
+            self.dict_cls = dict
             items = collections.OrderedDict((k, items[k]) for k in sorted(items.keys()))
         self.items = items
 
@@ -26,7 +27,7 @@ class ConstDictVariable(VariableTracker):
         return {k: v.as_proxy() for k, v in self.items.items()}
 
     def python_type(self):
-        return self._python_type
+        return self.dict_cls
 
     def reconstruct(self, codegen):
         if len(self.items) == 0:
@@ -138,14 +139,6 @@ class ConstDictVariable(VariableTracker):
     def modifed(self, items, **options):
         """a copy of self with different items"""
         return self.clone(items=items, **options)
-
-    def clone(self, **kwargs):
-        """Shallow copy with some (optional) changes"""
-        args = dict(self.__dict__)
-        args.pop("_python_type", None)  # _python_type is used internally
-        kwargs.pop("_python_type", None)
-        args.update(kwargs)
-        return self.__class__(**args)
 
 
 class DataClassVariable(ConstDictVariable):

--- a/torchdynamo/variables/dicts.py
+++ b/torchdynamo/variables/dicts.py
@@ -21,6 +21,8 @@ class ConstDictVariable(VariableTracker):
             assert isinstance(items, dict)
             self.dict_cls = dict
             items = collections.OrderedDict((k, items[k]) for k in sorted(items.keys()))
+        else:
+            assert self.dict_cls == collections.OrderedDict
         self.items = items
 
     def as_proxy(self):

--- a/torchdynamo/variables/dicts.py
+++ b/torchdynamo/variables/dicts.py
@@ -16,6 +16,7 @@ from .base import VariableTracker
 class ConstDictVariable(VariableTracker):
     def __init__(self, items, **kwargs):
         super(ConstDictVariable, self).__init__(**kwargs)
+        self._python_type = type(items)
         if not isinstance(items, collections.OrderedDict):
             assert isinstance(items, dict)
             items = collections.OrderedDict((k, items[k]) for k in sorted(items.keys()))
@@ -25,7 +26,7 @@ class ConstDictVariable(VariableTracker):
         return {k: v.as_proxy() for k, v in self.items.items()}
 
     def python_type(self):
-        return dict
+        return self._python_type
 
     def reconstruct(self, codegen):
         if len(self.items) == 0:
@@ -137,6 +138,14 @@ class ConstDictVariable(VariableTracker):
     def modifed(self, items, **options):
         """a copy of self with different items"""
         return self.clone(items=items, **options)
+
+    def clone(self, **kwargs):
+        """Shallow copy with some (optional) changes"""
+        args = dict(self.__dict__)
+        args.pop("_python_type", None)  # _python_type is used internally
+        kwargs.pop("_python_type", None)
+        args.update(kwargs)
+        return self.__class__(**args)
 
 
 class DataClassVariable(ConstDictVariable):

--- a/torchdynamo/variables/functions.py
+++ b/torchdynamo/variables/functions.py
@@ -27,6 +27,8 @@ def wrap_bound_arg(val, options):
         return cls([wrap_bound_arg(x, options) for x in val], **options)
     elif variables.ConstantVariable.is_literal(val):
         return variables.ConstantVariable(val, **options)
+    elif isinstance(val, type):
+        return variables.UserDefinedClassVariable(val, **options)
     else:
         assert isinstance(val, VariableTracker), typestr(val)
         return val

--- a/torchdynamo/variables/functions.py
+++ b/torchdynamo/variables/functions.py
@@ -20,7 +20,7 @@ from .base import typestr
 def wrap_bound_arg(val, options):
     if isinstance(val, dict):
         return variables.ConstDictVariable(
-            {k: wrap_bound_arg(v, options) for k, v in val.items()}, **options
+            {k: wrap_bound_arg(v, options) for k, v in val.items()}, dict, **options
         )
     elif isinstance(val, (tuple, list)):
         cls = variables.BaseListVariable.cls_for(type(val))


### PR DESCRIPTION
*This is the 2/N issue found from https://github.com/pytorch/torchdynamo/issues/156.*

Problem:
* Failed test example: [```test_NVIDIA_retinanet_examples.py:MobileNet```](https://github.com/yanboliang/pytorch-jit-paritybench/blob/master/generated/test_NVIDIA_retinanet_examples.py)
* Error: ```TypeError: OrderedDict is not a Module subclass```

Minimal code to reproduce:
```
from typing import List
import torch
import torchdynamo
from torchvision.models import mobilenet

class MyMobileNet(mobilenet.MobileNetV2):

    def __init__(self, outputs=[18], url=None):
        self.stride = 128
        self.url = url
        super().__init__()
        self.outputs = outputs

    def forward(self, x):
        outputs = []
        for indx, feat in enumerate(self.features[:-1]):
            x = feat(x)
            if indx in self.outputs:
                outputs.append(x)
        return outputs

def my_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
    return gm.forward

with torchdynamo.optimize(my_compiler):
    model = MyMobileNet()
    model.eval()
    model(torch.rand([4, 3, 64, 64]))
```

Root causes and solutions
* Error at ```self.features[:-1]``` where calling the [```Sequential.__getitem__```](https://github.com/pytorch/pytorch/blob/c031643e392d2d5dda14c5876761265ac6bcf32a/torch/nn/modules/container.py#L101) and return ```self.__class__(OrderedDict(list(self._modules.items())[idx]))``` to construct ```Sequential```. Then jump to [```Sequential.__init__```](https://github.com/pytorch/pytorch/blob/c031643e392d2d5dda14c5876761265ac6bcf32a/torch/nn/modules/container.py#L82), where it checks ```isinstance(args[0], OrderedDict)```. We should pass this check as ```args[0]``` is ```OrderedDict```. However, torchdynamo wrap ```OrderedDict``` as ```ConstDictVariable``` and return python type ```dict```. Hence we can't pass this check, fall into another branch and throw error.   
* There are lots of functions contain class type arguments, e.g, ```MobileNetV2.__init__```, ```Conv2dNormActivation.__init__``` and ```ConvNormActivation.__init__```. Torchdynamo calls ```wrap_bound_arg``` to wrap arguments into variables, where misses the handling for class type arguments and throw error.