### PR TITLE
Add type checking in Constant match - Fix Pytorch tests 4/n

### DIFF
--- a/tests/test_repros.py
+++ b/tests/test_repros.py
@@ -2,11 +2,13 @@
 import collections
 import copy
 import inspect
+import itertools
 from abc import ABC
 from collections import namedtuple
 from copy import deepcopy
 from typing import List
 
+import numpy as np
 import torch
 from torch import nn
 from torch.nn import functional as F
@@ -1160,3 +1162,52 @@ class ReproTests(torchdynamo.testing.TestCase):
 
         self.assertGreaterEqual(torchdynamo.utils.counters["frames"]["ok"], 3)
         self.assertGreaterEqual(torchdynamo.utils.counters["frames"]["total"], 3)
+
+    def test_guard_fail(self):
+        @torchdynamo.skip
+        def fn():
+            condition_shape = (5, 5)
+            dtypes = (torch.bool,)
+            shapes = (
+                (),
+                (5,),
+                (1, 5),
+            )
+
+            tensors = list(
+                [
+                    torch.empty(shape, dtype=dtype).fill_(17)
+                    for shape, dtype in itertools.product(shapes, dtypes)
+                ]
+            )
+
+            x_vals = (True,)
+            y_vals = (8.0, *tensors)
+
+            @torchdynamo.disable
+            def get_expected(condition, x, y):
+                x_np = x.cpu().numpy() if isinstance(x, torch.Tensor) else x
+                y_np = y.cpu().numpy() if isinstance(y, torch.Tensor) else y
+                return torch.from_numpy(
+                    np.where(condition.cpu().numpy(), x_np, y_np)
+                ).to(common_dtype)
+
+            for x in x_vals:
+                for y in y_vals:
+                    condition = torch.empty(
+                        *condition_shape, dtype=torch.bool
+                    ).bernoulli_()
+                    common_dtype = torch.result_type(x, y)
+
+                    def check_equal(condition, x, y):
+                        # NumPy aggressively promotes to double, hence cast to output to correct dtype
+                        expected = get_expected(condition, x, y)
+                        result = torch.where(condition, x, y)
+                        assert torch.allclose(expected, result)
+
+                    check_equal(condition, x, y)
+                    check_equal(condition, y, x)
+
+        fn()
+        with torchdynamo.optimize("eager"):
+            fn()


### PR DESCRIPTION
A guard like `y == 9.0` where y is a `torch.Tensor` results in boolean Tensor, and fails guard execution. This PR adds a type check in `CONSTANT_MATCH` to prevent such checking in the first place.