### PR TITLE
Revert "Fix slicing list returning wrong result (#222)"

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1158,6 +1158,7 @@ class MiscTests(torchdynamo.testing.TestCase):
         result = bytecode_transformation.assemble(inst, fn.__code__.co_firstlineno)
         self.assertTrue(result[1] == fn.__code__.co_lnotab)
 
+    @unittest.skip("disabled for now")
     def test_python_slice(self):
         def fn(input):
             y = 0

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -319,7 +319,7 @@ def rot_n_helper(n):
 def is_safe_constant(v):
     if istype(v, (tuple, frozenset)):
         return all(map(is_safe_constant, v))
-    return istype(v, (types.CodeType, int, float, bool, str, bytes, type(None), slice))
+    return istype(v, (types.CodeType, int, float, bool, str, bytes, type(None)))
 
 
 def check_constant_args(args, kwargs):

--- a/torchdynamo/variables/lists.py
+++ b/torchdynamo/variables/lists.py
@@ -6,7 +6,6 @@ import torch
 from .. import variables
 from ..bytecode_transformation import create_instruction
 from ..exc import unimplemented
-from ..source import GetItemSource
 from ..utils import namedtuple_fields
 from .base import MutableLocal
 from .base import VariableTracker
@@ -41,11 +40,9 @@ class BaseListVariable(VariableTracker):
     def getitem_const(self, arg: VariableTracker):
         index = arg.as_python_constant()
         if isinstance(index, slice):
-            return self.clone(
-                items=self.items[index],
-                source=GetItemSource(self.source, index),
-                mutable_local=None,
-            ).add_options(arg, self)
+            return self.clone(items=self.items[index], mutable_local=None).add_options(
+                arg, self
+            )
         else:
             assert isinstance(index, int)
             return self.items[index].add_options(arg, self)


### PR DESCRIPTION
This reverts commit 243222ea119212fa17ca520020bacac9f2f11a21.

@yanboliang I noticed an error in `./torchbench.py` and `git bisect` says it is this commit.

The error is:
```
 ./torchbench.py -k yolov3 
cpu  eval  yolov3                             ERROR FROM offset=262 filename /home/jansel/torchbenchmark/torchbenchmark/models/yolov3/yolo_models.py 290 AttributeError
========== TorchDynamo Stack Trace ==========
Traceback (most recent call last):
  File "/home/jansel/torchdynamo/torchdynamo/convert_frame.py", line 175, in _convert_frame_assert
    code = transform_code_object(frame.f_code, transform)
  File "/home/jansel/torchdynamo/torchdynamo/bytecode_transformation.py", line 338, in transform_code_object
    transformations(instructions, code_options)
  File "/home/jansel/torchdynamo/torchdynamo/convert_frame.py", line 150, in transform
    tracer.run()
  File "/home/jansel/torchdynamo/torchdynamo/symbolic_convert.py", line 300, in run
    and self.step()
  File "/home/jansel/torchdynamo/torchdynamo/symbolic_convert.py", line 278, in step
    getattr(self, inst.opname)(inst)
  File "/home/jansel/torchdynamo/torchdynamo/symbolic_convert.py", line 149, in wrapper
    self.output.compile_subgraph(self)
  File "/home/jansel/torchdynamo/torchdynamo/output_graph.py", line 247, in compile_subgraph
    pass1.foreach(stack_values)
  File "/home/jansel/torchdynamo/torchdynamo/codegen.py", line 142, in foreach
    self(i)
  File "/home/jansel/torchdynamo/torchdynamo/codegen.py", line 89, in __call__
    output.extend(value.source.reconstruct(self))
  File "/home/jansel/torchdynamo/torchdynamo/source.py", line 111, in reconstruct
    return self.base.reconstruct(codegen) + [
AttributeError: 'NoneType' object has no attribute 'reconstruct'
========== Exception (above) while processing ==========
  File "./torchbench.py", line 1217, in <module>
    main()
  File "./torchbench.py", line 1097, in main
    run_one_model(
  File "./torchbench.py", line 1176, in run_one_model
    new_result = model_iter_fn(model, example_inputs)
  File "./torchbench.py", line 577, in forward_pass
    return mod(*inputs)
  File "/home/jansel/pytorch/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/jansel/torchbenchmark/torchbenchmark/models/yolov3/yolo_models.py", line 235, in forward
    def forward(self, x, augment=False, verbose=False):
  File "/home/jansel/torchbenchmark/torchbenchmark/models/yolov3/yolo_models.py", line 265, in forward_once
    def forward_once(self, x, augment=False, verbose=False):
========== End debug info ==========
 97/ 99 +0 frames  32s 93 graphs 26 graph calls  113/ 344 =  33% ops   5% time
```

Can you try to debug this then resubmit the PR?