### PR TITLE
support tracing __getitem__ of torch.nn.ModuleDict

### DIFF
--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -268,6 +268,21 @@ class ModuleList(torch.nn.Module):
         return x
 
 
+class ModuleDict(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = torch.nn.ModuleDict(
+            {
+                "0": torch.nn.Linear(10, 10),
+            }
+        )
+
+    def forward(self, x):
+        # TODO(future PR): handle more logic
+        x = self.layers["0"](x)
+        return x
+
+
 class TensorList(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -548,6 +563,7 @@ class NNModuleTests(torchdynamo.testing.TestCase):
     test_cfgmod = make_test(CfgModule())
     test_stringmember = make_test(StringMember())
     test_modulelist = make_test(ModuleList())
+    test_moduledict = make_test(ModuleDict())
     test_super1 = make_test(SuperModule())
     test_super_class_method = make_test(SuperChildCallsClassMethod())
     test_children = make_test(Children())

--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -283,6 +283,7 @@ class NNModuleVariable(VariableTracker):
         elif name == "__getitem__":
             assert not kwargs and len(args) == 1
             assert type(module).__getitem__ in (
+                torch.nn.ModuleDict.__getitem__,
                 torch.nn.ModuleList.__getitem__,
                 torch.nn.ParameterList.__getitem__,
             ), typestr(module)


### PR DESCRIPTION
Summary:

Supports tracing through

```
class ModuleDict(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.layers = torch.nn.ModuleDict(
            {
                "0": torch.nn.Linear(10, 10),
            }
        )

    def forward(self, x):
        x = self.layers["0"](x)
        return x
```

This is useful for DBR quant.

Note: handling other logic for `ModuleDict` is left for future PRs.

Test plan:

```
pytest -vsk test_moduledict
```