### PR TITLE
Low precision support

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -366,32 +366,6 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(8, 9, 3, 21), torch.randn(8, 9, 3, 21)))
 
-    def test_fn_sum(self):
-        def fn(a,b):
-            return a+b
-
-        size=(4,32,16,112,112)
-        size1=(32,1,112,1)
-        a=torch.randn(size, dtype=torch.half).transpose(-1,-2)
-        b=torch.randn(size1, dtype=torch.half).transpose(-1,-2)
-        self.common(fn, (a,b))
-
-    # def test_fn_sum1(self):
-    #     def fn(x0, x1, x2):
-    #         x4=x2+x0
-    #         x5=x2+x1
-    #         x6=x5.sum(-1)
-    #         x7=x1.sum(-1)
-    #         return x4, x6, x7
-
-
-    #     size=(2048, 1024)
-    #     x0=torch.randn(size, dtype=torch.half)
-    #     x1=torch.randn(size, dtype=torch.half)
-    #     x2=torch.randn(size[-1], dtype=torch.half)
-    #     self.common(fn, (x0,x1,x2))
-
-
     def test_sum3(self):
         def fn(a, b):
             r1 = a + b

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -9,7 +9,8 @@ from unittest.mock import patch
 import sympy
 import torch
 from torch.nn import functional as F
-from torch.utils._pytree import tree_flatten, tree_unflatten
+from torch.utils._pytree import tree_flatten
+from torch.utils._pytree import tree_unflatten
 
 import torchdynamo
 from torchdynamo.testing import rand_strided

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -107,6 +107,7 @@ class InputGen:
 def check_model(self: TestCase, model, example_inputs, tol=1e-4, check_lowp=True):
     # check_lowp is ignored here, it's kept just to be able to call `common` with extra arg
     has_lowp_args = False
+
     def upcast_fn(x):
         nonlocal has_lowp_args
         if isinstance(x, torch.Tensor) and (x.dtype == torch.float16 or x.dtype == torch.bfloat16):
@@ -123,6 +124,7 @@ def check_model(self: TestCase, model, example_inputs, tol=1e-4, check_lowp=True
     if has_lowp_args:
         if hasattr(model, "to"):
             model = model.to(torch.half)
+
     @torchdynamo.optimize_assert(functools.partial(compile_fx, cudagraphs=False))
     def run(*ex):
         return model(*ex)
@@ -531,7 +533,7 @@ class CommonTemplate:
 
         self.common(
             fn, (torch.tensor((float("nan"), float("inf"), float("-inf"), 1.0)),),
-            check_lowp=False # a much more elaborate test is required to match finfo max's for float and half
+            check_lowp=False  # a much more elaborate test is required to match finfo max's for float and half
         )
 
     def test_div(self):
@@ -843,7 +845,7 @@ class CommonTemplate:
         self.common(
             fn,
             (torch.randn([2, 2, 10]),),
-            check_lowp=False # cpu doesn't understand fp16, and there are explicit .cpu() calls
+            check_lowp=False  # cpu doesn't understand fp16, and there are explicit .cpu() calls
         )
 
     def test_unbind(self):
@@ -1122,7 +1124,7 @@ class CommonTemplate:
         self.common(
             m,
             (torch.randn([3, 10, 16, 16]),),
-            check_lowp=False, #too painful to match types of bn model
+            check_lowp=False,  # too painful to match types of bn model
         )
 
     def test_leaky_relu(self):
@@ -1484,7 +1486,7 @@ class CommonTemplate:
                 torch.randn([4, 8, 2048]),
                 torch.randn([4, 8, 2048]),
             ),
-            check_lowp=False, #difference in rnn is too large between half and float inputs
+            check_lowp=False,  # difference in rnn is too large between half and float inputs
         )
 
     def test_upsample_nearest2d(self):

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -380,16 +380,16 @@ class Kernel(CodeGen):
         self.stores = stores
         self.cse = cse
 
-    def load(self, name: str, index: sympy.Expr):
+    def load(self, name: str, index: sympy.Expr, upcast: bool = False):
         raise NotImplementedError()
 
-    def indirect_load(self, name: str, index: sympy.Expr):
+    def indirect_load(self, name: str, index: sympy.Expr, upcast: bool = False):
         """A load the depends on an index we have read"""
         prior = self.loads
         try:
             # put the load in the compute section as it might have deps
             self.loads = self.compute
-            return self.load(name, index)
+            return self.load(name, index, upcast)
         finally:
             self.loads = prior
 
@@ -415,16 +415,16 @@ class Kernel(CodeGen):
                 return sympy.Symbol(str(index_var))
 
             @staticmethod
-            def load(name: str, index: sympy.Expr):
+            def load(name: str, index: sympy.Expr, upcast: bool = False):
                 if "tmp" in str(index):
-                    return self.indirect_load(name, index)
+                    return self.indirect_load(name, index, upcast)
                 store_cache = self.cse.store_cache
                 if (name, index) in store_cache:
                     return store_cache[(name, index)]
                 if (name, self.rename_indexing(index)) in store_cache:
                     # TODO(jansel): figure out why we need this second case
                     return store_cache[(name, self.rename_indexing(index))]
