### PR TITLE
codegen to update mutated variables with side effect should after stack value's codegen

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1571,3 +1571,35 @@ class MiscTests(torchdynamo.testing.TestCase):
                 fn(x, np.int64(i))
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 2)
+
+    def test_side_effects_codegen_update_mutated(self):
+        # codegen to update mutated variables with side effect
+        # should after stack value's codegen
+        def f1(x):
+            alist = [x]
+            alist.append(x + 1)
+            alist[0].sum().item()  # graph break
+            res = alist.pop()
+            res.sum().item()  # graph break
+            return res
+
+        def f2(a, b):
+            d = {"a": a + 1, "b": b + 2}
+            x = d.pop("b")
+            x.sum().item()  # graph break
+            y = d["a"] + x
+            y.sum().item()  # graph break
+            d["c"] = y
+            return d
+
+        x = torch.rand([2, 3])
+        a = torch.rand([5, 6])
+        b = torch.rand([5, 6])
+        res11 = f1(x)
+        res21 = f2(a, b)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res12 = f1(x)
+            res22 = f2(a, b)
+        self.assertTrue(same(res11, res12))
+        self.assertTrue(same(res21, res22))

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -247,8 +247,9 @@ class OutputGraph(fx.Tracer):
         else:
             graph_output_var = self.new_var("graph_out")
             pass1 = PyCodegen(tx, root, graph_output_var)
-            self.side_effects.codegen(pass1)
+            self.side_effects.codegen_save_tempvars(pass1)
             pass1.foreach(stack_values)
+            self.side_effects.codegen_update_mutated(pass1)
 
             # one more time now that we have established tempvars
             pass2 = PyCodegen(
@@ -257,8 +258,9 @@ class OutputGraph(fx.Tracer):
                 graph_output_var,
                 tempvars={val: None for val, count in pass1.uses.items() if count > 1},
             )
-            self.side_effects.codegen(pass2)
+            self.side_effects.codegen_save_tempvars(pass2)
             pass2.foreach(stack_values)
+            self.side_effects.codegen_update_mutated(pass2)
 
             output = []
             if count_calls(self.graph) != 0 or len(pass2.graph_outputs) != 0:


### PR DESCRIPTION
See context at https://github.com/pytorch/torchdynamo/issues/329.

As ```pass2.foreach(stack_values)``` reconstructs stack values which may depends on source, ```self.side_effects.codegen(pass2)``` updates variables which has side effect. However, the variable updated in side effect may be the source of the stack values, so we should update side effect variables after generating stack values. 

Fix https://github.com/pytorch/torchdynamo/issues/329