### PR TITLE
autotune conv kernels

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -1146,6 +1146,7 @@ class CommonTemplate:
 
     @requires_cuda()
     @patch.object(config.triton, "use_conv", False)
+    @patch.object(config, "autotune", True)
     def test_conv_autotune(self):
         @torchdynamo.optimize("inductor", nopython=True)
         def triton_conv(

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -1119,7 +1119,7 @@ class CommonTemplate:
         self.assertEqual(c.stride()[2], 1)
 
     @requires_cuda()
-    @patch.object(config.triton, "use_conv", True)
+    @patch.object(config.triton, "convolution", "triton")
     def test_triton_conv(self):
         @torchdynamo.optimize("inductor", nopython=True)
         def triton_conv(
@@ -1145,8 +1145,7 @@ class CommonTemplate:
         self.assertTrue(same(y, y_correct, cos_similarity=True, tol=0.1))
 
     @requires_cuda()
-    @patch.object(config.triton, "use_conv", False)
-    @patch.object(config, "autotune", True)
+    @patch.object(config.triton, "convolution", "autotune")
     def test_conv_autotune(self):
         @torchdynamo.optimize("inductor", nopython=True)
         def triton_conv(

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -1144,6 +1144,32 @@ class CommonTemplate:
         y_correct = torch.conv2d(x, w, bias, stride, padding, dilation, groups)
         self.assertTrue(same(y, y_correct, cos_similarity=True, tol=0.1))
 
+    @requires_cuda()
+    @patch.object(config.triton, "use_conv", False)
+    def test_conv_autotune(self):
+        @torchdynamo.optimize("inductor", nopython=True)
+        def triton_conv(
+            x,
+            w,
+            bias,
+            stride,
+            padding,
+            dilation,
+            groups,
+        ):
+            y = torch.conv2d(x, w, bias, stride, padding, dilation, groups)
+            return y
+
+        stride, padding, dilation, groups = (1, 1), (0, 0), (1, 1), 1
+        dtype = torch.float32
+        x = torch.randn((32, 128, 32, 32), dtype=dtype, device=self.device)
+        w = torch.randn((32, 128, 1, 1), dtype=dtype, device=self.device)
+        bias = torch.randn((32), dtype=dtype, device=self.device)
+
+        y = triton_conv(x, w, bias, stride, padding, dilation, groups)
+        y_correct = torch.conv2d(x, w, bias, stride, padding, dilation, groups)
+        self.assertTrue(same(y, y_correct, cos_similarity=True, tol=0.1))
+
     def test_std(self):
         def fn(x):
             return (

--- a/torchinductor/codegen/autotuner.py
+++ b/torchinductor/codegen/autotuner.py
@@ -157,6 +157,9 @@ def tuned_conv(*args, **kwargs):
         # bench_end = time.time()
         # bench_time = bench_end - bench_start
         autotune.cache[key] = builtins.min(timings, key=timings.get)
+        if torchinductor.config.debug:
+            print("for key = ", key)
+            print("best_kernel", autotune.cache[key])
         # kernels_timings = timings
     best_kernel_name = autotune.cache[key]
     best_kernel = kernel_dict[best_kernel_name]

--- a/torchinductor/codegen/autotuner.py
+++ b/torchinductor/codegen/autotuner.py
@@ -9,94 +9,28 @@ import torchinductor.triton_ops
 aten = torch.ops.aten
 triton_ops = torchinductor.triton_ops
 
-# Instatiatie Autotuner class object -- init the cache, and sort of global
-
-# Autotuning an op
-#   1) Register that Node in the codegen of ExternKernelOP
-#   2) Autotuner
-#   1) register that IRNode "ExternKerneNode" in Autotuner - autotune()
-#
-# def autotune():
-#     """
-#     Decorator for auto-tuning a function.
-
-#     .. highlight:: python
-#     .. code-block:: python
-
-#         @triton.autotune()
-#         wrap_conv(x, w, bias, stride, ...)
-
-#     :note: For the wrap function, the candidate kernels will run multiple time.
-#     """
-#     def inner(fn):
-#         autotuner = Autotuner(fn)
-#         return autotuner
-
-#     return inner
-
 
 class Autotuner:
     def __init__(self):
 
         self.cache = dict()
 
-    def _bench(self, *args, kernel, **kwargs):
+    def _bench(self, kernel, *args, **kwargs):
         def kernel_call():
             kernel(*args, **kwargs)
 
         return triton.testing.do_bench(kernel_call, warmup=10, rep=50)
 
-    # def __call__(self, *args, **kwargs):
-    #     # collect input shape/stride/device, layer params
-    #     self.fn.set_args(*args, **kwargs)
-    #     # get candidate kernels for fn
-    #     self.kernels = self.fn.candidate_kernels()
-    #     # filter kernels that args/kwargs does not meet requirements
-    #     self.fn.filter_kernels(self.kernels)
-    #     # if only one choice, return that kernel
-    #     if len(self.kernels) == 1:
-    #         kernel = self.kernels[0]
-    #         return kernel(*args, **kwargs)
-    #     # use input shape, stride, layer parameters as key to cache the best kernel to use
-    #     key = self.fn.gen_key()
-    #     if key not in self.cache:
-    #         bench_start = time.time()
-    #         timings = {
-    #             kernel: self._bench(*args, kernel=kernel, **kwargs) for kernel in self.kernels
-    #         }
-    #         bench_end = time.time()
-    #         self.bench_time = bench_end - bench_start
-    #         self.cache[key] = builtins.min(timings, key=timings.get)
-    #         self.kernels_timings = timings
-    #         kernel = self.cache[key]
-    #     self.best_kernel = kernel
-    #     return self.best_kernel(*args, **kwargs)
-
 
 autotune = Autotuner()
 
 
-def tuned_conv(*args, **kwargs):
-
-    # gather info
-    x = args[0]
-    w = args[1]
-    # bias = args[2]
-    stride = args[3]
-    padding = args[4]
-    dilation = args[5]
-    transposed = args[6]
-    output_padding = args[7]
-    groups = args[8]
+def tuned_conv(
+    x, w, bias, stride, padding, dilation, transposed, output_padding, groups
+):
 
     BATCH, IN_C, IN_H, IN_W = x.shape
     KERNEL_N, _, KERNEL_H, KERNEL_W = w.shape
-    stride = stride
-    padding = padding
-    dilation = dilation
-    transposed = transposed
-    output_padding = output_padding
-    groups = groups
     stride_x = x.stride()
     stride_w = w.stride()
     # the identifiable args for the layers
@@ -124,34 +58,40 @@ def tuned_conv(*args, **kwargs):
     key = ("conv",) + key
 
     # candidate kernels
-    kernels = ["aten.convolution"]
+    kernels = [aten.convolution]
     if use_cuda:
-        kernels += ["triton_ops.conv", "triton_ops.conv1x1"]
+        kernels += [triton_ops.conv, triton_ops.conv1x1]
 
     # filter kernels that args/kwargs does not meet requirements
     remove_kernels = []
     if groups > 1 or transposed:
-        remove_kernels += ["triton_ops.conv", "triton_ops.conv1x1"]
+        remove_kernels += [triton_ops.conv, triton_ops.conv1x1]
     # triton_ops.conv1x1 could only deal with nhwc 1x1 kernel
-    if stride_x[1] > 1 or KERNEL_H > 1 or KERNEL_W > 1:
-        remove_kernels += ["triton_ops.conv1x1"]
+    if KERNEL_H > 1 or KERNEL_W > 1:
+        remove_kernels += [triton_ops.conv1x1]
     kernels = [k for k in kernels if k not in remove_kernels]
-
-    # str to callable functions
-    kernel_dict = {
-        "aten.convolution": aten.convolution,
-        "triton_ops.conv": triton_ops.conv,
-        "triton_ops.conv1x1": triton_ops.conv1x1,
-    }
 
     # if only one choice, return that kernel
     if len(kernels) == 1:
-        kernel = kernel_dict[kernels[0]]
-        return kernel(*args, **kwargs)
+        kernel = kernels[0]
+        return kernel(
+            x, w, bias, stride, padding, dilation, transposed, output_padding, groups
+        )
     if key not in autotune.cache:
         # bench_start = time.time()
         timings = {
-            kernel: autotune._bench(*args, kernel=kernel_dict[kernel], **kwargs)
+            kernel: autotune._bench(
+                kernel,
+                x,
+                w,
+                bias,
+                stride,
+                padding,
+                dilation,
+                transposed,
+                output_padding,
+                groups,
+            )
             for kernel in kernels
         }
         # bench_end = time.time()
@@ -159,8 +99,9 @@ def tuned_conv(*args, **kwargs):
         autotune.cache[key] = builtins.min(timings, key=timings.get)
         if torchinductor.config.debug:
             print("for key = ", key)
+            print("timing", timings)
             print("best_kernel", autotune.cache[key])
-        # kernels_timings = timings
-    best_kernel_name = autotune.cache[key]
-    best_kernel = kernel_dict[best_kernel_name]
-    return best_kernel(*args, **kwargs)
+    best_kernel = autotune.cache[key]
+    return best_kernel(
+        x, w, bias, stride, padding, dilation, transposed, output_padding, groups
+    )

--- a/torchinductor/codegen/autotuner.py
+++ b/torchinductor/codegen/autotuner.py
@@ -1,0 +1,158 @@
+import builtins
+import time
+import triton
+import torch
+import torchinductor
+
+aten = torch.ops.aten
+triton_ops = torchinductor.triton_ops
+
+# Instatiatie Autotuner class object -- init the cache, and sort of global
+
+# Autotuning an op
+#   1) Register that Node in the codegen of ExternKernelOP
+#   2) Autotuner
+#   1) register that IRNode "ExternKerneNode" in Autotuner - autotune()
+#   
+# def autotune():
+#     """
+#     Decorator for auto-tuning a function.
+
+#     .. highlight:: python
+#     .. code-block:: python
+
+#         @triton.autotune()
+#         wrap_conv(x, w, bias, stride, ...)
+
+#     :note: For the wrap function, the candidate kernels will run multiple time.
+#     """
+#     def inner(fn):
+#         autotuner = Autotuner(fn)
+#         return autotuner
+
+#     return inner
+
+
+class Autotuner:
+    def __init__(self):
+
+        self.cache = dict()
+
+    def _bench(self, *args, kernel, **kwargs):
+
+        def kernel_call():
+            kernel(*args, **kwargs)
+
+        return triton.testing.do_bench(kernel_call, warmup=10, rep=50)
+
+    def register_node(self, op_name, *args, **kwargs):
+        # op_name = conv
+        # args
+        self.op += [op_name]
+
+    def __call__(self, *args, **kwargs):
+        # collect input shape/stride/device, layer params
+        self.fn.set_args(*args, **kwargs)
+        # get candidate kernels for fn
+        self.kernels = self.fn.candidate_kernels()
+        # filter kernels that args/kwargs does not meet requirements
+        self.fn.filter_kernels(self.kernels)
+        # if only one choice, return that kernel
+        if len(self.kernels) == 1:
+            kernel = self.kernels[0]
+            return kernel(*args, **kwargs)
+        # use input shape, stride, layer parameters as key to cache the best kernel to use
+        key = self.fn.gen_key()
+        if key not in self.cache:
+            bench_start = time.time()
+            timings = {
+                kernel: self._bench(*args, kernel=kernel, **kwargs) for kernel in self.kernels
+            }
+            bench_end = time.time()
+            self.bench_time = bench_end - bench_start
+            self.cache[key] = builtins.min(timings, key=timings.get)
+            self.kernels_timings = timings
+            kernel = self.cache[key]
+        self.best_kernel = kernel
+        return self.best_kernel(*args, **kwargs)
+
+
+autotune = Autotuner()
+
+
+def tuned_conv(*args, **kwargs):
+
+    # gather info
+    x = args[0]
+    w = args[1]
+    # bias = args[2]
+    stride = args[3]
+    padding = args[4]
+    dilation = args[5]
+    transposed = args[6]
+    output_padding = args[7]
+    groups = args[8]
+
+    BATCH, IN_C, IN_H, IN_W = x.shape
+    KERNEL_N, _, KERNEL_H, KERNEL_W = w.shape
+    stride = stride
+    padding = padding
+    dilation = dilation
+    transposed = transposed
+    output_padding = output_padding
+    groups = groups
+    stride_x = x.stride()
+    stride_w = w.stride()
+    # the identifiable args for the layers
+    id_args = [
+        BATCH, IN_C, IN_H, IN_W,
+        KERNEL_N, KERNEL_H, KERNEL_W,
+        stride, padding, dilation,
+        transposed, output_padding, groups,
+        stride_x, stride_w,
+    ]
+    use_cuda = x.is_cuda
+
+    # gen_key
+    key = tuple([arg for arg in id_args])
+    key = ("conv", ) + key
+
+    # candidate kernels
+    kernels = ["aten.convolution"]
+    if use_cuda:
+        kernels += ["triton_ops.conv", "triton_ops.conv1x1"]
+
+    # filter kernels that args/kwargs does not meet requirements
+    remove_kernels = []
+    if groups > 1 or transposed:
+        remove_kernels += ["triton_ops.conv", "triton_ops.conv1x1"]
+    # triton_ops.conv1x1 could only deal with nhwc 1x1 kernel
+    if stride_x[1] > 1 or KERNEL_H > 1 or KERNEL_W > 1:
+        remove_kernels += ["triton_ops.conv1x1"]
+    kernels = [k for k in kernels if k not in remove_kernels]
+
+    # str to callable functions
+    kernel_dict = {
+        "aten.convolution": aten.convolution,
+        "triton_ops.conv": triton_ops.conv,
+        "triton_ops.conv1x1": triton_ops.conv1x1,
+    }
+
+    # if only one choice, return that kernel
+    if len(kernels) == 1:
+        kernel = kernels[0]
+        return kernel(*args, **kwargs)
+    if key not in autotune.cache:
+        bench_start = time.time()
+        timings = {
+            kernel: autotune._bench(*args, kernel=kernel_dict[kernel], **kwargs) for kernel in kernels
+        }
+        print("timings", timings)
+        bench_end = time.time()
+        # bench_time = bench_end - bench_start
+        autotune.cache[key] = builtins.min(timings, key=timings.get)
+        # kernels_timings = timings
+    kernel = autotune.cache[key]
+    print("best kernel", kernel)
+    best_kernel = kernel_dict[kernel]
+    return best_kernel(*args, **kwargs)

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -28,9 +28,6 @@ inplace_buffers = False
 # codegen benchmark harness
 benchmark_harness = True
 
-# autotune kernels
-autotune = False
-
 
 # config specific to codegen/cpp.pp
 class cpp:
@@ -50,8 +47,8 @@ class triton:
     # Monkey patching to lower overheads
     hackery = False
 
-    # use triton conv as backend
-    use_conv = False
+    # choose conv backend, "aten" or "triton" or "autotune"
+    convolution = "aten"
 
     # Always load full blocks (rather than broadcasting inside the block)
     dense_indexing = False

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -28,6 +28,9 @@ inplace_buffers = False
 # codegen benchmark harness
 benchmark_harness = True
 
+# autotune kernels
+autotune = False
+
 
 # config specific to codegen/cpp.pp
 class cpp:

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1902,22 +1902,13 @@ class MultiOutput(ExternKernel):
 
 
 class Convolution(ExternKernelAlloc):
-    kernel = "aten.convolution"
-
-    def __init__(self, layout, inputs, constant_args=()):
-        if (
-            config.triton.use_conv
-            and len(inputs) > 0
-            and inputs[0].get_device().type == "cuda"
-        ):
-            self.kernel = "triton_ops_conv"
-        elif (
-            config.autotune
-            and len(inputs) > 0
-            and inputs[0].get_device().type == "cuda"
-        ):
-            self.kernel = "tuned_conv"
-        super().__init__(layout, self.unwrap_storage(inputs), constant_args)
+    config_conv = config.triton.convolution
+    if config_conv == "aten":
+        kernel = "aten.convolution"
+    elif config_conv == "triton":
+        kernel = "triton_ops_conv"
+    else:
+        kernel = "tuned_conv"
 
     def codegen(self, wrapper):
         if self.kernel == "triton_ops_conv":

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1934,14 +1934,17 @@ class Convolution(ExternKernelAlloc):
     elif config_conv == "triton":
         kernel = "triton_ops_conv"
     else:
+        assert config_conv == "autotune"
         kernel = "tuned_conv"
 
     def codegen(self, wrapper):
         if self.kernel == "triton_ops_conv":
-            wrapper.writeline(f"import torchinductor.triton_ops.conv as {self.kernel}")
+            wrapper.header.writeline(
+                f"import torchinductor.triton_ops.conv as {self.kernel}"
+            )
         # choose from different conv kernels
         elif self.kernel == "tuned_conv":
-            wrapper.writeline(
+            wrapper.header.writeline(
                 f"from torchinductor.codegen.autotuner import {self.kernel}"
             )
         wrapper.writeline(

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1902,7 +1902,8 @@ class MultiOutput(ExternKernel):
 
 
 class Convolution(ExternKernelAlloc):
-    kernel = "aten.convolution"
+    # kernel = "aten.convolution"
+    kernel = "tuned_conv"
 
     def __init__(self, layout, inputs, constant_args=()):
         if (
@@ -1916,6 +1917,11 @@ class Convolution(ExternKernelAlloc):
     def codegen(self, wrapper):
         if self.kernel == "triton_ops_conv":
             wrapper.writeline(f"import torchinductor.triton_ops.conv as {self.kernel}")
+        # choose from different conv kernels
+        else:
+            wrapper.writeline(
+                f"from torchinductor.codegen.autotuner import {self.kernel}"
+            )
         wrapper.writeline(
             f"{self.get_name()} = {self.kernel}({', '.join(self.codegen_args())})"
         )

--- a/torchinductor/triton_ops/bench/bench_autotune_conv.py
+++ b/torchinductor/triton_ops/bench/bench_autotune_conv.py
@@ -59,8 +59,8 @@ def bench_op(
         fn = lambda: torch.conv2d(x, w, bias, stride, padding, dilation, groups)
     if provider == "autotune":
         @torchdynamo.optimize("inductor")
-        def wrap_conv(x, w, bias, stride, padding, dilation, groups):
-            return torch.conv2d(x, w, bias, stride, padding, dilation, groups)
+        def wrap_conv(*args, **kwargs):
+            return torch.conv2d(*args, **kwargs)
 
         fn = lambda: wrap_conv(x, w, bias, stride, padding, dilation, groups)
 

--- a/torchinductor/triton_ops/bench/bench_autotune_conv.py
+++ b/torchinductor/triton_ops/bench/bench_autotune_conv.py
@@ -3,7 +3,7 @@ import triton
 
 import torchdynamo
 import model
-import torchdynamo.config as config
+import torchinductor.config as config
 
 # enable autotune conv kernels
 config.autotune = True

--- a/torchinductor/triton_ops/bench/bench_autotune_conv.py
+++ b/torchinductor/triton_ops/bench/bench_autotune_conv.py
@@ -1,0 +1,71 @@
+import torch
+import triton
+
+import torchdynamo
+import model
+import torchdynamo.config as config
+
+# enable autotune conv kernels
+config.autotune = True
+# The flag below controls whether to allow TF32 on matmul. This flag defaults to True.
+torch.backends.cuda.matmul.allow_tf32 = True
+# The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
+torch.backends.cudnn.allow_tf32 = True
+
+
+# conv benchmarks
+conv_confs = [
+    triton.testing.Benchmark(
+        x_names=["layout"],
+        x_vals=["nchw", "nhwc"],
+        line_arg="provider",
+        line_vals=["cublas", "autotune"],
+        line_names=["cuBLAS", "autotune"],
+        ylabel="TFLOPS",
+        plot_name=f"resnet50-conv{i}-perf",
+        args={"BATCH": BATCH, "IN_H": IN_H, "IN_W": IN_W, "IN_C": IN_C, "KERNEL_N": KERNEL_N,
+              "KERNEL_H": KERNEL_H, "KERNEL_W": KERNEL_W, "stride": stride, "padding": padding},
+    ) for i, (IN_H, IN_W, IN_C, KERNEL_H, KERNEL_W, KERNEL_N, stride, padding) in enumerate(model.resnet50_layers)
+    for BATCH in [32]
+]
+
+
+@triton.testing.perf_report(conv_confs)
+def bench_op(
+        # Tensor dimensions
+        BATCH, IN_C, IN_H, IN_W,
+        KERNEL_N, KERNEL_H, KERNEL_W,
+        # provider
+        provider,
+        # parameters of conv
+        stride=(1, 1), padding=(0, 0),
+        dilation=(1, 1), groups=1,
+        dtype=torch.float32, layout="nhwc",
+        warmup=25, rep=75):
+
+    # allocate inputs, nchw
+    x = torch.randn((BATCH, IN_C, IN_H, IN_W), dtype=dtype, device='cuda')
+    w = torch.randn((KERNEL_N, IN_C // groups, KERNEL_H, KERNEL_W),
+                    dtype=dtype, device='cuda')
+    bias = torch.randn((KERNEL_N), dtype=dtype, device='cuda')
+    if layout == "nhwc":
+        x = x.to(memory_format=torch.channels_last)
+        w = w.to(memory_format=torch.channels_last)
+    OUT_H = (IN_H + 2 * padding[0] - dilation[0] * (KERNEL_H - 1) - 1 + stride[0]) // stride[0]
+    OUT_W = (IN_W + 2 * padding[1] - dilation[1] * (KERNEL_W - 1) - 1 + stride[1]) // stride[1]
+
+    tflops = lambda ms: 2. * BATCH * OUT_H * OUT_W * IN_C * KERNEL_H * KERNEL_W * KERNEL_N / ms * 1e-9
+    if provider == "cublas":
+        fn = lambda: torch.conv2d(x, w, bias, stride, padding, dilation, groups)
+    if provider == "autotune":
+        @torchdynamo.optimize("inductor")
+        def wrap_conv(x, w, bias, stride, padding, dilation, groups):
+            return torch.conv2d(x, w, bias, stride, padding, dilation, groups)
+
+        fn = lambda: wrap_conv(x, w, bias, stride, padding, dilation, groups)
+
+    ms, min_ms, max_ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    return tflops(ms), tflops(max_ms), tflops(min_ms)
+
+
+bench_op.run(print_data=True)

--- a/torchinductor/triton_ops/bench/bench_autotune_conv.py
+++ b/torchinductor/triton_ops/bench/bench_autotune_conv.py
@@ -1,16 +1,18 @@
 import torch
 import triton
+import model
 
 import torchdynamo
-import model
+import torchinductor
+import torchinductor.triton_ops
 import torchinductor.config as config
 
-# enable autotune conv kernels
-config.autotune = True
 # The flag below controls whether to allow TF32 on matmul. This flag defaults to True.
 torch.backends.cuda.matmul.allow_tf32 = True
 # The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
 torch.backends.cudnn.allow_tf32 = True
+# config.debug = True
+config.triton.convolution = "autotune"
 
 
 # conv benchmarks
@@ -19,8 +21,8 @@ conv_confs = [
         x_names=["layout"],
         x_vals=["nchw", "nhwc"],
         line_arg="provider",
-        line_vals=["cublas", "autotune"],
-        line_names=["cuBLAS", "autotune"],
+        line_vals=["aten", "autotune", "triton_conv", "triton_conv1x1"],
+        line_names=["aten", "autotune", "triton_conv", "triton_conv1x1"],
         ylabel="TFLOPS",
         plot_name=f"resnet50-conv{i}-perf",
         args={"BATCH": BATCH, "IN_H": IN_H, "IN_W": IN_W, "IN_C": IN_C, "KERNEL_N": KERNEL_N,
@@ -43,6 +45,7 @@ def bench_op(
         dtype=torch.float32, layout="nhwc",
         warmup=25, rep=75):
 
+    skip = False
     # allocate inputs, nchw
     x = torch.randn((BATCH, IN_C, IN_H, IN_W), dtype=dtype, device='cuda')
     w = torch.randn((KERNEL_N, IN_C // groups, KERNEL_H, KERNEL_W),
@@ -55,17 +58,60 @@ def bench_op(
     OUT_W = (IN_W + 2 * padding[1] - dilation[1] * (KERNEL_W - 1) - 1 + stride[1]) // stride[1]
 
     tflops = lambda ms: 2. * BATCH * OUT_H * OUT_W * IN_C * KERNEL_H * KERNEL_W * KERNEL_N / ms * 1e-9
-    if provider == "cublas":
+    if provider == "aten":
         fn = lambda: torch.conv2d(x, w, bias, stride, padding, dilation, groups)
-    if provider == "autotune":
+    
+    if provider == "triton_conv":
+
+        fn = lambda: torchinductor.triton_ops.conv(
+            x, w, bias, stride, padding, dilation, False, (0, 0), groups
+        )
+    if provider == "triton_conv1x1":
+
+        fn = lambda: torchinductor.triton_ops.conv1x1(
+            x, w, bias, stride, padding, dilation, False, (0, 0), groups
+        )
+        if KERNEL_H != 1 or KERNEL_W != 1:
+            skip = True
+
+    elif provider == "autotune":
         @torchdynamo.optimize("inductor")
         def wrap_conv(*args, **kwargs):
             return torch.conv2d(*args, **kwargs)
 
         fn = lambda: wrap_conv(x, w, bias, stride, padding, dilation, groups)
 
-    ms, min_ms, max_ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
-    return tflops(ms), tflops(max_ms), tflops(min_ms)
+    # use cuda graph for fair comparison
+    if provider != "autotune" and not skip:
+        # prepare new tensor
+        new_x = x.clone()
+        new_w = w.clone()
+        new_bias = bias.clone()
+
+        # warmp up for cudagraph
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for i in range(3):
+                tmp = fn()
+        torch.cuda.current_stream().wait_stream(s)
+
+        # capture
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            tmp = fn()
+
+        def fn():
+            x.copy_(new_x)
+            w.copy_(new_w)
+            bias.copy_(new_bias)
+            return g.replay()
+
+    if not skip:
+        ms, min_ms, max_ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+        return tflops(ms), tflops(max_ms), tflops(min_ms)
+    else:
+        return 0, 0, 0
 
 
 bench_op.run(print_data=True)

--- a/torchinductor/triton_ops/conv1x1.py
+++ b/torchinductor/triton_ops/conv1x1.py
@@ -80,6 +80,7 @@ class _conv1x1:
         OUT_W = shape_y[yw]
 
         assert KERNEL_H == 1 and KERNEL_W == 1, "only support 1x1 conv"
+        channels_last = x.stride()[1] == 1
 
         if padding == (0, 0):
             # nchw -> nhwc
@@ -100,6 +101,8 @@ class _conv1x1:
             # convert back to the original layout of y
             # nhwc -> nchw
             y = y.permute(0, 3, 1, 2)
+            if not channels_last:
+                y = y.to(memory_format=torch.contiguous_format)
             return y
 
         else:
@@ -108,6 +111,8 @@ class _conv1x1:
                 device=device,
                 dtype=x.dtype,
             )
+            if channels_last:
+                y = y.to(memory_format=torch.channels_last)
             # y = bias.repeat((shape_y[yn], shape_y[yh], shape_y[yw], 1)).to(device).type(x.dtype)
             # convert x to channel-last layout;
             # don't care w layout since kernel size is 1


### PR DESCRIPTION
In torchinductor/ir.py, code_gen() generate `tuned_conv` which will choose candidate kernels(aten.convolution, triton_ops.conv, triton_ops.conv1x1) according to benchmarking results. Store best kernels in global cache with key as ("conv", layer params, input strides, etc.) to avoid re-benchmarking next time.
Benchmark:
`torchinductor/triton_ops/bench/bench_autotune_conv.py`
Test:
`pytest tests/test_torchinductor.py::GpuTests::test_conv_autotune_cuda`

Currently, the tuned_conv overhead is noticeable. Any idea how to reduce the overhead?
And any suggestions for better code style for Autotuner or tuned_conv to make it more generalizable?