### PR TITLE
Inline function jump on tensor condition should be unimplemented

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1244,3 +1244,21 @@ class MiscTests(torchdynamo.testing.TestCase):
         with torchdynamo.optimize(cnts, nopython=True):
             fn(x, Foo.BAR)
         self.assertEqual(cnts.op_count, 1)
+
+    def test_inline_func_jump_on_tensor_condition(self):
+        def f1(input):
+            if input == 0:
+                return input + 1
+            else:
+                return input + 2
+
+        def f2(input):
+            return f1(input)
+
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res1 = f2(torch.tensor([1.0]))
+            res2 = f2(torch.tensor([0.0]))
+
+        self.assertEqual(res1, 3)
+        self.assertEqual(res2, 1)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -123,7 +123,9 @@ def generic_jump(truth_fn: typing.Callable, push: bool):
                 + if_next
                 + if_jump
             )
-        elif value.has_unpack_var_sequence(self):
+        elif not isinstance(value, TensorVariable) and value.has_unpack_var_sequence(
+            self
+        ):
             if truth_fn(len(value.unpack_var_sequence(self))):
                 push and self.push(value)
                 self.jump(inst)


### PR DESCRIPTION
*This is the 4/N issue found from https://github.com/pytorch/torchdynamo/issues/156.*

Problem
* Failed test example: [```test_666DZY666_model_compression.py:BNFold_Conv2d_Q```](https://github.com/yanboliang/pytorch-jit-paritybench/blob/master/generated/test_666DZY666_model_compression.py#L557)
* Error: ```AssertionError: Tensor-likes are not close!``` The model output under torchdynamo is different from native Pytorch.

The original model is very complicated, I identified the problem and have the following minimal code to reproduce:
```
from typing import List
import torch
import torchdynamo

def f1(input):
    if input == 0:
        return input + 1
    else:
        return input + 2

def f2(input):
    return f1(input)

torchdynamo.config.debug = True

def my_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
    return gm.forward

with torchdynamo.optimize(my_compiler):
    print(f2(torch.tensor([1.0])))
    print(f2(torch.tensor([0.0])))
```
The above code's output is: 
```
tensor([2.])
tensor([1.])
```
which is not correct, actually the output should be:
```
tensor([3.])
tensor([1.])
```

Root cause and solution:
* The problem comes from the jump condition ```input == 0``` where ```input``` is tensor type. It returns ```tensor([True])``` or ```tensor[False]```. As ```f1``` will be complied inline where is all-or-nothing.  In ```generic_jump```, it falls into [this line](https://github.com/pytorch/torchdynamo/blob/main/torchdynamo/symbolic_convert.py#L126) where returning true/false on value's length. This is correct for ```ListVariable```, but for ```TensorVariable``` it's always return true, so always jump into the first branch.
* The fix is to return ```unimplemented``` if inline function has tensor condition.
