### PR TITLE
enumerate supports start argument

### DIFF
--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -504,3 +504,13 @@ class SubGraphTests(torchdynamo.testing.TestCase):
         with torchdynamo.optimize(cnt):
             self.assertEqual(fn(v1, it1).tolist(), (v1 + 1 + 2 + 3).tolist())
         self.assertEqual(list(it1), [4, 5, 6, 7, 8, 9])
+
+    def test_enumerate_not_break_graph(self):
+        def fn(a, b):
+            for i, x in enumerate(a.shape):
+                b = b + x
+            for i, x in enumerate(b.shape, 0):
+                b = b + x * i
+            return b
+
+        self._common(fn, 1, 2)

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -294,15 +294,20 @@ class BuiltinVariable(VariableTracker):
             ]
             return variables.TupleVariable(items, **options)
 
-    def call_enumerate(self, tx, arg):
-        options = VariableTracker.propagate(self, arg)
-        if arg.has_unpack_var_sequence(tx):
+    def call_enumerate(self, tx, *args):
+        options = VariableTracker.propagate(self, args)
+        if len(args) == 1:
+            start = 0
+        else:
+            assert isinstance(args[1], variables.ConstantVariable)
+            start = args[1].as_python_constant()
+        if args[0].has_unpack_var_sequence(tx):
             items = [
                 variables.TupleVariable(
                     [variables.ConstantVariable(idx, **options), var],
                     **options,
                 )
-                for idx, var in enumerate(arg.unpack_var_sequence(tx))
+                for idx, var in enumerate(args[0].unpack_var_sequence(tx), start)
             ]
             return variables.TupleVariable(items, **options)
 


### PR DESCRIPTION
As title, to support ```enumerate ([1, 2, 3, 4], 2)```