### PR TITLE
Make TorchInductor use Triton's MM implementation in codegen

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -1146,6 +1146,19 @@ class CommonTemplate:
         y_correct = torch.conv2d(x, w, bias, stride, padding, dilation, groups)
         self.assertTrue(same(y, y_correct, cos_similarity=True, tol=0.1))
 
+    @patch.object(config.triton, "use_mm", True)
+    def test_triton_mm2(self):
+        @torchdynamo.optimize("inductor", nopython=True)
+        def fn(x, y):
+            return torch.mm(x, y)
+
+        N = 1024
+        a = torch.randn([N, N], device=self.device, dtype=torch.float32)
+        b = torch.randn([N, N], device=self.device, dtype=torch.float32)
+        c1 = torch.mm(a, b)
+        c = fn(a, b)
+        assert torch.allclose(c1, c, atol=1e-3, rtol=1e-3)
+
     def test_std(self):
         def fn(x):
             return (

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -73,6 +73,16 @@ class WrapperCodeGen(CodeGen):
                 aten = torch.ops.aten
             """
         )
+
+        if config.triton.use_mm:
+            self.header.splice(
+                """
+                try:
+                    from torchinductor.triton_ops.matmul import matmul_out as triton_mm_out
+                except ImportError:
+                    pass
+                """
+            )
         self.prefix.writelines(
             ["", "", f"def call({', '.join(V.graph.graph_inputs.keys())}):"]
         )

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -61,3 +61,7 @@ class triton:
 
     # use triton.autotune?
     autotune = True
+
+    # enable codegen to use Triton's mm
+    use_mm = False
+

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -64,4 +64,3 @@ class triton:
 
     # enable codegen to use Triton's mm
     use_mm = False
-

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1653,6 +1653,15 @@ class ExternKernelAlloc(ExternKernel):
 class MatrixMultiply(ExternKernelOut):
     kernel = "aten.mm.out"
 
+    def __init__(self, layout, inputs, constant_args=(), output_view=None):
+        super().__init__(layout, inputs, constant_args, output_view)
+        if (
+            config.triton.use_mm
+            and len(inputs) > 0
+            and inputs[0].get_device().type == "cuda"
+        ):
+            self.kernel = "triton_mm_out"
+
     @classmethod
     def create(cls, a, b):
         *m, k1 = a.get_size()

--- a/torchinductor/triton_ops/matmul.py
+++ b/torchinductor/triton_ops/matmul.py
@@ -1,0 +1,228 @@
+import torch
+import triton
+import triton.language as tl
+from triton.ops.matmul import get_configs_io_bound
+from triton.ops.matmul_perf_model import early_config_prune
+from triton.ops.matmul_perf_model import estimate_matmul_time
+
+
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0,
+    }
+)
+@triton.autotune(
+    configs=[
+        # basic configs for compute-bound matmuls
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=5,
+            num_warps=2,
+        ),
+        # good for int8
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=5,
+            num_warps=2,
+        ),
+    ]
+    + get_configs_io_bound(),
+    key=["M", "N", "K"],
+    prune_configs_by={
+        "early_config_prune": early_config_prune,
+        "perf_model": estimate_matmul_time,
+        "top_k": 10,
+    },
+)
+@triton.jit
+def _kernel(
+    A,
+    B,
+    C,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    ACC_TYPE: tl.constexpr,
+):
+    # matrix multiplication
+    pid = tl.program_id(0)
+    pid_z = tl.program_id(1)
+    grid_m = (M + BLOCK_M - 1) // BLOCK_M
+    grid_n = (N + BLOCK_N - 1) // BLOCK_N
+    # re-order program ID for better L2 performance
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // (group_size)
+    # do matrix multiplication
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    rk = pid_z * BLOCK_K + tl.arange(0, BLOCK_K)
+    # pointers
+    A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
+    B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+    for k in range(K, 0, -BLOCK_K * SPLIT_K):
+        if EVEN_K:
+            a = tl.load(A)
+            b = tl.load(B)
+        else:
+            a = tl.load(A, mask=rk[None, :] < k, other=0.0)
+            b = tl.load(B, mask=rk[:, None] < k, other=0.0)
+        acc += tl.dot(a, b, allow_tf32=False)
+        A += BLOCK_K * SPLIT_K * stride_ak
+        B += BLOCK_K * SPLIT_K * stride_bk
+    acc = acc.to(C.dtype.element_ty)
+    # rematerialize rm and rn to save registers
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    C = C + (rm[:, None] * stride_cm + rn[None, :] * stride_cn)
+    mask = (rm < M)[:, None] & (rn < N)[None, :]
+    # handles write-back with reduction-splitting
+    if SPLIT_K == 1:
+        tl.store(C, acc, mask=mask)
+    else:
+        tl.atomic_add(C, acc, mask=mask)
+
+
+def matmul_out(a, b, out):
+    # handle non-contiguous inputs if necessary
+    if a.stride(0) > 1 and a.stride(1) > 1:
+        a = a.contiguous()
+    if b.stride(0) > 1 and b.stride(1) > 1:
+        b = b.contiguous()
+    # checks constraints
+    assert a.shape[1] == b.shape[0], "incompatible dimensions"
+    M, K = a.shape
+    _, N = b.shape
+    # allocates output
+    c = out
+    # accumulator types
+    ACC_TYPE = (
+        tl.float32
+        if a.dtype in [torch.float16, torch.bfloat16, torch.float32]
+        else tl.int32
+    )
+
+    # launch kernel (grid defined as using def instead of lambda to pass `make lint`)
+    def grid(META):
+        return (
+            triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+            META["SPLIT_K"],
+        )
+
+    # grid = lambda META: (
+    #     triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+    #     META["SPLIT_K"],
+    # )
+    _kernel[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        GROUP_M=8,
+        ACC_TYPE=ACC_TYPE,
+    )


### PR DESCRIPTION
The motivation is that torchinductor currently generates a call to `aten.mm.out` for `torch.mm` operations, and we'd like to use Triton's MM implementation in torchinductor's code generation, which makes fusion possible and guarantee the performance of MM in the same time. Our first step is to just make torchinductor generate a call to Triton's mm implementation for `torch.mm`, and make sure this can work. 

The modifications are
- Added a directory called `triton_ops/` in `torchinductor`
- Added Triton's MM implementation in `triton_ops/` and made an "out" version
- Added an option `use_triton_mm` in `torchinductor/config.py`, which defaults to `False`
- Some minor changes to `ir.py` and `wrapper.py` to use triton's mm (out version) function

A simple example to use is like the following:

```python
import torch
import torchdynamo
import torchinductor.config as inductor_config
inductor_config.debug = True
inductor_config.use_triton_mm = True

def toy_example(a, b):
    return torch.mm(a, b)

N = 1024
a = torch.rand([N, N], device='cuda', dtype=torch.float16)
b = torch.rand([N, N], device='cuda', dtype=torch.float16)
c1 = torch.mm(a, b)

with torchdynamo.optimize("inductor"):
    for _ in range(100):
        c = toy_example(a, b)

assert(torch.allclose(c1, c))
```

which generates the following code:

```python
from ctypes import c_void_p, c_long
import torch
from torch import empty_strided, as_strided
from torchinductor.codecache import CppCodeCache, TritonCodeCache, grid
try:
    import triton
    import triton.language as tl
except ImportError:
    pass
aten = torch.ops.aten
from torchinductor.triton_ops.matmul import matmul_out as triton_mm_out


def call(arg0, arg1):
    arg0_size = arg0.size()
    s0 = arg0_size[0]
    buf0 = empty_strided((s0, s0), (s0, 1), device='cuda', dtype=torch.float16)
    triton_mm_out(arg0, arg1, out=buf0)
    return (buf0, )

if __name__ == "__main__":
    from torchdynamo.testing import rand_strided
    from torchinductor.microbench import print_performance
    arg0 = rand_strided((1024, 1024), (1024, 1), device='cuda', dtype=torch.float16)
    arg1 = rand_strided((1024, 1024), (1024, 1), device='cuda', dtype=torch.float16)
    print_performance(lambda: call(arg0, arg1))

```