### PR TITLE
Implement verbose tensor guards check 

### DIFF
--- a/tests/test_recompile_ux.py
+++ b/tests/test_recompile_ux.py
@@ -128,18 +128,22 @@ class RecompileUxTests(torchdynamo.testing.TestCase):
 
         a = torch.rand(3, 4, 5)
         cache_fail_test(
-            a, a[0:2, :, :], "tensor size mismatch at index 0. expected 3, actual 2"
+            a, a[0:2, :, :], "tensor 'a' size mismatch at index 0. expected 3, actual 2"
         )
         cache_fail_test(
             a,
             a.clone().as_strided((3, 4, 5), stride=(1, 3, 12)),
-            "tensor strides mismatch at index 0. expected 20, actual 1",
+            "tensor 'a' strides mismatch at index 0. expected 20, actual 1",
         )
-        cache_fail_test(a, a[0, :, :], "tensor rank mismatch. expected 3, actual 2")
-        cache_fail_test(a, a.to("meta"), "tensor dispatch key set mismatch.")
+        cache_fail_test(a, a[0, :, :], "tensor 'a' rank mismatch. expected 3, actual 2")
+        cache_fail_test(a, a.to("meta"), "tensor 'a' dispatch key set mismatch.")
         cache_fail_test(
-            a, a.to(torch.float16), "tensor dtype mismatch. expected Float, actual Half"
+            a,
+            a.to(torch.float16),
+            "tensor 'a' dtype mismatch. expected Float, actual Half",
         )
         a_grad = a.clone()
         a_grad.requires_grad = True
-        cache_fail_test(a, a_grad, "requires_grad mismatch. expected requires_grad=0")
+        cache_fail_test(
+            a, a_grad, "tensor 'a' requires_grad mismatch. expected requires_grad=0"
+        )

--- a/torchdynamo/_guards.cpp
+++ b/torchdynamo/_guards.cpp
@@ -60,26 +60,27 @@ public:
     return true;
   }
 
