### PR TITLE
enable tracing through enum comparison

### DIFF
--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -1,5 +1,6 @@
 import collections
 import dataclasses
+import enum
 import functools
 import inspect
 import re
@@ -34,6 +35,7 @@ from ..utils import tuple_iterator_len
 from .base import MutableLocal
 from .builtin import BuiltinVariable
 from .constant import ConstantVariable
+from .constant import EnumVariable
 from .dicts import ConstDictVariable
 from .dicts import DataClassVariable
 from .functions import UserFunctionVariable
@@ -199,6 +201,11 @@ class VariableBuilder:
             return ConstantVariable(
                 value=value,
                 guards=make_guards(GuardBuilder.CONSTANT_MATCH),
+            )
+        elif isinstance(value, enum.Enum):
+            return EnumVariable(
+                value=value,
+                guards=make_guards(GuardBuilder.ID_MATCH),
             )
         elif is_builtin(value):
             return BuiltinVariable(

--- a/torchdynamo/variables/constant.py
+++ b/torchdynamo/variables/constant.py
@@ -95,3 +95,21 @@ class ConstantVariable(VariableTracker):
             return ConstantVariable(result, **options)
 
         unimplemented(f"const method call {typestr(self.value)}.{name}")
+
+
+class EnumVariable(VariableTracker):
+    def __init__(self, value, **kwargs):
+        super(EnumVariable, self).__init__(**kwargs)
+        self.value = value
+
+    def as_proxy(self):
+        return self.value
+
+    def __str__(self):
+        return f"EnumVariable({type(self.value)})"
+
+    def python_type(self):
+        return type(self.value)
+
+    def as_python_constant(self):
+        return self.value


### PR DESCRIPTION
Summary:

Enables tracing through enum comparisons, such as

```
import enum

class Foo(enum.Enum):
    FOO = 0
    BAR = 1

def fn(x, foo):
    if foo is Foo.FOO:
        x = torch.add(x, 1.0)
    x = torch.mul(x, 1.0)
    return x
```

This is useful for DBR quantization.

Test plan:

```
pytest -vsk test_enum_no_graphbreaks
```