### PR TITLE
Add support for STORE_GLOBAL

### DIFF
--- a/tests/test_global.py
+++ b/tests/test_global.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env pytest
+import torch
+
+import torchdynamo.testing
+from torchdynamo.testing import same
+
+from . import test_global_declaration
+
+torchdynamo.config.debug = True
+
+
+class Pair(object):
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+def Foo():
+    return Pair(1, 1)
+
+
+g_counter = 1
+g_list = [0, 1, 2]
+g_dict = {"a": 0, "b": 1}
+g_object = Foo()
+g_tensor = torch.zeros(10)
+
+
+_name: int = 0
+
+
+def fresh_name() -> str:
+    """create a new unique name for a variable: v0, v1, v2"""
+    global _name
+    r = f"v{_name}"
+    _name += 1
+    return r
+
+
+def reset_name():
+    global _name
+    _name = 0
+
+
+class TestGlobals(torchdynamo.testing.TestCase):
+    def test_store_global_1(self):
+        def fn(x):
+            global g_counter
+            val = x + g_counter
+            g_counter += 1
+            return val
+
+        x = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res1 = fn(x)
+        res2 = fn(x)
+        self.assertTrue(same(res2 - res1, torch.ones(10)))
+
+    def test_store_global_2(self):
+        def fn(x):
+            global g_counter
+            val = x + g_counter
+            g_counter += 1
+            g_counter += 1
+            return val
+
+        x = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res1 = fn(x)
+        """Wrap the second call with torchdynamo as well"""
+        with torchdynamo.optimize(cnts):
+            res2 = fn(x)
+        self.assertTrue(same(res2 - res1, 2 * torch.ones(10)))
+
+    def test_store_global_new(self):
+        def fn(x):
+            # Test create a new global
+            global g_counter_new
+            g_counter_new = x + 1
+            return x + g_counter_new
+
+        x = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res1 = fn(x)
+        self.assertTrue(same(res1, x + x + 1))
+
+    def test_store_global_list(self):
+        def fn(x):
+            global g_list
+            val = x + g_list[1]
+            """
+            Strictly speaking, we are not testing STORE_GLOBAL
+            here, since STORE_SUBSCR is actually used to store.
+            """
+            g_list[1] += 1
+            return val
+
+        x = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res1 = fn(x)
+        res2 = fn(x)
+        self.assertTrue(same(res2 - res1, torch.ones(10)))
+
+    def test_store_global_list_2(self):
+        def fn(x):
+            global g_list
+            val = x + g_list[1]
+            g_list = [x + 1 for x in g_list]
+            return val
+
+        x = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res1 = fn(x)
+        res2 = fn(x)
+        self.assertTrue(same(res2 - res1, torch.ones(10)))
+
+    def test_store_global_dict(self):
+        def fn(x):
+            global g_dict
+            val = x + g_dict["b"]
+            """
+            Strictly speaking, we are not testing STORE_GLOBAL
+            here, since STORE_SUBSCR is actually used to store.
+            """
+            g_dict["b"] += 1
+            return val
+
+        x = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res1 = fn(x)
+        res2 = fn(x)
+        self.assertTrue(same(res2 - res1, torch.ones(10)))
+
+    def test_store_global_dict_2(self):
+        def fn(x):
+            global g_dict
+            g_dict = {key: value + 1 for key, value in g_dict.items()}
+            val = x + g_dict["b"]
+            return val
+
+        x = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res1 = fn(x)
+        res2 = fn(x)
+        self.assertTrue(same(res2 - res1, torch.ones(10)))
+
+    def test_store_global_object(self):
+        def fn(x):
+            global g_object
+            val = x + g_object.y
+            g_object.y += 1
+            return val
+
+        x = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res1 = fn(x)
+        res2 = fn(x)
+        self.assertTrue(same(res2 - res1, torch.ones(10)))
+
+    def test_store_global_cross_file(self):
+        def fn(x):
+            val = x + test_global_declaration.g_tensor_export
+            test_global_declaration.g_tensor_export = (
+                test_global_declaration.g_tensor_export + 1
+            )
+            return val
+
+        x = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res1 = fn(x)
+        res2 = fn(x)
+        self.assertTrue(same(res2 - res1, torch.ones(10)))
+
+    def test_store_global_inline_1(self):
+        # Borrowed from test_python_autograd.py
+        class Variable:
+            def __init__(self, value: torch.Tensor, name: str = None):
+                self.value = value
+                self.name = name or fresh_name()
+
+        def fn(a, b):
+            a = Variable(a)
+            b = Variable(b)
+            return a.value + b.value, a.name + b.name
+
+        a = torch.randn(10)
+        b = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            v0, s0 = fn(a, b)
+        self.assertEqual(s0, "v0v1")
+        reset_name()
+
+    def test_store_global_inline_2(self):
+        # Borrowed from test_python_autograd.py
+        class Variable:
+            def __init__(self, value: torch.Tensor, name: str = None):
+                self.value = value
+                self.name = name or fresh_name()
+
+            @staticmethod
+            def constant(value: torch.Tensor, name: str = None):
+                return Variable(value, name)
+
+        def fn(a, b):
+            a = Variable.constant(a)
+            b = Variable.constant(b)
+            return a.value + b.value, a.name + b.name
+
+        a = torch.randn(10)
+        b = torch.randn(10)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            v0, s0 = fn(a, b)
+        self.assertEqual(s0, "v0v1")
+        reset_name()

