### PR TITLE
Dump conv args into file

### DIFF
--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env pytest
 import importlib
+import json
+import os
 import unittest
 
 import torch
@@ -7,6 +9,7 @@ import torch
 import torchdynamo
 from torchdynamo.optimizations import backends
 from torchdynamo.optimizations.inference import offline_autotuner
+from torchdynamo.optimizations.log_args import conv_args_analysis
 from torchdynamo.optimizations.normalize import Inplacifier
 from torchdynamo.optimizations.normalize import normalize
 from torchdynamo.testing import same
@@ -85,6 +88,33 @@ class TestOptimizations(torchdynamo.testing.TestCase):
         self.assertIsNotNone(r1)
         self.assertTrue(same(r1, r2))
         self.assertTrue(same(r1, r3))
+
+    def test_log_conv_args(self):
+        model = Conv_Bn_Relu(3, 32, kernel_size=3, stride=1)
+        model = model.to(memory_format=torch.channels_last)
+        model = model.eval()
+        input = torch.randn(8, 3, 64, 64).contiguous(memory_format=torch.channels_last)
+        r1 = model(input)
+        with torchdynamo.optimize(conv_args_analysis), torch.no_grad():
+            r2 = model(input)
+        self.assertTrue(same(r1, r2.float(), tol=0.1))
+        # check tmp/conv_args.json exists and has keys as arg names
+        filename = "tmp/conv_args.json"
+        self.assertTrue(os.path.exists(filename))
+        with open(filename) as f:
+            args_dict = json.load(f)
+            self.assertIn("convolution", args_dict.keys())
+            conv_args_dict = args_dict["convolution"]
+            self.assertIn("input", conv_args_dict.keys())
+            self.assertIn("weight", conv_args_dict.keys())
+            self.assertIn("bias", conv_args_dict.keys())
+            self.assertIn("stride", conv_args_dict.keys())
+            self.assertIn("padding", conv_args_dict.keys())
+            self.assertIn("dilation", conv_args_dict.keys())
+            self.assertIn("transposed", conv_args_dict.keys())
+            self.assertIn("output_padding", conv_args_dict.keys())
+            self.assertIn("groups", conv_args_dict.keys())
+        os.remove(filename)
 
     @unittest.skipIf(not has_onnxruntime(), "requires onnxruntime")
     def test_export(self):

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -31,6 +31,14 @@ def has_ipex():
         return False
 
 
+def has_functorch():
+    try:
+        importlib.import_module("functorch")
+        return True
+    except ImportError:
+        return False
+
+
 class Seq(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -89,6 +97,7 @@ class TestOptimizations(torchdynamo.testing.TestCase):
         self.assertTrue(same(r1, r2))
         self.assertTrue(same(r1, r3))
 
+    @unittest.skipIf(not has_functorch(), "requires functorch")
     def test_log_conv_args(self):
         model = Conv_Bn_Relu(3, 32, kernel_size=3, stride=1)
         model = model.to(memory_format=torch.channels_last)

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -104,11 +104,13 @@ class TestOptimizations(torchdynamo.testing.TestCase):
         model = model.eval()
         input = torch.randn(8, 3, 64, 64).contiguous(memory_format=torch.channels_last)
         r1 = model(input)
+        # check tmp/conv_args.json exists and has keys as arg names
+        filename = "tmp/conv_args.json"
+        if os.path.exists(filename):
+            os.remove(filename)
         with torchdynamo.optimize(conv_args_analysis), torch.no_grad():
             r2 = model(input)
         self.assertTrue(same(r1, r2.float(), tol=0.1))
-        # check tmp/conv_args.json exists and has keys as arg names
-        filename = "tmp/conv_args.json"
         self.assertTrue(os.path.exists(filename))
         with open(filename) as f:
             args_dict = json.load(f)

--- a/torchbench.py
+++ b/torchbench.py
@@ -1034,10 +1034,7 @@ def main():
         output_filename = f"speedup_{args.backend}.csv"
         args.isolate = True
     elif args.log_conv_args:
-        optimize_ctx = torchdynamo.optimize(
-            conv_args_analysis,
-            nopython=args.nopython
-        )
+        optimize_ctx = torchdynamo.optimize(conv_args_analysis, nopython=args.nopython)
         output_filename = "log_conv_args.csv"
     else:
         optimize_ctx = torchdynamo.optimize(fx_insert_profiling, nopython=args.nopython)

--- a/torchbench.py
+++ b/torchbench.py
@@ -32,6 +32,7 @@ from torchdynamo.optimizations.inference import fixed_strategy1
 from torchdynamo.optimizations.inference import fixed_strategy2
 from torchdynamo.optimizations.inference import offline_autotuner
 from torchdynamo.optimizations.inference import online_autotuner
+from torchdynamo.optimizations.log_args import conv_args_analysis
 from torchdynamo.optimizations.python_key import python_key
 from torchdynamo.optimizations.training import aot_autograd_debug_strategy1
 from torchdynamo.optimizations.training import aot_autograd_nnc_strategy
@@ -804,6 +805,11 @@ def main():
         action="store_true",
         help="Test that bytecode rewriting works properly.",
     )
