### PR TITLE
PyTorch tests - 6/n - Add type check for list/tuple elems in CONSTANT_MATCH

### DIFF
--- a/tests/test_repros.py
+++ b/tests/test_repros.py
@@ -1163,7 +1163,7 @@ class ReproTests(torchdynamo.testing.TestCase):
         self.assertGreaterEqual(torchdynamo.utils.counters["frames"]["ok"], 3)
         self.assertGreaterEqual(torchdynamo.utils.counters["frames"]["total"], 3)
 
-    def test_guard_fail(self):
+    def test_guard_fail_tensor_bool(self):
         @torchdynamo.skip
         def fn():
             condition_shape = (5, 5)
@@ -1208,3 +1208,16 @@ class ReproTests(torchdynamo.testing.TestCase):
         fn()
         with torchdynamo.optimize("eager"):
             fn()
+
+    def test_guard_fail_nested_tuple(self):
+        def fn(args):
+            return torch.ones(()), args[0] * 2
+
+        with torchdynamo.optimize("eager"):
+            # This adds a tensor check on args[1][0] and args[1][1]
+            args = (torch.ones(1), (torch.ones(1), torch.ones(1)))
+            ref = fn(args)
+            args = (torch.ones(1), torch.ones(1))
+            res = fn(args)
+
+        self.assertTrue(same(ref, res))

--- a/torchdynamo/guards.py
+++ b/torchdynamo/guards.py
@@ -221,6 +221,12 @@ class GuardBuilder:
 
         # Add a type check to prevent boolean check of a tensor and non-tensor.
         self.code.append(f"___check_type_id({ref}, {self.id_ref(type(val))})")
+        if istype(val, (list, slice, tuple)):
+            for idx, elem in enumerate(val):
+                self.code.append(
+                    f"___check_type_id({ref}[{idx}], {self.id_ref(type(elem))})"
+                )
+
         self.code.append(f"{ref} == {val!r}")
 
     def CONSTANT_MATCH(self, guard: Guard):

--- a/torchdynamo/guards.py
+++ b/torchdynamo/guards.py
@@ -263,6 +263,18 @@ class GuardBuilder:
         self.code.append(f"___check_type_id({ref}, {self.id_ref(type(value))})")
         self.code.append(f"len({ref}) == {len(value)}")
 
+        def add_guard_recursively(prefix_index_str, lst):
+            for idx, elem in enumerate(lst):
+                if istype(elem, (list, tuple)):
+                    r = f"{ref}{prefix_index_str}[{idx}]"
+                    self.code.append(
+                        f"___check_type_id({r}, {self.id_ref(type(elem))})"
+                    )
+                    self.code.append(f"len({r}) == {len(elem)}")
+                    add_guard_recursively(f"{prefix_index_str}[{idx}]", elem)
+
+        add_guard_recursively("", value)
+
     def TUPLE_ITERATOR_LEN(self, guard):
         ref = self.arg_ref(guard)
         value = self.get(guard.name)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1191,12 +1191,28 @@ class InstructionTranslator(InstructionTranslatorBase):
             if k in f_locals
         )
 
-        # TODO(jansel): figure out why the following is needed for detectron2_maskrcnn
+        # symbolic_locals contains the mapping from original f_locals to the
+        # Variable objects. During the Variable building phase, each object also
+        # has its associated guards. At the end, we will accumulate these
+        # guards.
+        #
+        # One way of handling these guards is to just accumulate all of them
+        # right now. However, many f_locals might not be used in the frame and
+        # thus can unnecessarily increase guard execution overhead.  Therefore,
+        # we selectively update output.guards as we run the Python Bytecode
+        # instruction by instruction.
+        #
+        # An exception here is list/dict variables. Guards related to these
+        # variables have indexed access, like Tensor_match on args[0], and if
+        # args is not used in this frame, we will miss a LIST_LENGTH check like
+        # len(args) == 2. Missing the LIST_LENGTH check causes problem for the
+        # next invocation when args is not a list, and args[0] is a runtime
+        # error. Therefore, we recursively add guards for list/dict variable here.
         for val in self.symbolic_locals.values():
             if isinstance(
                 val, (ListIteratorVariable, BaseListVariable, ConstDictVariable)
             ):
-                self.output.guards.update(val.guards)
+                self.output.guards.update(VariableTracker.propagate(val)["guards"])
 
         self._freevars_ids = dict()
         for name in self.code_options["co_freevars"]:

--- a/torchdynamo/variables/base.py
+++ b/torchdynamo/variables/base.py
@@ -50,6 +50,10 @@ class VariableTracker:
             if type(var) in (list, tuple, dict_values, odict_values):
                 for i in var:
                     visit(i)
+            elif isinstance(var, variables.BaseListVariable):
+                guards.update(var.guards)
+                for i in var.items:
+                    visit(i)
             else:
                 assert isinstance(var, VariableTracker), typestr(var)
                 guards.update(var.guards)


### PR DESCRIPTION

For guards like

~~~
isinstance(args, list) # ---> its fast equivalent
and args = (110, 11)
~~~

if `args` actual runtime value is a list of tensor like 

~~~
(tensor(...), )
~~~

The type check passes and it proceeds to comparing Tensor and a scalar value, leading to boolean Tensor and guard executing failure. This PR adds an extra type checks on each element of the list/tuple when it is a CONSTANT_MATCH guard.

This PR also add list length guard recursively for list.