### PR TITLE
Initial implementation of UnspecializedPrimitiveVariable

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -651,8 +651,8 @@ class MiscTests(torchdynamo.testing.TestCase):
         with torchdynamo.optimize(cnts):
             self.assertTrue(same(fn(*args), correct))
             self.assertTrue(same(fn(*args), correct))
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 1)
+        self.assertEqual(cnts.frame_count, 0)
+        self.assertEqual(cnts.op_count, 0)
 
     def test_dict_mutation_side_effect(self):
         def fn(d):
@@ -1534,3 +1534,26 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertEqual(len(module_dict), len(modules))
         for k1, m2 in zip(modules, module_dict.children()):
             self.assertTrue(modules[k1] is m2)
+
+    def test_unspecialized_primitive_variable(self):
+        def fn(x, y, z):
+            xy = [x + y, y, False]
+            np_x = x.numpy()
+            np_y = y.numpy()
+            return {
+                "x": x,
+                "z": z,
+                "a": np_y.sum(),
+                "b": xy,
+                "c": np_y[0][0] / 68,
+                "d": np_x.sum(),
+            }
+
+        x = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float64)
+        y = torch.ones([2, 2], dtype=torch.int64)
+        z = np.int64(12)
+        res1 = fn(x, y, z)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res2 = fn(x, y, z)
+        self.assertTrue(same(res1, res2))

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -651,8 +651,8 @@ class MiscTests(torchdynamo.testing.TestCase):
         with torchdynamo.optimize(cnts):
             self.assertTrue(same(fn(*args), correct))
             self.assertTrue(same(fn(*args), correct))
-        self.assertEqual(cnts.frame_count, 0)
-        self.assertEqual(cnts.op_count, 0)
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(cnts.op_count, 2)
 
     def test_dict_mutation_side_effect(self):
         def fn(d):

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -95,6 +95,17 @@ def is_numpy_int_type(value):
     )
 
 
+def is_numpy_float_type(value):
+    return istype(
+        value,
+        (
+            np.float16,
+            np.float32,
+            np.float64,
+        ),
+    )
+
+
 def istensor(obj):
     """Check of obj is a tensor"""
     return istype(
@@ -407,6 +418,8 @@ def same(a, b, cos_similarity=False, tol=1e-4, equal_nan=False):
             return torch.allclose(a, b, atol=tol, rtol=tol, equal_nan=equal_nan)
     elif isinstance(a, (str, int, float, type(None), bool, torch.device)):
         return a == b
+    elif is_numpy_int_type(a) or is_numpy_float_type(a):
+        return (type(a) is type(b)) and (a == b)
     elif type(a).__name__ in (
         "MaskedLMOutput",
         "Seq2SeqLMOutput",

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -275,9 +275,7 @@ class VariableBuilder:
             return AutogradFunctionVariable(
                 value, guards=make_guards(GuardBuilder.FUNCTION_MATCH)
             )
-        elif (
-            is_numpy_int_type(value) or is_numpy_float_type(value)
-        ) and self.name.startswith("___stack"):
+        elif is_numpy_int_type(value) or is_numpy_float_type(value):
             self.tx.output.graphargs.append(
                 GraphArg(self.get_source(), torch.tensor(value))
             )

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -26,6 +26,7 @@ from ..source import Source
 from ..source import TupleIteratorGetItemSource
 from ..utils import getfile
 from ..utils import is_namedtuple
+from ..utils import is_numpy_float_type
 from ..utils import is_numpy_int_type
 from ..utils import istensor
 from ..utils import istype
@@ -54,6 +55,7 @@ from .misc import SkipFilesVariable
 from .nn_module import UnspecializedNNModuleVariable
 from .tensor import TensorVariable
 from .tensor import TensorWithTFOverrideVariable
+from .tensor import UnspecializedPrimitiveVariable
 from .torch import TorchVariable
 from .user_defined import UserDefinedClassVariable
 from .user_defined import UserDefinedObjectVariable
@@ -273,8 +275,20 @@ class VariableBuilder:
             return AutogradFunctionVariable(
                 value, guards=make_guards(GuardBuilder.FUNCTION_MATCH)
             )
-        elif is_numpy_int_type(value):
-            return self._wrap(int(value))
+        elif (
+            is_numpy_int_type(value) or is_numpy_float_type(value)
+        ) and self.name.startswith("___stack"):
+            self.tx.output.graphargs.append(
+                GraphArg(self.get_source(), torch.tensor(value))
+            )
+            return UnspecializedPrimitiveVariable.create(
+                tx=self.tx,
+                proxy=self.tx.output.create_graph_input(
+                    re.sub(r"[^a-zA-Z0-9]+", "_", self.name), type(value)
+                ),
+                example_value=torch.tensor(value),
+                guards=self.make_guards(GuardBuilder.TYPE_MATCH),
+            )
         elif DataClassVariable.is_matching_object(value):
             return DataClassVariable.wrap(self, value).add_guards(
                 make_guards(GuardBuilder.TYPE_MATCH)


### PR DESCRIPTION
Changes:
* Add ```UnspecializedPrimitiveVariable``` which is a 1-element tensor representing unspecialized primitive type.
* Add heuristic to decide when to specialize and when not to:
  * If the variable is numpy int or float, we wrap it as unspecialized.
* More heuristic will be added later if this is the right direction. 

Fix https://github.com/pytorch/torchdynamo/issues/292
Partially contribute to https://github.com/pytorch/torchdynamo/issues/70 
