### PR TITLE
Print value of TorchVariable object

### DIFF
--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -51,6 +51,9 @@ class TorchVariable(VariableTracker):
         else:
             assert False, f"{value} found with __self__ set"
 
+    def __repr__(self):
+        return f"TorchVariable({self.value})"
+
     def unique_var_name(self):
         name = torch_get_name(self.value, f"allowed_fn_{id(self.value)}")
         return "__" + re.sub(r"[^a-zA-Z0-9_]+", "_", name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #370
* #369

I find this is helpful for debugging what exactly a given TorchVariable
is; presently there is no information so it is hard to tell.  Because
these are PyTorch variables they should be well behaved and it shouldn't
cause problems to call repr on them.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>