### PR TITLE
Disabling TorchDynamo inside torch.jit and torch.onnx compiler

### DIFF
--- a/torchdynamo/allowed_functions.py
+++ b/torchdynamo/allowed_functions.py
@@ -100,7 +100,6 @@ def _allowed_function_ids():
     Walk torch.* and get the ids of all the stuff in it
     """
     warnings.filterwarnings("ignore", category=UserWarning, module="torch.distributed")
-    torch.distributions.Distribution.set_default_validate_args(False)
     torch_object_ids = dict()
 
     def _is_allowed_module_prefix(obj):

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -45,13 +45,20 @@ compile_lock = threading.Lock()
 
 
 class _TorchDynamoContext:
-    def __init__(self, callback, on_enter=nothing, backend_ctx_ctor=null_context):
+    def __init__(
+        self,
+        callback,
+        on_enter=nothing,
+        backend_ctx_ctor=null_context,
+        patch_fn=nothing,
+    ):
         super().__init__()
         assert callable(callback) or callback is False or callback is None
         self.callback = callback
         self.prior = unset
         self.on_enter = on_enter
         self.extra_ctx_ctor = backend_ctx_ctor
+        patch_fn()
 
     def __enter__(self):
         self.on_enter()
@@ -102,6 +109,7 @@ class OptimizeContext(_TorchDynamoContext):
             callback=callback,
             on_enter=install_generation_tagging_init,
             backend_ctx_ctor=backend_ctx_ctor,
+            patch_fn=patch_torch,
         )
 
 
@@ -261,3 +269,14 @@ def skip(fn=None):
     skip_code(fn.__code__)
     fn._torchdynamo_disable = True
     return fn
+
+
+@functools.lru_cache(None)
+def patch_torch():
+    # Disable TorchDynamo on some torch.* compilers generated frames
+    torch.jit.trace = disable(torch.jit.trace)
+    torch.jit.trace_module = disable(torch.jit.trace_module)
+    torch.jit._get_trace_graph = disable(torch.jit._get_trace_graph)
+
+    torch.onnx.export_to_pretty_string = disable(torch.onnx.export_to_pretty_string)
+    torch.distributions.Distribution.set_default_validate_args(False)

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -28,15 +28,6 @@ _NP_DTYPE = {
     torch.bool: np.bool_,
 }
 
-# Disable TorchDynamo on some torch.* compilers generated frames
-torch.jit.trace = torchdynamo.disable(torch.jit.trace)
-torch.jit.trace_module = torchdynamo.disable(torch.jit.trace_module)
-torch.jit._get_trace_graph = torchdynamo.disable(torch.jit._get_trace_graph)
-
-torch.onnx.export_to_pretty_string = torchdynamo.disable(
-    torch.onnx.export_to_pretty_string
-)
-
 
 def create_backend(fn):
     @functools.wraps(fn)

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -14,6 +14,9 @@ import torchdynamo.convert_frame
 from torchdynamo.optimizations.subgraph import SubGraph
 from torchdynamo.utils import identity
 
+torch.jit.script = torchdynamo.disable(torch.jit.script)
+torch.jit.trace = torchdynamo.disable(torch.jit.trace)
+
 log = logging.getLogger(__name__)
 BACKENDS = dict()
 _NP_DTYPE = {

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -14,9 +14,6 @@ import torchdynamo.convert_frame
 from torchdynamo.optimizations.subgraph import SubGraph
 from torchdynamo.utils import identity
 
-torch.jit.trace = torchdynamo.disable(torch.jit.trace)
-torch.jit.trace_module = torchdynamo.disable(torch.jit.trace_module)
-
 log = logging.getLogger(__name__)
 BACKENDS = dict()
 _NP_DTYPE = {
@@ -30,6 +27,15 @@ _NP_DTYPE = {
     torch.int64: np.longlong,
     torch.bool: np.bool_,
 }
+
+# Disable TorchDynamo on some torch.* compilers generated frames
+torch.jit.trace = torchdynamo.disable(torch.jit.trace)
+torch.jit.trace_module = torchdynamo.disable(torch.jit.trace_module)
+torch.jit._get_trace_graph = torchdynamo.disable(torch.jit._get_trace_graph)
+
+torch.onnx.export_to_pretty_string = torchdynamo.disable(
+    torch.onnx.export_to_pretty_string
+)
 
 
 def create_backend(fn):

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -14,7 +14,6 @@ import torchdynamo.convert_frame
 from torchdynamo.optimizations.subgraph import SubGraph
 from torchdynamo.utils import identity
 
-torch.jit.script = torchdynamo.disable(torch.jit.script)
 torch.jit.trace = torchdynamo.disable(torch.jit.trace)
 torch.jit.trace_module = torchdynamo.disable(torch.jit.trace_module)
 

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -16,6 +16,7 @@ from torchdynamo.utils import identity
 
 torch.jit.script = torchdynamo.disable(torch.jit.script)
 torch.jit.trace = torchdynamo.disable(torch.jit.trace)
+torch.jit.trace_module = torchdynamo.disable(torch.jit.trace_module)
 
 log = logging.getLogger(__name__)
 BACKENDS = dict()


### PR DESCRIPTION

* Helps with many PyTorch JIT tests.  Only 7 test/jit/* failures now. 
* All 136 failures with test/onnx/* are resolved.