### PR TITLE
Fix slowdown due to generation_tagging_new

### DIFF
--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env pytest
 
+from copy import deepcopy
+
 import torch
 from torch.nn import functional as F
 
 import torchdynamo.testing
 from torchdynamo.eval_frame import unsupported
-from copy import deepcopy
 
 from . import test_functions
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -5,6 +5,7 @@ from torch.nn import functional as F
 
 import torchdynamo.testing
 from torchdynamo.eval_frame import unsupported
+from copy import deepcopy
 
 from . import test_functions
 
@@ -610,6 +611,28 @@ class NNModuleTests(torchdynamo.testing.TestCase):
         self.assertTrue(torchdynamo.testing.same(out2, out3))
         self.assertTrue(torchdynamo.testing.same(out2, out4))
         self.assertEqual(cnt.frame_count, 3)
+
+    def test_generation_tag(self):
+        cnt = torchdynamo.testing.CompileCounter()
+
+        # guarantee that we have installed
+        # the generation tagging function
+        with torchdynamo.optimize_assert(cnt):
+            pass
+
+        m1 = torch.nn.Linear(10, 10)
+        prev_generation = m1.generation
+        cur_generation = prev_generation + 1
+
+        with torchdynamo.optimize_assert(cnt):
+            m2 = torch.nn.Linear(10, 10)
+
+        self.assertEqual(m1.generation, prev_generation)
+        self.assertEqual(m2.generation, cur_generation)
+        # check that newly constructed instances
+        # also have the same generation (even if copied from an old instance)
+        m3 = deepcopy(m1)
+        self.assertEqual(m3.generation, cur_generation)
 
     def test_simple_torch_function(self):
         def foo(x):

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -12,7 +12,7 @@ from torchdynamo.utils import clone_inputs
 from . import config
 from . import convert_frame
 from . import skipfiles
-from .mutation_guard import install_generation_tagging_new
+from .mutation_guard import install_generation_tagging_init
 from .utils import same
 
 log = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ class OptimizeContext(_TorchDynamoContext):
     def __init__(self, callback, backend_ctx_ctor):
         super().__init__(
             callback=callback,
-            on_enter=install_generation_tagging_new,
+            on_enter=install_generation_tagging_init,
             backend_ctx_ctor=backend_ctx_ctor,
         )
 


### PR DESCRIPTION
* Fix slowdown due to monkey-patching new() of torch modules

Generation tagging was previously implemented by patching new() to populate a map of object -> generation tag. This changes the implementation to patch init() and setstate() to directly populate a generation attribute on the object. 

The comparison below was made by running alexnet ([test script](https://github.com/pytorch/torchdynamo/issues/107#issuecomment-1102872948)) in eager mode with and without torchdynamo, and computing the ratio of torch dynamo eager latency / eager mode latency * 100.

Ceiling was computed by making every module non-dynamic (not tracking generation tags) which shows the overhead of torchdynamo in isolation. The other values were computed by averaging 10 runs of the [test script](https://github.com/pytorch/torchdynamo/issues/107#issuecomment-1102872948).

| |ceiling|patched init with map | patched new | patched init with attr
-- | -- | -- | -- | --
Result  | 96.74 | 94.74 | 91.22 | 95.11


