### PR TITLE
add support for tracing torch.nn.ModuleDict.__contains__

### DIFF
--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -271,6 +271,15 @@ class NNModuleVariable(VariableTracker):
         elif name == "__len__":
             assert not (args or kwargs)
             return ConstantVariable(len(module), **options)
+        elif (
+            name == "__contains__"
+            and isinstance(module, (torch.nn.ModuleDict, torch.nn.ParameterDict))
+            and args
+            and args[0].is_python_constant()
+        ):
+            return ConstantVariable(
+                args[0].as_python_constant() in module._modules, **options
+            )
         elif name == "__getitem__":
             assert not kwargs and len(args) == 1
             assert type(module).__getitem__ in (


### PR DESCRIPTION
Summary:

Adds support for tracing through this syntax:

```
class M(torch.nn.Module):
    def __init__(self, module_dict):
        super().__init__()
        self.module_dict = module_dict

    def forward(self, x):
        if "foo" in self.module_dict:
            x = torch.mul(x, 1.0)
        x = torch.add(x, 1.0)
        return x
```

This is useful for DBR quantization.

Test plan:

```
pytest -vsk test_nn_moduledict_contains
```