### PR TITLE
Decomposition for nan_to_num

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -366,6 +366,21 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(8, 8),))
 
+    def test_nan_to_num(self):
+        def fn(a):
+            return (
+                torch.nan_to_num(a),
+                torch.nan_to_num(a, nan=3.0),
+                torch.nan_to_num(a, nan=None),
+                torch.nan_to_num(a, posinf=4.0),
+                torch.nan_to_num(a, neginf=5.0),
+                torch.nan_to_num(a, nan=3.0, posinf=4.0, neginf=5.0),
+            )
+
+        self.common(
+            fn, (torch.tensor((float("nan"), float("inf"), float("-inf"), 1.0)),)
+        )
+
     def test_sum_keepdims(self):
         def fn(a, b):
             return (torch.sum(a + b, -1, keepdim=True),)

--- a/torchinductor/codecache.py
+++ b/torchinductor/codecache.py
@@ -79,7 +79,7 @@ def cpp_compile_command(input, output, include_pytorch=False):
         f"""
             {cpp_compiler()} -shared -fPIC -Wall -std=c++14 -Wno-unused-variable
             {ipaths} {lpaths} {libs}
-            -march=native -O3 -ffast-math -fopenmp
+            -march=native -O3 -ffast-math -fno-finite-math-only -fopenmp
             -o{output} {input}
         """,
     ).strip()


### PR DESCRIPTION
Implement [nan_to_num](https://pytorch.org/docs/stable/generated/torch.nan_to_num.html).  Note that supporting inf and nan properly on CPU requires disabling `-ffinite-math-only`, which probably reduces some optimization but is necessary for correctness.  (Chances are we'll need to drop `-ffast-math` entirely at some point, but then we actually need to implement a good reduction algorithm since the compiler would no longer do it for us.  Maybe `-fassociative-math` would be good enough and safe, idk.)