-  std::string check_verbose(const LocalState &state, const at::Tensor &v) {
+  std::string check_verbose(const LocalState &state, const at::Tensor &v, std::string tensor_name) {
     std::stringstream fail_reason;
+    fail_reason << "tensor '" << tensor_name << "' ";
     if (dispatch_key_ != state.apply(v.key_set()).raw_repr()){
       // return fmt::format("tensor dispatch key mismatch. expected {}, actual {}", dispatch_key_, state.apply(v.key_set()).raw_repr());
-      fail_reason << "tensor dispatch key set mismatch. expected " << c10::DispatchKeySet(c10::DispatchKeySet::RAW, dispatch_key_)
+      fail_reason << "dispatch key set mismatch. expected " << c10::DispatchKeySet(c10::DispatchKeySet::RAW, dispatch_key_)
                   << ", actual " << state.apply(v.key_set());
       return fail_reason.str();
     } else if(dtype_ != v.dtype().toScalarType()) {
       // return fmt::format("tensor dtype mismatch. expected {}, actual {}", dtype_, v.dtype().toScalarType());
-      fail_reason << "tensor dtype mismatch. expected " << dtype_ << ", actual " << v.dtype().toScalarType();
+      fail_reason << "dtype mismatch. expected " << dtype_ << ", actual " << v.dtype().toScalarType();
       return fail_reason.str();
     } else if(requires_grad_ != (state.grad_mode_enabled && v.requires_grad())) {
       // return fmt::format("tensor requires_grad mismatch. expected {}", requires_grad_);
-      fail_reason << "tensor requires_grad mismatch. expected requires_grad=" << requires_grad_;
+      fail_reason << "requires_grad mismatch. expected requires_grad=" << requires_grad_;
       return fail_reason.str();
     }
     size_t ndim = static_cast<size_t>(v.ndimension());
     if (ndim != sizes_.size()) {
       // return fmt::format("tensor rank mismatch. expected {}, actual {}", sizes_.size(), ndim);
-      fail_reason << "tensor rank mismatch. expected " << sizes_.size() << ", actual " << ndim;
+      fail_reason << "rank mismatch. expected " << sizes_.size() << ", actual " << ndim;
       return fail_reason.str();
     }
     if (!dynamic_shapes_) {
@@ -88,11 +89,11 @@ public:
       for (size_t i = 0; i < ndim; ++i) {
         if (sizes_[i] != sizes[i]){
           // return fmt::format("tensor size mismatch at index {}. expected {}, actual {}", i, sizes_[i], sizes[i]);
-          fail_reason << "tensor size mismatch at index " << i << ". expected " << sizes_[i] << ", actual " << sizes[i];
+          fail_reason << "size mismatch at index " << i << ". expected " << sizes_[i] << ", actual " << sizes[i];
           return fail_reason.str();
         } else if (strides_[i] != strides[i]) {
           // return fmt::format("tensor strides mismatch at index {}. expected {}, actual {}", i, strides_[i]);
-          fail_reason << "tensor strides mismatch at index " << i << ". expected " << strides_[i] << ", actual " << strides[i];
+          fail_reason << "strides mismatch at index " << i << ". expected " << strides_[i] << ", actual " << strides[i];
           return fail_reason.str();
         }
       }
@@ -192,7 +193,7 @@ PyObject *TensorGuards_check(TensorGuards *self, PyObject *args) {
   Py_RETURN_TRUE;
 }
 
-PyObject *TensorGuards_check_verbose(TensorGuards *self, PyObject *args) {
+PyObject *TensorGuards_check_verbose(TensorGuards *self, PyObject *args,  PyObject *kwargs) {
   if (!PyTuple_CheckExact(args)) {
     PyErr_SetString(PyExc_TypeError, "expected tuple()");
     return NULL;
@@ -204,15 +205,42 @@ PyObject *TensorGuards_check_verbose(TensorGuards *self, PyObject *args) {
     PyErr_SetString(PyExc_TypeError, "wrong length");
     return NULL;
   }
+  
+  PyObject *tensor_check_names_py = PyDict_GetItemString(kwargs, "tensor_check_names");
+  if (tensor_check_names_py == NULL) {
+    PyErr_SetString(PyExc_TypeError, "missing tensor_check_names kwarg");
+    return NULL;
+  }
+  
+	if (!PyList_Check(tensor_check_names_py)) {
+    PyErr_SetString(PyExc_TypeError, "tensor_check_names kwarg must be a list");
+    return NULL;
+  }
+  
+  size_t names_size = PyList_Size(tensor_check_names_py);
+  if(names_size != checks.size()) {
+    PyErr_SetString(PyExc_TypeError, "tensor_check_names should be the same size as # tensors");
+    return NULL;
+  }
 
+  std::vector<std::string> tensor_check_names;
+  tensor_check_names.reserve(names_size);
+  for(Py_ssize_t i = 0; i < names_size; i++) {
+    PyObject *value = PyList_GetItem(tensor_check_names_py, i);
+    if (!PyUnicode_Check(value)) {
+      PyErr_SetString(PyExc_TypeError, "tensor_check_names must only contain strings");
+      return NULL;
+    }
+    tensor_check_names.emplace_back(PyUnicode_AsUTF8(value));
+  }
+  
   LocalState state;
-
   for (ssize_t i = 0; i < len; ++i) {
     PyObject *item = PyTuple_GET_ITEM(args, i);
     if (Py_TYPE(item) != checks[i].pytype) {
       return Py_BuildValue("s", "Py_Type check fail");
     }
-    std::string fail_reason = checks[i].check_verbose(state, THPVariable_Unpack(item));
+    std::string fail_reason = checks[i].check_verbose(state, THPVariable_Unpack(item), tensor_check_names[i]);
     if(fail_reason.length() > 0){
       return Py_BuildValue("s", fail_reason.c_str());
     }
@@ -223,7 +251,7 @@ PyObject *TensorGuards_check_verbose(TensorGuards *self, PyObject *args) {
 
 static PyMethodDef TensorGuards_methods[] = {
     {"check", (PyCFunction)TensorGuards_check, METH_VARARGS, ""},
-    {"check_verbose", (PyCFunction)TensorGuards_check_verbose, METH_VARARGS, "verbose fail reasons for failed checks"},
+    {"check_verbose", (PyCFunction)TensorGuards_check_verbose, METH_VARARGS | METH_KEYWORDS, "verbose fail reasons for failed checks"},
     {NULL} /* Sentinel */
 };
 

--- a/torchdynamo/guards.py
+++ b/torchdynamo/guards.py
@@ -355,9 +355,10 @@ class GuardedCode:
             check_tensors_fn = tensor_guards.check
             check_tensors_verbose_fn = tensor_guards.check_verbose
             code_parts.append(f"___check_tensors({', '.join(tensor_check_names)})")
-            verbose_code_parts.append(
-                f"___check_tensors_verbose({', '.join(tensor_check_names)})"
+            verbose_args = ", ".join(
+                tensor_check_names + ["tensor_check_names=tensor_check_names"]
             )
+            verbose_code_parts.append(f"___check_tensors_verbose({verbose_args})")
 
         code = " and ".join(unique(code_parts))
 
@@ -366,6 +367,7 @@ class GuardedCode:
                 ("___guarded_code", self),
                 ("___check_tensors", check_tensors_fn),
                 ("___check_tensors_verbose", check_tensors_verbose_fn),
+                ("tensor_check_names", tensor_check_names),
             ]
         )
         closure_vars.update(CLOSURE_VARS)

--- a/torchdynamo/guards.py
+++ b/torchdynamo/guards.py
@@ -334,20 +334,30 @@ class GuardedCode:
         code_parts = (
             ["___guarded_code.valid"] + local_builder.code + global_builder.code
         )
+        # TODO(whc) maybe only the 'check_tensors' one is ambiguous? if so we can be less general..
+        verbose_code_parts = (
+            ["___guarded_code.valid"] + local_builder.code + global_builder.code
+        )
 
         tensor_check_names = (
             local_builder.tensor_check_names + global_builder.tensor_check_names
         )
         check_tensors_fn = None
+        check_tensors_verbose_fn = None
         if tensor_check_names:
             tensor_check_examples = (
                 local_builder.tensor_check_examples
                 + global_builder.tensor_check_examples
             )
-            check_tensors_fn = TensorGuards(
+            tensor_guards = TensorGuards(
                 *tensor_check_examples, dynamic_shapes=config.dynamic_shapes
-            ).check
+            )
+            check_tensors_fn = tensor_guards.check
+            check_tensors_verbose_fn = tensor_guards.check_verbose
             code_parts.append(f"___check_tensors({', '.join(tensor_check_names)})")
+            verbose_code_parts.append(
+                f"___check_tensors_verbose({', '.join(tensor_check_names)})"
+            )
 
         code = " and ".join(unique(code_parts))
 
@@ -355,6 +365,7 @@ class GuardedCode:
             [
                 ("___guarded_code", self),
                 ("___check_tensors", check_tensors_fn),
+                ("___check_tensors_verbose", check_tensors_verbose_fn),
             ]
         )
         closure_vars.update(CLOSURE_VARS)
@@ -366,13 +377,14 @@ class GuardedCode:
         )
         if os.environ.get("TORCHDYNAMO_PRINT_GUARDS", None) == "1":
             print("GUARDS", code)
-        # if os.environ.get("TORCHDYNAMO_PRINT_GUARD_FAILS", None) == "1":
         set_guard_fail_hook(guard_fail_hook)
         out = dict()
         exec(py_code, global_builder.scope, out)
         guard_fn = out["___make_guard_fn"](*closure_vars.values())
         guard_fn.closure_vars = closure_vars
+        # TODO(whc) maybe '.code_parts' was only kept around for the guard callback? so we don't need both
         guard_fn.code_parts = code_parts
+        guard_fn.verbose_code_parts = verbose_code_parts
         guard_fn.global_scope = global_builder.scope
         return guard_fn
 
@@ -395,16 +407,21 @@ def guard_fail_hook(
     guard_fn: Callable, code: types.CodeType, f_locals: Dict[str, Any], last: bool
 ):
     """
-    set TORCHDYNAMO_PRINT_GUARD_FAILS=1 to cause this to be called
-    whenever a guard fails.
+    called whenever a guard fails.
     """
     if not last:
         return
     scope = {rename_implicit(k): v for k, v in f_locals.items()}
     scope.update(guard_fn.closure_vars)
     reasons = []
-    for part in guard_fn.code_parts:
-        if not eval(part, guard_fn.global_scope, scope):
+    for part in guard_fn.verbose_code_parts:
+        fail_reason = eval(part, guard_fn.global_scope, scope)
+        # TODO(whc) hacky for now as not every 'part' in guard_fn.verbose_code_parts
+        # is updated to return a string explaining the failure.
+        if isinstance(fail_reason, str):
+            reasons.append(fail_reason)
+            break
+        elif isinstance(fail_reason, bool) and not fail_reason:
             reasons.append(part)
             break
     guard_failures[orig_code_map[code]].append(reasons)


### PR DESCRIPTION
Verbose guard checks are guards used outside of the hot path
for providing specific failure information to the user on compile
cache miss.

This PR adds support for verbose guards and implements one for the
tensor guard, leaving other guards alone.

Note: depends on unmerged https://github.com/pytorch/torchdynamo/pull/281 - 
when reviewing this PR, only look at the latest commit "Implement verbose tensor guards check"