### PR TITLE
Remove reference cycle - with exceptions

### DIFF
--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -149,7 +149,6 @@ def convert_frame_assert(compiler_fn: Callable, one_graph=True):
             )
             tracer.run()
             output = tracer.output
-            output.cleanup()
             assert output.output_instructions
             instructions[:] = output.output_instructions
             code_options.update(output.code_options)

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -374,3 +374,7 @@ class OutputGraph(fx.Tracer):
         # Cleanup graphargs
         for graph_arg in self.graphargs:
             graph_arg.erase()
+
+        for node in self.graph.nodes:
+            if "example_value" in node.meta:
+                del node.meta["example_value"]

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -314,6 +314,8 @@ class InstructionTranslatorBase(object):
                 f"{self.lineno} {typestr(e)}\n"
             )
             raise
+        finally:
+            self.output.cleanup()
 
     def push(self, val):
         assert val is None or isinstance(


### PR DESCRIPTION
This is a followup of #223 

#223 was cleaning up the `OutputGraph`. However, it was missing the cleanup when an exception was raised. This led to some memory held alive for the following case. Therefore, moving the cleanup to `finalize` of `try ... except` block.


~~~

@torchdynamo.disable
def print_mem(name):
    print(name, torch.cuda.memory_allocated() / 10**9, "GB")


def fn1(x, y, z):
    out = torch.addcdiv(x, y, z)
    print_mem("Inside func")
    return out.sum()


def fn():
    x = torch.randn(1024, 1024, 1024, device="cuda")
    y = torch.randn(1024, 1024, 1024, device="cuda")
    z = torch.randn(1024, 1024, 1024, device="cuda")
    return fn1(x, y, z)


fn()
print_mem("Outside func")
print("------ Eager Done --------")
print("\n\n\n")

# torchdynamo.config.debug = True
# torchdynamo.config.trace = True

with torchdynamo.optimize("eager"):
    fn()
    print_mem("Outside func")
print("------ TorchDynamo Done --------")
print("\n\n\n")


gc.collect()
torch.cuda.empty_cache()
print_mem("End")
~~~

