### PR TITLE
Remove reference cycle

### DIFF
--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -149,6 +149,7 @@ def convert_frame_assert(compiler_fn: Callable, one_graph=True):
             )
             tracer.run()
             output = tracer.output
+            output.cleanup()
             assert output.output_instructions
             instructions[:] = output.output_instructions
             code_options.update(output.code_options)

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -365,3 +365,12 @@ class OutputGraph(fx.Tracer):
 
     def install_global(self, name, value):
         self.cleanups.append(CleanupHook.create(self.root_globals, name, value))
+
+    def cleanup(self):
+        # There is a reference cycle between tracer and OutputGraph, causing
+        # some of the tensor objects to be held alive for longer than necessary.
+        self.root_tx = None
+
+        # Cleanup graphargs
+        for graph_arg in self.graphargs:
+            graph_arg.erase()

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -70,6 +70,9 @@ class GraphArg:
     def __len__(self):
         return 1
 
+    def erase(self):
+        self.example = None
+
 
 class VariableBuilder:
     """Wrap a python value in a VariableTracker() instance"""


### PR DESCRIPTION
For the following test, Dynamo was holding on to more memory than necessary. And this memory was released after calling `gc.collect()`. This indicated that their was a reference cycle somewhere.

~~~

def print_mem(name):
    print(name, torch.cuda.memory_allocated() / 10**9, "GB")


def fn1():
    x = torch.randn(1024, 1024, 1024, device="cuda")
    print_mem("Inside func")
    return x.sum()


fn1()
print_mem("Outside func")
print("------ Eager Done --------")
print("\n\n\n")

# torchdynamo.config.debug = True
# torchdynamo.config.trace = True

with torchdynamo.optimize("eager"):
    fn1()
    print_mem("Outside func")
print("------ TorchDynamo Done --------")
print("\n\n\n")


graph = refcycle.garbage()
sccs = graph.strongly_connected_components()

refcycles = graph.source_components()
for idx, r in enumerate(refcycles):
    r.export_image(f"cycle{idx}.svg")

print(refcycles)
~~~

I used `refcycle` package to find the reference cycles, and following is the culprit.

![image](https://user-images.githubusercontent.com/13822661/167517938-663f2155-e07e-47a3-b0b8-fd7ff099a2ce.png)

This PR does the following
* Breaks the cycle by setting output_graph.root_tx = None after we are done with tracing
* Also, cleanup the graphargs, the data structure that was holding on to the tensor.
