### PR TITLE
Fix list slice & ConstantVariable to TupleVariable conversion missing source info

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1158,7 +1158,6 @@ class MiscTests(torchdynamo.testing.TestCase):
         result = bytecode_transformation.assemble(inst, fn.__code__.co_firstlineno)
         self.assertTrue(result[1] == fn.__code__.co_lnotab)
 
-    @unittest.skip("disabled for now")
     def test_python_slice(self):
         def fn(input):
             y = 0

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1159,16 +1159,25 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertTrue(result[1] == fn.__code__.co_lnotab)
 
     def test_python_slice(self):
-        def fn(input):
+        def f1(input):
             y = 0
             for i, x in enumerate(input[2:], 1):
                 y = y + x
             return y
 
+        def f2(input):
+            y = 0
+            for i, x in enumerate(input.shape[2:], 1):
+                y = y + x
+            return y
+
         cnts = torchdynamo.testing.CompileCounter()
         with torchdynamo.optimize(cnts):
-            z = fn([1, 2, 3, 5])
-        self.assertEqual(z, 8)
+            res1 = f1([1, 2, 3, 5])
+            res2 = f2(torch.rand([2, 3, 4, 5]))
+
+        self.assertEqual(res1, 8)
+        self.assertEqual(res2, 9)
 
     def test_const_dict_variable_python_type(self):
         from torchdynamo.variables import ConstDictVariable

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -319,7 +319,7 @@ def rot_n_helper(n):
 def is_safe_constant(v):
     if istype(v, (tuple, frozenset)):
         return all(map(is_safe_constant, v))
-    return istype(v, (types.CodeType, int, float, bool, str, bytes, type(None)))
+    return istype(v, (types.CodeType, int, float, bool, str, bytes, type(None), slice))
 
 
 def check_constant_args(args, kwargs):

--- a/torchdynamo/variables/constant.py
+++ b/torchdynamo/variables/constant.py
@@ -73,7 +73,7 @@ class ConstantVariable(VariableTracker):
         if istype(self.value, tuple):
             # empty tuple constant etc
             return variables.TupleVariable(
-                self.unpack_var_sequence(tx), **options
+                items=self.unpack_var_sequence(tx), source=self.source, **options
             ).call_method(tx, name, args, kwargs)
 
         try:

--- a/torchdynamo/variables/lists.py
+++ b/torchdynamo/variables/lists.py
@@ -6,6 +6,7 @@ import torch
 from .. import variables
 from ..bytecode_transformation import create_instruction
 from ..exc import unimplemented
+from ..source import GetItemSource
 from ..utils import namedtuple_fields
 from .base import MutableLocal
 from .base import VariableTracker
@@ -40,9 +41,11 @@ class BaseListVariable(VariableTracker):
     def getitem_const(self, arg: VariableTracker):
         index = arg.as_python_constant()
         if isinstance(index, slice):
-            return self.clone(items=self.items[index], mutable_local=None).add_options(
-                arg, self
-            )
+            return self.clone(
+                items=self.items[index],
+                source=GetItemSource(self.source, index),
+                mutable_local=None,
+            ).add_options(arg, self)
         else:
             assert isinstance(index, int)
             return self.items[index].add_options(arg, self)


### PR DESCRIPTION
This is to resubmit https://github.com/pytorch/torchdynamo/pull/222.
Fix https://github.com/pytorch/torchdynamo/pull/231
* Root cause: ```ConstantVariable.call_method``` wraps value as ```TupleVariable``` and call its ```call_method```, but doesn't propagate source info in this conversion, so the source chain is missed when codegen.
* Why ```torchbench``` doesn't fail before https://github.com/pytorch/torchdynamo/pull/222?
  * Because it fall into another branch [here](https://github.com/pytorch/torchdynamo/blob/main/torchdynamo/codegen.py#L90) previously. Actually I think we can switch the order to first check python constant:
 ```
if value.is_python_constant() and is_safe_constant(
    value.as_python_constant()
):
    output.append(self.create_load_const(value.as_python_constant()))
elif value.source is not None and allow_cache:
    output.extend(value.source.reconstruct(self))
```  
As this can generate more concise code if the stack value is python constant compatible(only LOAD CONST in this case, and doesn't need to trace the source). I'd like to know if this is aligned with the design philosophy and update this PR if it makes sense. 