### PR TITLE
Fix slicing list returning wrong result

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1157,3 +1157,15 @@ class MiscTests(torchdynamo.testing.TestCase):
         inst = dis.get_instructions(fn)
         result = bytecode_transformation.assemble(inst, fn.__code__.co_firstlineno)
         self.assertTrue(result[1] == fn.__code__.co_lnotab)
+
+    def test_python_slice(self):
+        def fn(input):
+            y = 0
+            for i, x in enumerate(input[2:], 1):
+                y = y + x
+            return y
+
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            z = fn([1, 2, 3, 5])
+        self.assertEqual(z, 8)

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -319,7 +319,7 @@ def rot_n_helper(n):
 def is_safe_constant(v):
     if istype(v, (tuple, frozenset)):
         return all(map(is_safe_constant, v))
-    return istype(v, (types.CodeType, int, float, bool, str, bytes, type(None)))
+    return istype(v, (types.CodeType, int, float, bool, str, bytes, type(None), slice))
 
 
 def check_constant_args(args, kwargs):

--- a/torchdynamo/variables/lists.py
+++ b/torchdynamo/variables/lists.py
@@ -9,6 +9,7 @@ from ..exc import unimplemented
 from ..utils import namedtuple_fields
 from .base import MutableLocal
 from .base import VariableTracker
+from ..source import GetItemSource
 
 
 class BaseListVariable(VariableTracker):
@@ -40,9 +41,11 @@ class BaseListVariable(VariableTracker):
     def getitem_const(self, arg: VariableTracker):
         index = arg.as_python_constant()
         if isinstance(index, slice):
-            return self.clone(items=self.items[index], mutable_local=None).add_options(
-                arg, self
-            )
+            return self.clone(
+                items=self.items[index],
+                source=GetItemSource(self.source, index),
+                mutable_local=None,
+            ).add_options(arg, self)
         else:
             assert isinstance(index, int)
             return self.items[index].add_options(arg, self)

--- a/torchdynamo/variables/lists.py
+++ b/torchdynamo/variables/lists.py
@@ -6,10 +6,10 @@ import torch
 from .. import variables
 from ..bytecode_transformation import create_instruction
 from ..exc import unimplemented
+from ..source import GetItemSource
 from ..utils import namedtuple_fields
 from .base import MutableLocal
 from .base import VariableTracker
-from ..source import GetItemSource
 
 
 class BaseListVariable(VariableTracker):


### PR DESCRIPTION
*This is the 3/N issue found from https://github.com/pytorch/torchdynamo/issues/156.*

Problem:
* Failed test case: [```test_achaiah_pywick.py:RefineNet4Cascade```](https://github.com/yanboliang/pytorch-jit-paritybench/blob/master/generated/test_achaiah_pywick.py#L10798)
* Error: ```RuntimeError: Given groups=1, weight of size [256, 256, 3, 3], expected input[4, 512, 2, 2] to have 256 channels, but got 512 channels instead```

Minimal code to reproduce:
```
from typing import List
import torch
import torchdynamo
import numpy as np

def fn(input):
    y = 0
    for i, x in enumerate(input[2:], 1):
        y = y + x
    return y

def my_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
    return gm.forward

with torchdynamo.optimize(my_compiler):
    print(fn([1, 2, 3]))
```
The correct output of the above code is: 3.
However, it print out 6 in the current main.

Root cause and solution:
* If we print out the original bytecode and modified bytecode, we'll found ```BINARY_SUBSCR``` is missing. ```BINARY_SUBSCR``` is used to generate ```input[2:]```, so it outputs wrong result which is the sum of the whole list rather than the slice elements.
* Then dig into [```PyCodegen.__call__```](https://github.com/pytorch/torchdynamo/blob/main/torchdynamo/codegen.py#L88) and found the error comes from source reconstruction. The ```ListVariable.source``` should be ```GetItemSource``` but is ```LocalSource``` now. This list was created at [```BaseListVariable.getitem_const```](https://github.com/pytorch/torchdynamo/blob/main/torchdynamo/variables/lists.py#L42) by cloning, but don't pass in the correct source.

