### PR TITLE
enable tracing through id(nn_module_variable)

### DIFF
--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -553,3 +553,11 @@ class BuiltinVariable(VariableTracker):
             return variables.TupleVariable(
                 items, **VariableTracker.propagate(self, iterable, *args)
             )
+
+    def call_id(self, tx, *args):
+        if len(args) > 0 and isinstance(args[0], variables.NNModuleVariable):
+            nn_mod_variable = args[0]
+            mod = tx.output.get_submodule(nn_mod_variable.module_key)
+            return variables.ConstantVariable(id(mod))
+        else:
+            unimplemented(f"call_id with args {args}")


### PR DESCRIPTION
Summary:

Enables tracing through this syntax:

```
class M(torch.nn.Module):
    def forward(self, x, ref_id):
        self_id = id(self)
        if self_id == ref_id:
            x = torch.mul(x, 1.0)
        x = torch.add(x, 1.0)
        return x
```

This is useful for DBR quant because it uses `id(module)` for some
FQN gymnastics.

Test plan:

```
pytest -vsk test_id_of_nn_module
```