### PR TITLE
[Draft] Light Refactor + Add support for torch.autograd.profiler.record_profile function

### DIFF
--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -38,6 +38,7 @@ def _disallowed_function_ids():
         torch.set_autocast_cpu_enabled,
         torch.set_autocast_enabled,
         torch.set_autocast_gpu_dtype,
+        torch.autograd.profiler.profile,
         warnings.warn,
     ]
     return {id(x) for x in remove}

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -122,7 +122,6 @@ class ContextWrappingVariable(ContextManagerVariable):
         self._call_func(tx, self.initial_value)
         return variables.ConstantVariable(None, **VariableTracker.propagate(self))
 
-
     def reconstruct(self, codegen, target_inst=None):
         """
         Generate following Python Bytecode, with a `torch._C._set_grad_enable` call
@@ -239,10 +238,12 @@ class ContextWrappingVariable(ContextManagerVariable):
     def _initial_value(self):
         raise NotImplementedError("_initial_value called on base")
 
+
 class GradModeVariable(ContextWrappingVariable):
     def __init__(self, target_value, initial_value=None, **kwargs):
-        super(GradModeVariable, self).__init__(target_value=target_value, initial_value=
-        initial_value, **kwargs)
+        super(GradModeVariable, self).__init__(
+            target_value=target_value, initial_value=initial_value, **kwargs
+        )
 
     def enter(self, tx):
         assert self.initial_value == torch.is_grad_enabled()
@@ -272,8 +273,9 @@ class GradModeVariable(ContextWrappingVariable):
 class ProfileRunModeVariable(ContextWrappingVariable):
     def __init__(self, target_value, initial_value=None, **kwargs):
         kwargs_edited = kwargs
-        super(ProfileRunModeVariable, self).__init__(target_value=target_value, initial_value=
-        initial_value, **kwargs_edited)
+        super(ProfileRunModeVariable, self).__init__(
+            target_value=target_value, initial_value=initial_value, **kwargs_edited
+        )
 
     def enter(self, tx):
         self.enter = True
@@ -283,7 +285,6 @@ class ProfileRunModeVariable(ContextWrappingVariable):
         self.enter = False
         super(ProfileRunModeVariable, self).exit(tx)
 
-
     def _call_func(self, tx, value):
         if self.enter:
             self.proxy_value = tx.output.create_proxy(
@@ -291,7 +292,10 @@ class ProfileRunModeVariable(ContextWrappingVariable):
             )
         else:
             tx.output.create_proxy(
-                "call_function", torch.ops.profiler._record_function_exit, (self.proxy_value,), {}
+                "call_function",
+                torch.ops.profiler._record_function_exit,
+                (self.proxy_value,),
+                {},
             )
 
     def _func_name(self):
@@ -299,9 +303,10 @@ class ProfileRunModeVariable(ContextWrappingVariable):
             return "torch.ops.profiler._record_function_enter"
         else:
             return "torch.ops.profiler._record_function_exit"
-    
+
     def _initial_value(self):
         return self.target_value
+
 
 class WithExitFunctionVariable(VariableTracker):
     def __init__(self, ctx: VariableTracker, target, **kwargs):

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -6,8 +6,6 @@ from typing import List
 
 import torch._C
 
-from torchdynamo.variables.tensor import TensorVariable
-
 from .. import variables
 from ..bytecode_transformation import create_instruction
 from ..exc import unimplemented

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -268,20 +268,20 @@ class GradModeVariable(ContextWrappingVariable):
             return "no_grad"
 
 
-class ProfileRunModeVariable(ContextWrappingVariable):
+class ProfileRecordFunctionVariable(ContextWrappingVariable):
     def __init__(self, target_value, initial_value=None, **kwargs):
         kwargs_edited = kwargs
-        super(ProfileRunModeVariable, self).__init__(
+        super(ProfileRecordFunctionVariable, self).__init__(
             target_value=target_value, initial_value=initial_value, **kwargs_edited
         )
 
     def enter(self, tx):
         self.enter = True
-        super(ProfileRunModeVariable, self).enter(tx)
+        super(ProfileRecordFunctionVariable, self).enter(tx)
 
     def exit(self, tx, *args):
         self.enter = False
-        super(ProfileRunModeVariable, self).exit(tx)
+        super(ProfileRecordFunctionVariable, self).exit(tx)
 
     def _call_func(self, tx, value):
         if self.enter:

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -228,7 +228,7 @@ class ContextWrappingVariable(ContextManagerVariable):
         return (prologue, epilogue)
 
     def _call_func(self, tx, initial_value):
-        raise NotImplementedError("call_func called on base")
+        raise NotImplementedError("_call_func called on base")
 
     def _func_name(self):
         raise NotImplementedError("_func_name called on base")

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -185,9 +185,6 @@ class TorchVariable(VariableTracker):
         elif self.value is torch.autograd.profiler.record_function:
             assert len(args) == 1
             return ProfileRecordFunctionVariable(str(args[0].as_proxy()), **options)
-        elif self.value is torch.autograd.profiler.profile:
-            # Passthrough
-            return None
         else:
             return TensorVariable.create(
                 tx=tx,

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -6,7 +6,7 @@ from typing import List
 import torch._C
 import torch.nn
 
-from torchdynamo.variables.misc import ProfileRunModeVariable
+from torchdynamo.variables.misc import ProfileRecordFunctionVariable
 
 from .. import config
 from .. import variables
@@ -184,10 +184,10 @@ class TorchVariable(VariableTracker):
             )
         elif self.value is torch.autograd.profiler.record_function:
             assert len(args) == 1
-            return ProfileRunModeVariable(str(args[0].as_proxy()), **options)
+            return ProfileRecordFunctionVariable(str(args[0].as_proxy()), **options)
         elif self.value is torch.autograd.profiler.profile:
             # Passthrough
-            return ConstantVariable(torch.autograd.profiler.profile, **options)
+            return None
         else:
             return TensorVariable.create(
                 tx=tx,

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -183,7 +183,7 @@ class TorchVariable(VariableTracker):
                 tensor_with_tf_override.subclass_type,
             )
         elif self.value is torch.autograd.profiler.record_function:
-            assert(len(args) == 1)
+            assert len(args) == 1
             return ProfileRunModeVariable(str(args[0].as_proxy()), **options)
         elif self.value is torch.autograd.profiler.profile:
             # Passthrough


### PR DESCRIPTION
This diff takes GradModeVariable's logic and pulls it partially into a more generic ContextWrappingVariable base class intended for making it easier to write context managed code.

This works, and passes all tests, but I am somewhat conflicted on the refactor. On one hand, it pulls a lot of boilerplate out, on the other hand, so far we dont have a ton of cases and it does make it more complicated to read. I also do not know what the n+1 case will look like, in terms of shared vs overriden logic.