-                return self.load(name, index)
+                return self.load(name, index, upcast)
 
             @staticmethod
             def store(name, index, value):

--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -203,7 +203,8 @@ class CppKernel(Kernel):
         self.reduction_suffix = IndentedBuffer()
         self.reduction_vars = {}
 
-    def load(self, name: str, index: sympy.Expr):
+    def load(self, name: str, index: sympy.Expr, upcast: bool = False):
+        # upcast argument is ignored on cpu
         var = self.args.input(name)
         index = self.rename_indexing(index)
         return self.cse.generate(self.loads, f"{var}[{cexpr(index)}]")

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -373,12 +373,14 @@ class TritonKernel(Kernel):
             yield var
         self._load_mask = prior
 
-    def load(self, name: str, index: sympy.Expr):
+    def load(self, name: str, index: sympy.Expr, upcast: bool = False):
         if (name, index) in self.disabled_reduction_stores:
             tmpvar = self.disabled_reduction_stores[(name, index)]
             return f"tl.reshape({tmpvar}, (BLOCK_SIZE, 1))"
         var = self.args.input(name)
         line = f"tl.load({var} + {self.indexing(index)}, {self.mask()})"
+        if upcast:
+            line += ".to(tl.float32)"
         return self.cse.generate(self.loads, line)
 
     def store(self, name, index, value):

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -70,9 +70,9 @@ class RecordLoadStore(V.MockHandler):
         self._index_exprs = set()
         self._size = tuple([x for x in size if x != 1])
 
-    def load(self, name: str, index: sympy.Expr):
+    def load(self, name: str, index: sympy.Expr, upcast: bool = False):
         self._reads.add(MemoryDep(name, index, self._size))
-        return f"load({name}, {index})"
+        return f"load({name}, {index}, {upcast})"
 
     def store(self, name, index, value):
         self._writes.add(MemoryDep(name, index, self._size))

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -697,7 +697,9 @@ class ReinterpretView(BaseView):
     def make_loader(self):
         def loader(index):
             indexer = self.layout.make_indexer()
-            upcast = self.get_dtype() == torch.float16 or self.get_dtype == torch.bfloat16
+            upcast = (
+                self.get_dtype() == torch.float16 or self.get_dtype == torch.bfloat16
+            )
             return ops.load(self.get_name(), indexer(index), upcast)
 
         return loader
@@ -1034,7 +1036,9 @@ class Buffer(IRNode):
     def make_loader(self):
         def loader(index):
             indexer = self.layout.make_indexer()
-            upcast = self.get_dtype() == torch.float16 or self.get_dtype() == torch.bfloat16
+            upcast = (
+                self.get_dtype() == torch.float16 or self.get_dtype() == torch.bfloat16
+            )
             return ops.load(self.name, indexer(index), upcast)
 
         return loader

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -697,7 +697,8 @@ class ReinterpretView(BaseView):
     def make_loader(self):
         def loader(index):
             indexer = self.layout.make_indexer()
-            return ops.load(self.get_name(), indexer(index))
+            upcast = self.get_dtype() == torch.float16 or self.get_dtype == torch.bfloat16
+            return ops.load(self.get_name(), indexer(index), upcast)
 
         return loader
 
@@ -1033,7 +1034,8 @@ class Buffer(IRNode):
     def make_loader(self):
         def loader(index):
             indexer = self.layout.make_indexer()
-            return ops.load(self.name, indexer(index))
+            upcast = self.get_dtype() == torch.float16 or self.get_dtype() == torch.bfloat16
+            return ops.load(self.name, indexer(index), upcast)
 
         return loader
 
@@ -2032,9 +2034,9 @@ class LoopBodyBlock:
             )
 
         class CaptureIndexing(V.WrapperHandler):
-            def load(self, name: str, index: sympy.Expr):
+            def load(self, name: str, index: sympy.Expr, upcast: bool = False):
                 index = add_index(index, "reads")
-                return self._inner.load(name, index)
+                return self._inner.load(name, index, upcast)
 
             def store(self, name, index, value):
                 index = add_index(index, "writes")

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -329,9 +329,9 @@ class SimplifyIndexing(V.WrapperHandler):
         super().__init__(inner)
         self._var_ranges = var_ranges
 
-    def load(self, name: str, index: sympy.Expr):
+    def load(self, name: str, index: sympy.Expr, upcast: bool = False):
         index = V.graph.sizevars.simplify_with_ranges(index, self._var_ranges)
-        return self._inner.load(name, index)
+        return self._inner.load(name, index, upcast)
 
     def store(self, name, index, value):
         index = V.graph.sizevars.simplify_with_ranges(index, self._var_ranges)


### PR DESCRIPTION
This PR adds simple fp16/bfloat16 to triton backend, by immediately converting fresh loads in these datatypes to fp32. Triton automatically converts stores to the dtype of the output, so as long as surrounding code creates correctly-typed outputs (it does) no special treatment is needed. 
We could go a more sophisticated route and actually add conversion to and from computation type to lowerings, and then codegen them, but that would create less accurate results with no appreciable perf gains, and it's also harder to implement. Current nvfuser approach is similarly to convert on loads and not do intermediate truncations.  
cc @desertfire 