### PR TITLE
Fix test failures

### DIFF
--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -56,7 +56,7 @@ class TritonOverrides(OpOverrides):
             return 'float("inf")'
         elif value == float("-inf"):
             return 'float("-inf")'
-        return super().constant(value, dtype)
+        return OpOverrides.constant(value, dtype)
 
     @staticmethod
     def abs(x):

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -140,7 +140,7 @@ def rsub(a, b):
     return b - a
 
 
-@register_decomposition([aten.pow.Tensor_Scalar], decompositions)
+@register_decomposition([aten.pow], decompositions)
 def pow(a, b):
     # see https://github.com/openai/triton/issues/506
     # triton doesn't support pow, so need to rewrite it


### PR DESCRIPTION
For the `aten.pow` one, something changed upstream in pytorch/functorch to break it.