### PR TITLE
Fix inline list/dict mutation

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1384,14 +1384,14 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertEqual(cnts.op_count, 1)
 
     def test_inline_list_mutation(self):
-        def f1(l):
-            l.append(torch.ones(8))
-            return l
+        def f1(x):
+            x.append(torch.ones(8))
+            return x
 
         def f2():
-            l = [torch.ones(6)]
-            f1(l)
-            return l
+            x = [torch.ones(6)]
+            f1(x)
+            return x
 
         res1 = f2()
         cnts = torchdynamo.testing.CompileCounter()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1442,4 +1442,3 @@ class MiscTests(torchdynamo.testing.TestCase):
         with torchdynamo.optimize(cnts):
             res2 = f4()
         self.assertTrue(same(res1, res2))
-        print(res1)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1414,3 +1414,32 @@ class MiscTests(torchdynamo.testing.TestCase):
         with torchdynamo.optimize(cnts):
             res2 = f2()
         self.assertTrue(same(res1, res2))
+
+    def test_recursive_inline_list_mutation(self):
+        def f1(x, y):
+            x.append(torch.tensor([1.1]))
+            y.append(torch.tensor([1.2]))
+            return x, y
+
+        def f2(x, y):
+            x.append(torch.tensor([2.1]))
+            y.append(torch.tensor([2.2]))
+            f1(x, y)
+            return x, y
+
+        def f3(x):
+            x.append(torch.tensor([3.1]))
+            y = [torch.tensor([3.2])]
+            f2(x, y)
+            return x, y
+
+        def f4():
+            x = [torch.tensor([4.1])]
+            return f3(x)
+
+        res1 = f4()
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res2 = f4()
+        self.assertTrue(same(res1, res2))
+        print(res1)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -218,6 +218,20 @@ class InstructionTranslatorBase(object):
         )
         self.push(fn.call_function(self, args, kwargs))
 
+    def update_locals_and_stack(
+        self, oldvar: VariableTracker, newvar: VariableTracker, apply_side_effects=False
+    ):
+        def repl(v: VariableTracker):
+            if v.mutable_local is oldvar.mutable_local:
+                return newvar
+            return v
+
+        if apply_side_effects:
+            self.output.side_effects.apply(repl)
+        self.stack = [VariableTracker.apply(repl, x) for x in self.stack]
+        for k, x in self.symbolic_locals.items():
+            self.symbolic_locals[k] = VariableTracker.apply(repl, x)
+
     def replace_all(self, oldvar: VariableTracker, newvar: VariableTracker):
         if isinstance(
             oldvar.mutable_local, torchdynamo.side_effects.MutableSideEffects
@@ -230,16 +244,7 @@ class InstructionTranslatorBase(object):
             newvar = newvar.clone(
                 mutable_local=torchdynamo.variables.base.MutableLocal()
             )
-
-        def repl(v: VariableTracker):
-            if v.mutable_local is oldvar.mutable_local:
-                return newvar
-            return v
-
-        self.output.side_effects.apply(repl)
-        self.stack = [VariableTracker.apply(repl, x) for x in self.stack]
-        for k, x in self.symbolic_locals.items():
-            self.symbolic_locals[k] = VariableTracker.apply(repl, x)
+        self.update_locals_and_stack(oldvar, newvar, True)
         return newvar
 
     def inline_user_function_return(self, fn, args, kwargs):
@@ -1322,6 +1327,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             code_options={k: getattr(code, k) for k in dir(code)},
             f_code=code,
         )
+        self.parent = parent
         self.symbolic_result = None
         self.closure_cells = closure_cells
 
@@ -1361,6 +1367,23 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
     def LOAD_CLOSURE(self, inst):
         assert inst.argval in self.cell_and_freevars()
         self.push(self.closure_cells[inst.argval])
+
+    def is_from_parent(self, var: VariableTracker):
+        for k, v in self.parent.symbolic_locals.items():
+            if var.mutable_local is v.mutable_local:
+                return True
+        return False
+
+    def replace_all(self, oldvar: VariableTracker, newvar: VariableTracker):
+        if isinstance(
+            oldvar, (ListVariable, ConstDictVariable)
+        ) and self.is_from_parent(oldvar):
+            newvar = self.parent.replace_all(oldvar, newvar)
+            # update this sub inline translator's symbolic_locals and stack
+            super().update_locals_and_stack(oldvar, newvar)
+            return newvar
+        else:
+            return super().replace_all(oldvar, newvar)
 
     def should_compile_partial_graph(self):
         return False  # inlining functions is all-or-nothing

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1367,8 +1367,11 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
     def replace_all(self, oldvar: VariableTracker, newvar: VariableTracker):
         newvar = super().replace_all(oldvar, newvar)
-        # check and update parent's locals and stack in case oldvar is from parent
-        self.parent.update_locals_and_stack(oldvar, newvar)
+        # recursively check and update parent's locals and stack in case oldvar is from parent
+        translator = self
+        while hasattr(translator, "parent"):
+            translator = translator.parent
+            translator.update_locals_and_stack(oldvar, newvar)
         return newvar
 
     def should_compile_partial_graph(self):


### PR DESCRIPTION
*This is the 5/N issue found from https://github.com/pytorch/torchdynamo/issues/156.*

Minimal code to reproduce:
```
from typing import List
import torch
import torchdynamo

def f1(my_list):
    my_list.append(torch.tensor([3.0]))
    return my_list

def f2():
    my_list = []
    f1(my_list)
    return my_list

def my_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
    return gm.forward

with torchdynamo.optimize(my_compiler):
    print(f2())
```
The above code's output is:
```
[]
```
which is not correct, actually the output should be:
```
[tensor([3.])]
```

The root cause is the list variable was mutated inside of the inline translator, which was not reflected in the parent translator. The solution is to modify inline translator's ```replace_all``` method and update both parent and inline translator's local variables and stack values.
BTW, this also apply to dict variables and added tests for both.