### PR TITLE
Delete example value for unused args

### DIFF
--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -355,6 +355,8 @@ class OutputGraph(fx.Tracer):
 
         for node, arg in list(zip(self.graph.nodes, expanded_graphargs)):
             if arg.uses == 0:
+                if "example_value" in node.meta:
+                    del node.meta["example_value"]
                 self.graph.erase_node(node)
 
         self.graphargs = [arg for arg in self.graphargs if arg.uses > 0]


### PR DESCRIPTION
Fixing memory leak for the following test case

~~~


@torchdynamo.disable
def print_mem(name):
    print(name, torch.cuda.memory_allocated() / 10**9, "GB")


def fn1(x, y, z):
    # Unused arg z
    out = torch.addcdiv(x, y, y)
    print_mem("Inside func")
    return out.sum()


def fn():
    x = torch.randn(1024, 1024, 1024, device="cuda")
    y = torch.randn(1024, 1024, 1024, device="cuda")
    z = torch.randn(1024, 1024, 1024, device="cuda")
    return fn1(x, y, z)


fn()
print_mem("Outside func")
print("------ Eager Done --------")
print("\n\n\n")

# torchdynamo.config.debug = True
# torchdynamo.config.trace = True

with torchdynamo.optimize("eager"):
    fn()
    print_mem("Outside func")
print("------ TorchDynamo Done --------")
print("\n\n\n")


torch.cuda.empty_cache()
gc.collect()

print_mem("End")
~~~