### PR TITLE
Fix repro test to unblock internal sync

### DIFF
--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -2,6 +2,7 @@ import builtins
 import collections
 import copy
 import functools
+import inspect
 import itertools
 import math
 import operator
@@ -69,6 +70,7 @@ def _disallowed_function_ids():
         collections.OrderedDict,
         copy.copy,
         copy.deepcopy,
+        inspect.signature,
         torch.autocast_decrement_nesting,
         torch.autocast_increment_nesting,
         torch.autograd.grad,


### PR DESCRIPTION
Currently `is_allowed` reads the PyTorch imports and also treats packages like `inspect` as torch objects.

For example parsing of this line - https://github.com/pytorch/pytorch/blob/master/torch/ao/quantization/utils.py#L11 results in an allowed object - `torch.ao.quantization.utils.signature`.

Ideally, we should filter out such stuff from `_allowed_ids`. For now, just sending a quick PR to unblock internal sync.

