### PR TITLE
Filter out unimportant modules from allowed modules

### DIFF
--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -118,6 +118,8 @@ def _allowed_function_ids():
                     or inspect.getmodule(obj).__name__.startswith("math")
                 ):
                     torch_object_ids[id(obj)] = f"{module.__name__}.{name}"
+                elif inspect.getmodule(obj) is None:
+                    torch_object_ids[id(obj)] = f"{module.__name__}.{name}"
 
     _find_torch_objects(torch)
     _find_torch_objects(math)

--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -113,7 +113,12 @@ def _allowed_function_ids():
                     if obj.__name__.startswith("torch."):
                         torch_object_ids[id(obj)] = f"{module.__name__}.{name}"
                         _find_torch_objects(obj)
-                else:
+                elif inspect.getmodule(obj) and (
+                    inspect.getmodule(obj).__name__.startswith("torch")
+                    or inspect.getmodule(obj).__name__.startswith("math")
+                ):
+                    torch_object_ids[id(obj)] = f"{module.__name__}.{name}"
+                elif inspect.getmodule(obj) is None:
                     torch_object_ids[id(obj)] = f"{module.__name__}.{name}"
 
     _find_torch_objects(torch)

--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -100,6 +100,12 @@ def _allowed_function_ids():
     torch.distributions.Distribution.set_default_validate_args(False)
     torch_object_ids = dict()
 
+    def _is_allowed_module_prefix(obj):
+        allowed_module_name_prefix_list = ("torch", "math")
+        return inspect.getmodule(obj) and inspect.getmodule(obj).__name__.startswith(
+            allowed_module_name_prefix_list
+        )
+
     def _find_torch_objects(module):
         if any(
             module.__name__.startswith(mod_name)
@@ -113,10 +119,7 @@ def _allowed_function_ids():
                     if obj.__name__.startswith("torch."):
                         torch_object_ids[id(obj)] = f"{module.__name__}.{name}"
                         _find_torch_objects(obj)
-                elif inspect.getmodule(obj) and (
-                    inspect.getmodule(obj).__name__.startswith("torch")
-                    or inspect.getmodule(obj).__name__.startswith("math")
-                ):
+                elif _is_allowed_module_prefix(obj):
                     torch_object_ids[id(obj)] = f"{module.__name__}.{name}"
                 elif inspect.getmodule(obj) is None:
                     torch_object_ids[id(obj)] = f"{module.__name__}.{name}"

--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -118,8 +118,6 @@ def _allowed_function_ids():
                     or inspect.getmodule(obj).__name__.startswith("math")
                 ):
                     torch_object_ids[id(obj)] = f"{module.__name__}.{name}"
-                elif inspect.getmodule(obj) is None:
-                    torch_object_ids[id(obj)] = f"{module.__name__}.{name}"
 
     _find_torch_objects(torch)
     _find_torch_objects(math)

--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -71,6 +71,8 @@ def _disallowed_function_ids():
         copy.copy,
         copy.deepcopy,
         inspect.signature,
+        math.__package__,
+        torch.__builtins__,
         torch.autocast_decrement_nesting,
         torch.autocast_increment_nesting,
         torch.autograd.grad,

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -33,6 +33,7 @@ from .symbolic_convert import InstructionTranslator
 from .utils import CleanupManager
 from .utils import counters
 from .utils import is_namedtuple
+from .utils import is_safe_constant
 from .utils import istype
 
 log = logging.getLogger(__name__)
@@ -133,7 +134,9 @@ def has_tensor_in_frame(frame):
     # Check if there is global import of torch.*
     for co_name in frame.f_code.co_names:
         if co_name in frame.f_globals:
-            if is_allowed(frame.f_globals[co_name]):
+            if is_allowed(frame.f_globals[co_name]) and not is_safe_constant(
+                frame.f_globals[co_name]
+            ):
                 return True
 
     seen_ids = dict()

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -33,7 +33,6 @@ from .symbolic_convert import InstructionTranslator
 from .utils import CleanupManager
 from .utils import counters
 from .utils import is_namedtuple
-from .utils import is_safe_constant
 from .utils import istype
 
 log = logging.getLogger(__name__)
@@ -134,9 +133,7 @@ def has_tensor_in_frame(frame):
     # Check if there is global import of torch.*
     for co_name in frame.f_code.co_names:
         if co_name in frame.f_globals:
-            if is_allowed(frame.f_globals[co_name]) and not is_safe_constant(
-                frame.f_globals[co_name]
-            ):
+            if is_allowed(frame.f_globals[co_name]):
                 return True
 
     seen_ids = dict()

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -7,6 +7,7 @@ import re
 import types
 from abc import ABCMeta
 from typing import Any
+from typing import List
 
 import torch
 
@@ -51,6 +52,7 @@ from .misc import LambdaVariable
 from .misc import NumpyVariable
 from .misc import PythonModuleVariable
 from .misc import SkipFilesVariable
+from .misc import TypingVariable
 from .nn_module import UnspecializedNNModuleVariable
 from .tensor import TensorVariable
 from .tensor import TensorWithTFOverrideVariable
@@ -223,6 +225,11 @@ class VariableBuilder:
             )
         elif is_allowed(value):
             return TorchVariable(
+                value,
+                guards=make_guards(GuardBuilder.FUNCTION_MATCH),
+            )
+        elif value is List:
+            return TypingVariable(
                 value,
                 guards=make_guards(GuardBuilder.FUNCTION_MATCH),
             )

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -231,7 +231,7 @@ class VariableBuilder:
         elif value is List:
             return TypingVariable(
                 value,
-                guards=make_guards(GuardBuilder.FUNCTION_MATCH),
+                guards=make_guards(GuardBuilder.ID_MATCH),
             )
         elif value is inspect.signature:
             return LambdaVariable(

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -575,8 +575,6 @@ class TypingVariable(VariableTracker):
             )
         unimplemented("typing")
 
-    pass
-
 
 class NumpyVariable(VariableTracker):
     """

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -568,7 +568,7 @@ class TypingVariable(VariableTracker):
         args: "List[VariableTracker]",
         kwargs: "Dict[str, VariableTracker]",
     ) -> "VariableTracker":
-        if name == "__getitem__":
+        if name == "__getitem__" and len(args) == 1:
             return variables.ConstantVariable(
                 self.value[args[0].as_python_constant()],
                 **VariableTracker.propagate(self, args),

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -556,6 +556,28 @@ class SkipFilesVariable(VariableTracker):
             unimplemented("call_function in skip_files " + path)
 
 
+class TypingVariable(VariableTracker):
+    def __init__(self, value, **kwargs):
+        super().__init__(**kwargs)
+        self.value = value
+
+    def call_method(
+        self,
+        tx,
+        name,
+        args: "List[VariableTracker]",
+        kwargs: "Dict[str, VariableTracker]",
+    ) -> "VariableTracker":
+        if name == "__getitem__":
+            return variables.ConstantVariable(
+                self.value[args[0].as_python_constant()],
+                **VariableTracker.propagate(self, args),
+            )
+        unimplemented("typing")
+
+    pass
+
+
 class NumpyVariable(VariableTracker):
     """
     Wrapper around `numpy.*` for better error messages.


### PR DESCRIPTION
With this a large number of PyTorch tests in `test/distributed/rpc/test_tensorpipe_agent.py` start passing. 

One side effect was filtering `typing` module as well, and this caused unnecessary graph breaks because they are used only for annotating the function args. So, I added a TypingVariable to deal with it.