--- a/tests/test_global_declaration.py
+++ b/tests/test_global_declaration.py
@@ -1,0 +1,3 @@
+import torch
+
+g_tensor_export = torch.ones(10)

--- a/tests/test_python_autograd.py
+++ b/tests/test_python_autograd.py
@@ -18,24 +18,16 @@ This is an example of a pure-python version of autograd implemented by
 to push the limits of what it can do.
 """
 
-if False:
-    # TODO(jansel): requires STORE_GLOBAL (#40) and f-strings (#41)
-    _name: int = 0
 
-    def fresh_name() -> str:
-        """create a new unique name for a variable: v0, v1, v2"""
-        global _name
-        r = f"v{_name}"
-        _name += 1
-        return r
+_name: int = 0
 
-else:
-    # this is the only remaining workaround
-    _names = []
 
-    def fresh_name():
-        _names.append("v" + str(len(_names)))
-        return _names[-1]
+def fresh_name() -> str:
+    """create a new unique name for a variable: v0, v1, v2"""
+    global _name
+    r = f"v{_name}"
+    _name += 1
+    return r
 
 
 class Variable:
@@ -81,7 +73,8 @@ gradient_tape: List[TapeEntry] = []
 
 def reset_tape():
     gradient_tape.clear()
-    _names.clear()
+    global _name
+    _name = 0
 
 
 def grad(L, desired_results: List[Variable]) -> List[Variable]:

--- a/torchdynamo/side_effects.py
+++ b/torchdynamo/side_effects.py
@@ -118,6 +118,15 @@ class SideEffects(object):
         assert isinstance(cellvar, variables.NewCellVariable)
         return self.load_attr(cellvar, "cell_contents")
 
+    def load_global(self, gvar: VariableTracker, name: str):
+        assert isinstance(gvar, variables.VariableTracker)
+        return self.load_attr(gvar, name)
+
+    def store_global(self, gvar: VariableTracker, name: str, value: VariableTracker):
+        assert isinstance(gvar, variables.VariableTracker)
+        assert isinstance(value, variables.VariableTracker)
+        self.store_attr(gvar, name, value)
+
     @staticmethod
     def cls_supports_mutation_side_effects(cls):
         return inspect.getattr_static(cls, "__setattr__", None) in (
@@ -189,6 +198,14 @@ class SideEffects(object):
 
     def track_cell_existing(self, source: Source, item: Any):
         variable = variables.NewCellVariable(
+            mutable_local=AttributeMutationExisting(source),
+        )
+        self.id_to_variable[id(item)] = variable
+        self.keepalive.append(item)
+        return variable
+
+    def track_global_existing(self, source: Source, item: Any):
+        variable = variables.NewGlobalVariable(
             mutable_local=AttributeMutationExisting(source),
         )
         self.id_to_variable[id(item)] = variable
@@ -297,10 +314,15 @@ class SideEffects(object):
                 for name, value in self.store_attr_mutations.get(
                     var.mutable_local, {}
                 ).items():
-                    cg.tx.output.update_co_names(name)
-                    cg(value)
-                    cg(var.mutable_local.source)
-                    suffixes.append([create_instruction("STORE_ATTR", name)])
+                    if isinstance(var, variables.NewGlobalVariable):
+                        cg.tx.output.update_co_names(name)
+                        cg(value)
+                        suffixes.append([create_instruction("STORE_GLOBAL", name)])
+                    else:
+                        cg.tx.output.update_co_names(name)
+                        cg(value)
+                        cg(var.mutable_local.source)
+                        suffixes.append([create_instruction("STORE_ATTR", name)])
             else:
                 assert False, type(var)
 

--- a/torchdynamo/variables/__init__.py
+++ b/torchdynamo/variables/__init__.py
@@ -22,6 +22,7 @@ from .misc import GradModeVariable
 from .misc import InspectSignatureVariable
 from .misc import LambdaVariable
 from .misc import NewCellVariable
+from .misc import NewGlobalVariable
 from .misc import NumpyVariable
 from .misc import PythonModuleVariable
 from .misc import SuperVariable
@@ -53,6 +54,7 @@ __all__ = [
     "NamedTupleVariable",
     "NestedUserFunctionVariable",
     "NewCellVariable",
+    "NewGlobalVariable",
     "NNModuleVariable",
     "NumpyVariable",
     "PythonModuleVariable",

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -95,6 +95,11 @@ class NewCellVariable(VariableTracker):
         super(NewCellVariable, self).__init__(**kwargs)
 
 
+class NewGlobalVariable(VariableTracker):
+    def __init__(self, **kwargs):
+        super(NewGlobalVariable, self).__init__(**kwargs)
+
+
 class ContextManagerVariable(VariableTracker):
     pass
 


### PR DESCRIPTION
Summary:
1. Create a symbolic_global table to store a global variable name to an
unique object mapping, and the unique object is further used as a key to
index into the store_attr_mutations table in SideEffects.
2. The actual STORE_GLOGAL action is buffered by SideEffects and later
LOAD_GLOBAL just reads from SideEffects when appropriate. STORE_GLOBAL
is eventually applied after the generated graph.