### PR TITLE
Refactor ConstDictVariable to support user_cls and use dict by default

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1169,3 +1169,14 @@ class MiscTests(torchdynamo.testing.TestCase):
         with torchdynamo.optimize(cnts):
             z = fn([1, 2, 3, 5])
         self.assertEqual(z, 8)
+
+    def test_const_dict_variable_python_type(self):
+        from torchdynamo.variables import ConstDictVariable
+
+        d1 = {"a": 10, "b": 20}
+        d2 = collections.OrderedDict([("x", 12), ("y", 22)])
+        self.assertEqual(ConstDictVariable(d1, dict).python_type(), dict)
+        self.assertEqual(
+            ConstDictVariable(d2, collections.OrderedDict).python_type(),
+            collections.OrderedDict,
+        )

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -157,21 +157,16 @@ class VariableBuilder:
             map(ConstantVariable.is_literal, value.keys())
         ):
             guards = self.make_guards(GuardBuilder.DICT_KEYS)
-            keys = (
-                value.keys()
-                if istype(value, collections.OrderedDict)
-                else sorted(value.keys())
-            )
-            result = collections.OrderedDict(
+            result = dict(
                 (
                     k,
                     VariableBuilder(self.tx, GetItemSource(self.get_source(), k))(
                         value[k]
                     ).add_guards(guards),
                 )
-                for k in keys
+                for k in value.keys()
             )
-            result = ConstDictVariable(result, guards=guards)
+            result = ConstDictVariable(result, type(value), guards=guards)
             if istype(value, dict):
                 return self.tx.output.side_effects.track_dict(
                     self.source, value, result

--- a/torchdynamo/variables/functions.py
+++ b/torchdynamo/variables/functions.py
@@ -20,7 +20,7 @@ from .base import typestr
 def wrap_bound_arg(val, options):
     if isinstance(val, dict):
         return variables.ConstDictVariable(
-            {k: wrap_bound_arg(v, options) for k, v in val.items()}, **options
+            {k: wrap_bound_arg(v, options) for k, v in val.items()}, dict, **options
         )
     elif isinstance(val, (tuple, list)):
         cls = variables.BaseListVariable.cls_for(type(val))


### PR DESCRIPTION
See context at https://github.com/pytorch/torchdynamo/pull/215 

Major changes:
* Refactor ```user_cls``` from ```DataClassVariable``` to parent class ```ConstDictVariable```.
* Use normal ```dict``` by default when generating ```ConstDictVariable```.
* Remove the dict conversion and sort logic inside of ```ConstDictVariable```.
* Reorder argument to ```items, user_cls``` to keep consistent with other class ```NamedTupleVariable```.
* Add unit test.