+    group.add_argument(
+        "--log-conv-args",
+        action="store_true",
+        help="Dump convolution input/weight/bias's shape/stride/dtype and other options to json",
+    )
 
     args = parser.parse_args()
 
@@ -1027,6 +1033,12 @@ def main():
         experiment = speedup_experiment
         output_filename = f"speedup_{args.backend}.csv"
         args.isolate = True
+    elif args.log_conv_args:
+        optimize_ctx = torchdynamo.optimize(
+            conv_args_analysis,
+            nopython=args.nopython
+        )
+        output_filename = "log_conv_args.csv"
     else:
         optimize_ctx = torchdynamo.optimize(fx_insert_profiling, nopython=args.nopython)
         experiment = coverage_experiment

--- a/torchdynamo/optimizations/log_args.py
+++ b/torchdynamo/optimizations/log_args.py
@@ -1,0 +1,63 @@
+import torch
+import json
+
+from torchdynamo.optimizations.python_key import python_key_normalize
+from torchinductor.lowering import tensor
+
+aten = torch.ops.aten
+
+
+class ConvArgsAnalysis(torch.fx.Interpreter):
+    """
+    Log arguments like input shape (input, bias, weights shape) 
+    and options(padding/stride/kernel size/dilation/etc) for
+    aten.convolution
+    """
+    def __init__(self, gm: torch.fx.GraphModule):
+        super().__init__(gm)
+
+        self.nodes_conv_args = {}
+        # self.convolution_args = inspect.getfullargspec(aten.convolution.op())[0]
+        # print(self.convolution_args)
+        # self.convolution_nargs = len(self.convolution_args)
+
+    def run(self, *args):
+        run_result = super().run(*args)
+        with open('tmp/conv_args.json', "w") as fd:
+            json.dump(self.nodes_conv_args, fd)
+        return run_result
+
+    def run_node(self, n: torch.fx.Node):
+        result = super().run_node(n)
+
+        if n.op == 'call_function':
+            if n.target == aten.convolution:
+                args, kwargs = self.fetch_args_kwargs_from_env(n)
+                assert(len(args) == 9), "aten.convolution should have 9 args"
+                # print(f"{n.op} {n.target} {n.args} {n.kwargs}")
+                #conv_args = {self.convolution_args[i]: args[i].shape
+                #    if isinstance(args[1], torch.tensor) else args[i]
+                #    for i in range(len(args)) }
+                # is there a way to inspect the parameters name of aten.convolution
+                conv_args = {}
+                conv_args['x'] = args[0].shape
+                conv_args['weight'] = args[1].shape
+                conv_args['bias'] = args[2].shape if args[2] is not None else None
+                conv_args['stride'] = args[3]
+                conv_args['padding'] = args[4]
+                conv_args['dilation'] = args[5]
+                conv_args['transposed'] = args[6]
+                conv_args['output_padding'] = args[7]
+                conv_args['groups'] = args[8]
+
+                self.nodes_conv_args[n.name] = conv_args
+        
+        return result
+
+
+def conv_args_analysis(gm: torch.fx.GraphModule, example_inputs):
+    # lowering graph
+    gm, wrap = python_key_normalize(gm, example_inputs)
+    # use Interpreter to logs the args of conv
+    graph = wrap(ConvArgsAnalysis(gm).run)(*example_inputs)
+    return wrap(gm.forward)

--- a/torchdynamo/optimizations/log_args.py
+++ b/torchdynamo/optimizations/log_args.py
@@ -19,7 +19,9 @@ class ConvArgsAnalysis(torch.fx.Interpreter):
         super().__init__(gm)
 
         self.nodes_conv_args = {}
-        self.conv_arg_names = [arg.name for arg in aten.convolution.default._schema.arguments]
+        self.conv_arg_names = [
+            arg.name for arg in aten.convolution.default._schema.arguments
+        ]
 
     def run(self, *args):
         run_result = super().run(*args)

--- a/torchdynamo/optimizations/log_args.py
+++ b/torchdynamo/optimizations/log_args.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import torch
 
@@ -24,7 +25,9 @@ class ConvArgsAnalysis(torch.fx.Interpreter):
 
     def run(self, *args):
         run_result = super().run(*args)
-        with open("tmp/conv_args.json", "w") as fd:
+        filename = "tmp/conv_args.json"
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        with open(filename, "w") as fd:
             json.dump(self.nodes_conv_args, fd)
         return run_result
 

--- a/torchdynamo/optimizations/log_args.py
+++ b/torchdynamo/optimizations/log_args.py
@@ -25,10 +25,12 @@ class ConvArgsAnalysis(torch.fx.Interpreter):
 
     def run(self, *args):
         run_result = super().run(*args)
