### PR TITLE
Only wrap in TorchVariable if is allowed, not if not disallowed

### DIFF
--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -13,7 +13,7 @@ from torchdynamo.variables.tensor import DynamicShapeVariable
 
 from .. import config
 from .. import variables
-from ..allowed_functions import is_disallowed
+from ..allowed_functions import is_allowed
 from ..exc import Unsupported
 from ..exc import unimplemented
 from ..source import AttrSource
@@ -480,7 +480,7 @@ class BuiltinVariable(VariableTracker):
                 return GetAttrVariable(obj, name, **options)
         elif isinstance(obj, TorchVariable):
             member = getattr(obj.value, name)
-            if not is_disallowed(member):
+            if is_allowed(member):
                 return TorchVariable(member, **options)
             elif ConstantVariable.is_literal(member):
                 return ConstantVariable(member, **options)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

If you don't do this, allowed_functions_module_string_ignorelist
doesn't actually affect if we try to trace these functions into
the graph, since the disallowed list doesn't actually respect
this config.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>