### PR TITLE
Add _refs and _prims to the allowlist

### DIFF
--- a/tests/test_recompile_ux.py
+++ b/tests/test_recompile_ux.py
@@ -111,7 +111,10 @@ class RecompileUxTests(torchdynamo.testing.TestCase):
 
     def test_verbose_tensor_check(self):
         def func(a):
-            return torch.sum(a)
+            # Warning: choose a function here whose meta implementation lives
+            # entirely in C++.  If you do a Python one, Dynamo will dive into
+            # torch._refs which is OK but it will muddy up the warnings
+            return torch.add(a, 4)
 
         def cache_fail_test(cached_input, missed_input, expected_failure):
             # TODO(whc) maybe its hacky to have a 'test within a test' but this seemed convenient

--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -3,8 +3,12 @@ from os.path import abspath
 from os.path import dirname
 
 import torch
-import torch._refs
-import torch._prims
+try:
+    import torch._refs
+    import torch._prims
+    HAS_REFS_PRIMS = True
+except ImportError:
+    HAS_REFS_PRIMS = False
 
 # print out lots of stuff
 debug = False
@@ -58,9 +62,12 @@ raise_on_backend_error = True
 skipfiles_inline_module_allowlist = {
     torch.nn,
     torch.distributions,
-    torch._refs,
-    torch._prims,
 }
+if HAS_REFS_PRIMS:
+    skipfiles_inline_module_allowlist |= {
+        torch._refs,
+        torch._prims,
+    }
 
 # If a string representing a PyTorch module is in this ignorelist,
 # the `allowed_functions.is_allowed` function will not consider it

--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -3,9 +3,11 @@ from os.path import abspath
 from os.path import dirname
 
 import torch
+
 try:
-    import torch._refs
     import torch._prims
+    import torch._refs
+
     HAS_REFS_PRIMS = True
 except ImportError:
     HAS_REFS_PRIMS = False

--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -3,6 +3,8 @@ from os.path import abspath
 from os.path import dirname
 
 import torch
+import torch._refs
+import torch._prims
 
 # print out lots of stuff
 debug = False
@@ -56,6 +58,8 @@ raise_on_backend_error = True
 skipfiles_inline_module_allowlist = {
     torch.nn,
     torch.distributions,
+    torch._refs,
+    torch._prims,
 }
 
 # If a string representing a PyTorch module is in this ignorelist,
@@ -65,4 +69,6 @@ skipfiles_inline_module_allowlist = {
 allowed_functions_module_string_ignorelist = {
     "torch.distributions",
     "torch.testing",
+    "torch._refs",
+    "torch._prims",
 }

--- a/torchdynamo/skipfiles.py
+++ b/torchdynamo/skipfiles.py
@@ -32,8 +32,9 @@ import _weakrefset
 import torch
 
 try:
-    import torch._refs
     import torch._prims
+    import torch._refs
+
     HAS_PRIMS_REFS = True
 except ImportError:
     HAS_PRIMS_REFS = False

--- a/torchdynamo/skipfiles.py
+++ b/torchdynamo/skipfiles.py
@@ -87,6 +87,12 @@ SKIP_DIRS = [
 ]
 FILENAME_ALLOWLIST = {
     torch.nn.Sequential.__init__.__code__.co_filename,
+    torch._prims.__file__,
+    torch._prims.utils.__file__,
+    torch._prims.wrappers.__file__,
+    torch._refs.__file__,
+    torch._refs.special.__file__,
+    torch._refs.nn.functional.__file__,
 }
 SKIP_DIRS_RE = None
 

--- a/torchdynamo/skipfiles.py
+++ b/torchdynamo/skipfiles.py
@@ -31,6 +31,13 @@ import _collections_abc
 import _weakrefset
 import torch
 
+try:
+    import torch._refs
+    import torch._prims
+    HAS_REFS_PRIMS = True
+except ImportError:
+    HAS_REFS_PRIMS = False
+
 from . import config
 
 
@@ -87,13 +94,16 @@ SKIP_DIRS = [
 ]
 FILENAME_ALLOWLIST = {
     torch.nn.Sequential.__init__.__code__.co_filename,
-    torch._prims.__file__,
-    torch._prims.utils.__file__,
-    torch._prims.wrappers.__file__,
-    torch._refs.__file__,
-    torch._refs.special.__file__,
-    torch._refs.nn.functional.__file__,
 }
+if HAS_PRIMS_REFS:
+    FILENAME_ALLOWLIST |= {
+        torch._prims.__file__,
+        torch._prims.utils.__file__,
+        torch._prims.wrappers.__file__,
+        torch._refs.__file__,
+        torch._refs.special.__file__,
+        torch._refs.nn.functional.__file__,
+    }
 SKIP_DIRS_RE = None
 
 

--- a/torchdynamo/skipfiles.py
+++ b/torchdynamo/skipfiles.py
@@ -34,9 +34,9 @@ import torch
 try:
     import torch._refs
     import torch._prims
-    HAS_REFS_PRIMS = True
+    HAS_PRIMS_REFS = True
 except ImportError:
-    HAS_REFS_PRIMS = False
+    HAS_PRIMS_REFS = False
 
 from . import config
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #345

This won't get exercised by real models but it's necessary so we
can test that PrimTorch decomps work under dynamo.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>