-        filename = "tmp/conv_args.json"
-        os.makedirs(os.path.dirname(filename), exist_ok=True)
-        with open(filename, "w") as fd:
-            json.dump(self.nodes_conv_args, fd)
+        if self.nodes_conv_args:
+            filename = "tmp/conv_args.json"
+            os.makedirs(os.path.dirname(filename), exist_ok=True)
+            with open(filename, "a") as fd:
+                json.dump(self.nodes_conv_args, fd)
+                fd.write("\n")
         return run_result
 
     def run_node(self, n: torch.fx.Node):

--- a/torchdynamo/optimizations/log_args.py
+++ b/torchdynamo/optimizations/log_args.py
@@ -19,17 +19,7 @@ class ConvArgsAnalysis(torch.fx.Interpreter):
         super().__init__(gm)
 
         self.nodes_conv_args = {}
-        self.conv_arg_names = (
-            "input",
-            "weight",
-            "bias",
-            "stride",
-            "padding",
-            "dilation",
-            "transposed",
-            "output_padding",
-            "groups",
-        )
+        self.conv_arg_names = [arg.name for arg in aten.convolution.default._schema.arguments]
 
     def run(self, *args):
         run_result = super().run(*args)

--- a/torchdynamo/optimizations/log_args.py
+++ b/torchdynamo/optimizations/log_args.py
@@ -1,18 +1,19 @@
-import torch
 import json
 
+import torch
+
 from torchdynamo.optimizations.python_key import python_key_normalize
-from torchinductor.lowering import tensor
 
 aten = torch.ops.aten
 
 
 class ConvArgsAnalysis(torch.fx.Interpreter):
     """
-    Log arguments like input shape (input, bias, weights shape) 
+    Log arguments like input shape (input, bias, weights shape)
     and options(padding/stride/kernel size/dilation/etc) for
     aten.convolution
     """
+
     def __init__(self, gm: torch.fx.GraphModule):
         super().__init__(gm)
 
@@ -23,35 +24,29 @@ class ConvArgsAnalysis(torch.fx.Interpreter):
 
     def run(self, *args):
         run_result = super().run(*args)
-        with open('tmp/conv_args.json', "w") as fd:
+        with open("tmp/conv_args.json", "w") as fd:
             json.dump(self.nodes_conv_args, fd)
         return run_result
 
     def run_node(self, n: torch.fx.Node):
         result = super().run_node(n)
 
-        if n.op == 'call_function':
+        if n.op == "call_function":
             if n.target == aten.convolution:
                 args, kwargs = self.fetch_args_kwargs_from_env(n)
-                assert(len(args) == 9), "aten.convolution should have 9 args"
-                # print(f"{n.op} {n.target} {n.args} {n.kwargs}")
-                #conv_args = {self.convolution_args[i]: args[i].shape
-                #    if isinstance(args[1], torch.tensor) else args[i]
-                #    for i in range(len(args)) }
-                # is there a way to inspect the parameters name of aten.convolution
+                assert len(args) == 9, "aten.convolution should have 9 args"
                 conv_args = {}
-                conv_args['x'] = args[0].shape
-                conv_args['weight'] = args[1].shape
-                conv_args['bias'] = args[2].shape if args[2] is not None else None
-                conv_args['stride'] = args[3]
-                conv_args['padding'] = args[4]
-                conv_args['dilation'] = args[5]
-                conv_args['transposed'] = args[6]
-                conv_args['output_padding'] = args[7]
-                conv_args['groups'] = args[8]
+                conv_args["input"] = args[0].shape
+                conv_args["weight"] = args[1].shape
+                conv_args["bias"] = args[2].shape if args[2] is not None else None
+                conv_args["stride"] = args[3]
+                conv_args["padding"] = args[4]
+                conv_args["dilation"] = args[5]
+                conv_args["transposed"] = args[6]
+                conv_args["output_padding"] = args[7]
+                conv_args["groups"] = args[8]
 
                 self.nodes_conv_args[n.name] = conv_args
-        
         return result
 
 
@@ -59,5 +54,5 @@ def conv_args_analysis(gm: torch.fx.GraphModule, example_inputs):
     # lowering graph
     gm, wrap = python_key_normalize(gm, example_inputs)
     # use Interpreter to logs the args of conv
-    graph = wrap(ConvArgsAnalysis(gm).run)(*example_inputs)
+    wrap(ConvArgsAnalysis(gm).run)(*example_inputs)
     return wrap(gm.forward)


### PR DESCRIPTION
Summary: 
In the FX graph extracted from python key tracing, when seeing calls to aten.convolution, dump args including shapes (for input/bias/weight) and different options such as padding/stride/kernel size/dilation/etc to a json file.

Usage:
```
with torchdynamo.optimize(conv_args_analysis):
   func_to_analysis()
```
Test:
`pytest tests/test_optimizations.py::TestOptimizations::test_log_conv_args`
