### PR TITLE
enable tracing through frozenset contains of PyTorch ops

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1339,3 +1339,23 @@ class MiscTests(torchdynamo.testing.TestCase):
 
         self.assertEqual(res1, 3)
         self.assertEqual(res2, 1)
+
+    def test_frozenset_torch_func_contains(self):
+        funcs = frozenset([torch.add])
+
+        def fn(x, func):
+            if func in funcs:
+                x = torch.add(x, 1.0)
+            x = torch.mul(x, 1.0)
+            return x
+
+        x = torch.randn(1)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts, nopython=True):
+            fn(x, torch.add)
+        self.assertEqual(cnts.op_count, 2)
+
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts, nopython=True):
+            fn(x, torch.mul)
+        self.assertEqual(cnts.op_count, 1)

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -202,6 +202,15 @@ class VariableBuilder:
                 value=value,
                 guards=make_guards(GuardBuilder.CONSTANT_MATCH),
             )
+        elif isinstance(value, frozenset) and (
+            all(is_allowed(x) or ConstantVariable.is_literal(x) for x in value)
+        ):
+            # For frozenset, we can guard by object ID instead of value
+            # equality, this allows us to handle non-literal values
+            return ConstantVariable(
+                value=value,
+                guards=make_guards(GuardBuilder.ID_MATCH),
+            )
         elif isinstance(value, enum.Enum):
             return EnumVariable(
                 value=value,


### PR DESCRIPTION
Summary:

Enables tracing through this syntax:

```
funcs = frozenset([torch.add])

def fn(x, func):
    if func in funcs:
        x = torch.add(x, 1.0)
    x = torch.mul(x, 1.0)
    return x
```

This is useful for DBR quantization.

Test plan:

```
pytest -vsk test_frozenset_torch_func_contains
```