### PR TITLE
Collect guard failures into one warning at cache limit hit

### DIFF
--- a/torchdynamo/__init__.py
+++ b/torchdynamo/__init__.py
@@ -6,6 +6,8 @@ from .eval_frame import optimize_assert
 from .eval_frame import reset_code
 from .eval_frame import run
 from .eval_frame import skip
+from .guards import guard_failures
+from .guards import orig_code_map
 
 __all__ = [
     "optimize",
@@ -24,6 +26,8 @@ def reset():
         reset_code(code)
     convert_frame.input_codes.clear()
     convert_frame.output_codes.clear()
+    orig_code_map.clear()
+    guard_failures.clear()
     resume_execution.ContinueExecutionCache.cache.clear()
 
 

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -207,7 +207,7 @@ def convert_frame_assert(compiler_fn: Callable, one_graph=True):
             for attempt in itertools.count():
                 try:
                     code = transform_code_object(frame.f_code, transform)
-                    orig_code_map[id(code)] = frame.f_code
+                    orig_code_map[code] = frame.f_code
                     break
                 except exc.RestartAnalysis:
                     if attempt > 100:

--- a/torchdynamo/guards.py
+++ b/torchdynamo/guards.py
@@ -24,6 +24,7 @@ from ._guards import check_obj_id
 from ._guards import check_type_id
 from .eval_frame import set_guard_error_hook
 from .eval_frame import set_guard_fail_hook
+from .utils import ExactWeakKeyDictionary
 from .utils import istype
 from .utils import rename_implicit
 from .utils import tuple_iterator_getitem
@@ -32,7 +33,7 @@ from .utils import tuple_iterator_len
 log = logging.getLogger(__name__)
 
 # map from transformed code back to original user code
-orig_code_map = {}
+orig_code_map = ExactWeakKeyDictionary()
 
 # keep a record of code_obj -> list of guard failure reasons for logging
 guard_failures = collections.defaultdict(list)
@@ -406,7 +407,7 @@ def guard_fail_hook(
         if not eval(part, guard_fn.global_scope, scope):
             reasons.append(part)
             break
-    guard_failures[orig_code_map[id(code)]].append(reasons)
+    guard_failures[orig_code_map[code]].append(reasons)
 
 
 def guard_error_hook(


### PR DESCRIPTION
- avoid warning on each guard failure separately (in cases cache limit >  1)
- instead, bundle a summary of gaurd failure warnings together at the  time of cache limit hit

Example Output:

> torchdynamo hit recompilation cache limit (2) for function 'model' (warn.py:39), due to the following guard failures: [['___check_tensors(input)'], ['___check_tensors(input)']]

Repro:
```
torchdynamo.config.cache_size_limit = 2

def model(input):
    return input + input

for i in range(10):
    bsz = torch.randint(low=0, high=1000, size=())
    x = torch.randn((bsz, 3, 4))
    with torchdynamo.optimize("eager"):
        out = model(x)

```