### PR TITLE
Skip inductor tests on older pytorch versions

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -15,9 +15,15 @@ from torchdynamo.testing import same
 
 try:
     importlib.import_module("functorch")
+
+    from torch._decomp import get_decompositions
+
     from torchinductor import config
     from torchinductor.compile_fx import compile_fx
-except (ImportError, ModuleNotFoundError):
+
+    # This will only pass on pytorch builds newer than roughly 5/15/2022
+    assert get_decompositions([torch.ops.aten.trace])
+except (ImportError, ModuleNotFoundError, AssertionError):
     raise unittest.SkipTest("requires functorch")
 
 

--- a/torchinductor/codecache.py
+++ b/torchinductor/codecache.py
@@ -65,11 +65,11 @@ def cpp_compile_command(input, output, include_pytorch=False):
     if include_pytorch:
         ipaths = cpp_extension.include_paths() + [sysconfig.get_path("include")]
         lpaths = cpp_extension.library_paths() + [sysconfig.get_config_var("LIBDIR")]
-        libs = ["c10", "torch", "torch_cpu", "torch_python", "omp5"]
+        libs = ["c10", "torch", "torch_cpu", "torch_python", "gomp"]
     else:
         ipaths = []
         lpaths = []
-        libs = ["omp5"]
+        libs = ["gomp"]
     ipaths = " ".join(["-I" + p for p in ipaths])
     lpaths = " ".join(["-L" + p for p in lpaths])
     libs = " ".join(["-l" + p for p in libs])

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -49,6 +49,8 @@ DTYPE_ID_LOOKUP = {
 
 
 def decode_dtype(dtype: int):
+    if not isinstance(dtype, int):
+        return dtype
     assert dtype in DTYPE_ID_LOOKUP, f"id {dtype} missing from DTYPE_ID_LOOKUP"
     dtype = DTYPE_ID_LOOKUP[dtype]
     return dtype
@@ -200,7 +202,7 @@ def _to_copy(
     non_blocking=False,
     memory_format=None,
 ):
-    assert not layout, "TODO"
+    assert not layout or layout == torch.strided, "TODO"
     assert not pin_memory, "TODO"
     assert not memory_format, "TODO"
     if dtype is not None:
@@ -623,7 +625,7 @@ def _full(fill_value, device, dtype, size):
 def constant_like(fill_value):
     def _constant_like(x, *, dtype, device, layout, pin_memory=False):
         assert not pin_memory
-        assert layout == 0
+        assert layout in (0, torch.strided)
         dtype = decode_dtype(dtype)
         return _full(fill_value, device, dtype, x.get_size())
 


### PR DESCRIPTION
This also fixes a few errors on the latest pytorch version.