### PR TITLE
update_locals_and_stack should use shared cache

### DIFF
--- a/torchdynamo/side_effects.py
+++ b/torchdynamo/side_effects.py
@@ -84,12 +84,13 @@ class SideEffects(object):
             keepalive=list(self.keepalive),
         )
 
-    def apply(self, fn):
+    def apply(self, fn, cache=None):
         self.id_to_variable = collections.OrderedDict(
-            (k, VariableTracker.apply(fn, v)) for k, v in self.id_to_variable.items()
+            (k, VariableTracker.apply(fn, v, cache))
+            for k, v in self.id_to_variable.items()
         )
         self.store_attr_mutations = collections.OrderedDict(
-            (k, VariableTracker.apply(fn, v))
+            (k, VariableTracker.apply(fn, v, cache))
             for k, v in self.store_attr_mutations.items()
         )
 

--- a/torchdynamo/side_effects.py
+++ b/torchdynamo/side_effects.py
@@ -85,6 +85,9 @@ class SideEffects(object):
         )
 
     def apply(self, fn, cache=None):
+        if cache is None:
+            cache = dict()
+
         self.id_to_variable = collections.OrderedDict(
             (k, VariableTracker.apply(fn, v, cache))
             for k, v in self.id_to_variable.items()

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -224,10 +224,11 @@ class InstructionTranslatorBase(object):
                 return newvar
             return v
 
-        self.output.side_effects.apply(repl)
-        self.stack = [VariableTracker.apply(repl, x) for x in self.stack]
+        cache = dict()
+        self.output.side_effects.apply(repl, cache)
+        self.stack = [VariableTracker.apply(repl, x, cache) for x in self.stack]
         for k, x in self.symbolic_locals.items():
-            self.symbolic_locals[k] = VariableTracker.apply(repl, x)
+            self.symbolic_locals[k] = VariableTracker.apply(repl, x, cache)
 
     def replace_all(self, oldvar: VariableTracker, newvar: VariableTracker):
         if isinstance(


### PR DESCRIPTION
*This is the 7/N issue found from https://github.com/pytorch/torchdynamo/issues/156.*

Failed models: [```test_LoSealL_VideoSuperResolution.py```](https://github.com/yanboliang/pytorch-jit-paritybench/blob/master/generated/test_LoSealL_VideoSuperResolution.py#L589)

Minimal code to reproduce:
```
from typing import List
import torch
import torchdynamo

def fn(x):
    perm = [0, 3, 5]
    perm = [i for i in range(min(perm))] + perm
    perm.extend(i for i in range(x.dim()) if i not in perm)
    return perm

def my_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
    return gm.forward

input = torch.rand([2, 2, 2, 2, 2, 2])

with torchdynamo.optimize(my_compiler):
    print(fn(input))
```
w/o torchdynamo, the output is: ```[0, 3, 5, 1, 2, 4]```
w torchdynamo, the output is: ```[0, 3, 5]```

Root cause and proposed solution:
* ```perm``` which is ```ListVariable``` occurs twice in the stack, so inside of [```compile_subgraph```](https://github.com/pytorch/torchdynamo/blob/main/torchdynamo/output_graph.py#L204) it should be listed in the ```pass2.tempvars```. ```pass2.tempvars``` is decided by [```self.uses```](https://github.com/pytorch/torchdynamo/blob/main/torchdynamo/codegen.py#L122) counter, whose key is the variable object(actually is memory address).
* Every time when a list change happens, ```replace_all``` will be called and meanwhile update variable objects in ```side_effect, stack and symbolic_locals```. However, the current implementation use separate cache, which makes the same variable links to different object(as [```VariableTracker.apply```](https://github.com/pytorch/torchdynamo/blob/main/torchdynamo/variables/base.py#L93) returns a new cloned object). We should use shared cache, then the same variable at ```side_effect, stack and symbolic_locals``` are the same object.