### PR TITLE
Pytorch tests 5/n - Graph break on MemberDescriptor type

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest
 tabulate
 torch
 sympy
+expecttest

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1442,3 +1442,19 @@ class MiscTests(torchdynamo.testing.TestCase):
         with torchdynamo.optimize(cnts):
             res2 = f4()
         self.assertTrue(same(res1, res2))
+
+    def test_sample_input(self):
+        from torch.testing._internal.common_methods_invocations import SampleInput
+
+        def fn(sample):
+            if isinstance(sample.input, torch.Tensor):
+                return sample.input * 2
+            return torch.zeros(())
+
+        sample = SampleInput(torch.ones(2))
+        ref = fn(sample)
+
+        with torchdynamo.optimize("eager"):
+            res = fn(sample)
+
+        self.assertTrue(same(ref, res))

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -159,10 +159,10 @@ def has_tensor_in_frame(frame):
             seen_ids[obj_id] = any([has_tensor(v) for v in obj.__dict__.values()])
             return seen_ids[obj_id]
         else:
-            if config.debug:
-                print(
-                    f"Assuming that object of type {type(obj)} does not have a tensor"
-                )
+            # if config.debug:
+            #     print(
+            #         f"Assuming that object of type {type(obj)} does not have a tensor"
+            #     )
             return False
 
     # Check if the passed arguments are of type Tensor
@@ -172,7 +172,7 @@ def has_tensor_in_frame(frame):
 
     if config.debug:
         print(
-            "skipping",
+            "skipping because no torch.*",
             frame.f_code.co_name,
             frame.f_code.co_filename,
             frame.f_code.co_firstlineno,


### PR DESCRIPTION
Supports `SampleInput` testing. If there is a python user defined object from C++, `ifinstance` causes a graph break with this PR.