### PR TITLE
Add fix for writing to closures

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -950,6 +950,7 @@ class MiscTests(torchdynamo.testing.TestCase):
     def test_write_to_closures_in_inlining(self):
         out = []
         for use_dynamo in [False, True]:
+
             def make_counter():
                 x = torch.randn(10)
 
@@ -966,6 +967,7 @@ class MiscTests(torchdynamo.testing.TestCase):
                 out.append(counter() + counter())
             else:
                 cnts = torchdynamo.testing.CompileCounter()
+
                 @torchdynamo.optimize(cnts, nopython=True)
                 def fn(counter):
                     return counter() + counter()

--- a/torchdynamo/side_effects.py
+++ b/torchdynamo/side_effects.py
@@ -187,11 +187,7 @@ class SideEffects(object):
         self.keepalive.append(obj)
         return variable
 
-    def track_cell_existing(
-        self,
-        source: Source,
-        item: Any
-    ):
+    def track_cell_existing(self, source: Source, item: Any):
         variable = variables.NewCellVariable(
             mutable_local=AttributeMutationExisting(source),
         )
@@ -244,9 +240,9 @@ class SideEffects(object):
         ]
 
         for var in modified_vars:
-            if isinstance(var.mutable_local, (AttributeMutationExisting, AttributeMutationNew)) and isinstance(
-                var, variables.NewCellVariable
-            ):
+            if isinstance(
+                var.mutable_local, (AttributeMutationExisting, AttributeMutationNew)
+            ) and isinstance(var, variables.NewCellVariable):
                 cg.load_import_from(utils.__name__, "make_cell")
                 cg.extend_output([create_instruction("CALL_FUNCTION", 0)])
                 cg.add_cache(var)

--- a/torchdynamo/side_effects.py
+++ b/torchdynamo/side_effects.py
@@ -187,6 +187,18 @@ class SideEffects(object):
         self.keepalive.append(obj)
         return variable
 
+    def track_cell_existing(
+        self,
+        source: Source,
+        item: Any
+    ):
+        variable = variables.NewCellVariable(
+            mutable_local=AttributeMutationExisting(source),
+        )
+        self.id_to_variable[id(item)] = variable
+        self.keepalive.append(item)
+        return variable
+
     def prune_dead_object_new(self, tx):
         live_new_objects = set()
         skip_obj = None
@@ -232,13 +244,14 @@ class SideEffects(object):
         ]
 
         for var in modified_vars:
-            if isinstance(var.mutable_local, AttributeMutationNew) and isinstance(
+            if isinstance(var.mutable_local, (AttributeMutationExisting, AttributeMutationNew)) and isinstance(
                 var, variables.NewCellVariable
             ):
                 cg.load_import_from(utils.__name__, "make_cell")
                 cg.extend_output([create_instruction("CALL_FUNCTION", 0)])
                 cg.add_cache(var)
-                var.mutable_local.source = LocalSource(cg.tempvars[var])
+                if isinstance(var.mutable_local, AttributeMutationNew):
+                    var.mutable_local.source = LocalSource(cg.tempvars[var])
             elif isinstance(var.mutable_local, AttributeMutationNew):
                 cg.load_import_from(utils.__name__, "object_new")
                 cg(var.mutable_local.cls_source)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1293,8 +1293,13 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             else:
                 self.output.side_effects.store_cell(cell, val)
         else:
-            if isinstance(self.symbolic_locals.get(inst.argval), torchdynamo.variables.NewCellVariable):
-                self.output.side_effects.store_cell(self.symbolic_locals[inst.argval], self.pop())
+            if isinstance(
+                self.symbolic_locals.get(inst.argval),
+                torchdynamo.variables.NewCellVariable,
+            ):
+                self.output.side_effects.store_cell(
+                    self.symbolic_locals[inst.argval], self.pop()
+                )
             else:
                 unimplemented("write to __closure__ while inlining")
 

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1293,7 +1293,10 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             else:
                 self.output.side_effects.store_cell(cell, val)
         else:
-            unimplemented("write to __closure__ while inlining")
+            if isinstance(self.symbolic_locals.get(inst.argval), torchdynamo.variables.NewCellVariable):
+                self.output.side_effects.store_cell(self.symbolic_locals[inst.argval], self.pop())
+            else:
+                unimplemented("write to __closure__ while inlining")
 
     def LOAD_DEREF(self, inst):
         if inst.argval in self.closure_cells:
@@ -1303,7 +1306,11 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             else:
                 self.push(self.output.side_effects.load_cell(cell))
         else:
-            super().LOAD_DEREF(inst)
+            maybe_sym_local = self.symbolic_locals.get(inst.argval, None)
+            if isinstance(maybe_sym_local, torchdynamo.variables.NewCellVariable):
+                self.push(self.output.side_effects.load_cell(maybe_sym_local))
+            else:
+                super().LOAD_DEREF(inst)
 
     def LOAD_CLOSURE(self, inst):
         assert inst.argval in self.cell_and_freevars()

--- a/torchdynamo/variables/functions.py
+++ b/torchdynamo/variables/functions.py
@@ -151,7 +151,8 @@ class UserFunctionVariable(BaseUserFunctionVariable):
                             closure_cell, "cell_contents"
                         )
 
-                        # cells are written to with "cell_contents", so the source should just be the closure_cell, not its contents
+                        # cells are written to with "cell_contents",
+                        # so the source should just be the closure_cell, not its contents
                         out = side_effects.track_cell_existing(closure_cell, cell)
                         side_effects.store_cell(
                             out,
@@ -161,6 +162,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
                         )
 
                     result[name] = out
+
                 else:
                     unimplemented("inline with __closure__")
 

--- a/torchdynamo/variables/functions.py
+++ b/torchdynamo/variables/functions.py
@@ -144,12 +144,21 @@ class UserFunctionVariable(BaseUserFunctionVariable):
                     if cell in side_effects:
                         out = side_effects[cell]
                     else:
-                        closure_cell = GetItemSource(AttrSource(self.source, "__closure__"), idx)
-                        closure_cell_contents = AttrSource(closure_cell, "cell_contents")
+                        closure_cell = GetItemSource(
+                            AttrSource(self.source, "__closure__"), idx
+                        )
+                        closure_cell_contents = AttrSource(
+                            closure_cell, "cell_contents"
+                        )
 
                         # cells are written to with "cell_contents", so the source should just be the closure_cell, not its contents
                         out = side_effects.track_cell_existing(closure_cell, cell)
-                        side_effects.store_cell(out, VariableBuilder(parent, closure_cell_contents)(cell.cell_contents))
+                        side_effects.store_cell(
+                            out,
+                            VariableBuilder(parent, closure_cell_contents)(
+                                cell.cell_contents
+                            ),
+                        )
 
                     result[name] = out
                 else:


### PR DESCRIPTION
Fix for https://github.com/pytorch/torchdynamo/issues/55

Rewrites 
```
def make_counter():
    x = torch.randn(10)

    def counter():
        nonlocal x
        x = x + 1
        return x

    return counter

@torchdynamo.optimize(torchdynamo.testing.CompileCounter(), nopython=True)
def fn(counter):
    return counter() + counter()


fn(make_counter())
```

As 
```
def fn(counter):
   v0 = counter.__closure__[0].cell_contents
   v1 = v0 + 1
   v2 = v1 + 1
   counter.__closure__[0].cell_contents = v2
   return v1 + v2
```

By rewriting the `STORE_DEREF` to use side-effects tracking