### PR TITLE
ConstDictVariable reconstruct should keep original order

### DIFF
--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -80,9 +80,11 @@ class PyCodegen(object):
         if allow_cache:
             if value.mutable_local and value.mutable_local in self.tempvars:
                 output.append(self.create_load(self.tempvars[value.mutable_local]))
+                self.top_of_stack = value
                 return
             if self.tempvars.get(value) is not None:
                 output.append(self.create_load(self.tempvars[value]))
+                self.top_of_stack = value
                 return
 
         if value.source is not None and allow_cache:

--- a/torchdynamo/variables/dicts.py
+++ b/torchdynamo/variables/dicts.py
@@ -28,7 +28,7 @@ class ConstDictVariable(VariableTracker):
     def reconstruct(self, codegen):
         if len(self.items) == 0:
             return [create_instruction("BUILD_MAP", 0)]
-        keys = tuple(sorted(self.items.keys()))
+        keys = tuple(self.items.keys())
         for key in keys:
             codegen(self.items[key])
         return [


### PR DESCRIPTION
Fix https://github.com/pytorch/torchdynamo/issues/298, where we should use original key's order to reconstruct ```ConstDictVariable```.

Bonus: After I corrected the reconstruct logics, ```test_return_dict``` fails. I dig into this failure and found another bug in ```codegen```, where we forget to update ```top_of_stack``` if we hit ```tempvars``` and early exit. 