### PR TITLE
Workaround triton float64 log issue

### DIFF
--- a/torchbench.py
+++ b/torchbench.py
@@ -1018,6 +1018,9 @@ def main():
         if args.float16:
             # TODO(jansel): check if correctness issue is real
             SKIP.add("yolov3")
+        if not (args.float16 or args.float32):
+            # https://github.com/openai/triton/issues/543 causes only 98.8% similarity
+            NONDETERMINISTIC.add("pyhpc_equation_of_state")
 
     if args.float16:
         # these give `INCORRECT - Variation in Eager runs itself` sometimes

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -74,7 +74,8 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def log(x):
-        return f"tl.log({x})"
+        # workaround https://github.com/openai/triton/issues/543
+        return f"tl.log({x}.to(tl.float32))"
 
     @staticmethod
     def isinf(x):


### PR DESCRIPTION
Fixes #363

We should revert this when https://github.com/openai/triton/issues/543 is fixed