### PR TITLE
Added microbenchmarks to measure performance of torch.mm vs torch.mm + relu vs inductor (triton mm)

### DIFF
--- a/micro-benchmark/benchmark_helper.py
+++ b/micro-benchmark/benchmark_helper.py
@@ -1,0 +1,17 @@
+import torch
+import time
+from torch.utils.benchmark import Timer
+
+def time_with_torch_timer(fn, args, string_id="function", kwargs={}, 
+                            iters=100, mean=True, median=False):
+    env = {"args": args, "kwargs": kwargs, "fn": fn}
+    fn_call = "fn(*args, **kwargs)"
+    
+    # Measure end-to-end time
+    timer = Timer(stmt=f"{fn_call}", globals=env)
+    
+    tt = timer.timeit(iters)
+    if mean:
+        print(f"{string_id}\t mean: {tt.mean * 1000:.4f} ms")
+    if median:
+        print(f"{string_id}\t median: {tt.median * 1000:.4f} ms")

--- a/micro-benchmark/matmul_relu.py
+++ b/micro-benchmark/matmul_relu.py
@@ -1,0 +1,84 @@
+import sre_compile
+import torch
+from benchmark_helper import time_with_torch_timer
+from torchinductor.triton_ops.matmul import matmul_out as triton_mm_out
+from torchinductor.triton_ops.matmul import matmul as triton_mm
+import torchdynamo
+import torchinductor.config as config
+
+config.triton.use_mm = True
+
+@torchdynamo.optimize("inductor", nopython=True)
+def inductor_mm(a, b):
+    return torch.mm(a, b)
+
+def torch_mm_relu(a, b):
+    return torch.nn.functional.relu(torch.matmul(a, b))
+
+def torch_mm(a, b):
+    return torch.matmul(a, b)
+
+
+if __name__ == "__main__":
+    # Real shapes from torchbench
+    a_shapes = [ [2048, 768], [64, 1280], [2048, 768], [32, 2048], [1, 39200], [128, 3072], [16, 1280]]
+    b_shapes = [ [768, 3072], [1280, 1000], [768, 768], [2048, 1000], [39200, 50], [3072, 1000], [1280, 1000]]
+
+    # Artificial larger shapes
+    a_shapes += [[10240, 512], [10240, 1024]]
+    b_shapes += [[512, 10240], [1024, 10240]]
+
+    for i in range(len(a_shapes)):
+        a_shape = a_shapes[i]
+        b_shape = b_shapes[i]
+        print("Shape:", a_shape, 'x', b_shape)
+        a = torch.randn(a_shape, device='cuda', dtype=torch.float16)
+        b = torch.randn(b_shape, device='cuda', dtype=a.dtype)
+
+        time_with_torch_timer(torch_mm, (a, b), string_id="torch mm")
+        time_with_torch_timer(torch_mm_relu, (a, b), string_id="torch mm + relu")
+        time_with_torch_timer(inductor_mm, (a, b), string_id="inductor mm")
+        
+
+
+
+
+# Results preview
+'''
+Shape: [2048, 768] x [768, 3072]
+torch mm         mean: 0.0593 ms
+torch mm + relu  mean: 0.0764 ms
+inductor mm      mean: 0.0680 ms
+Shape: [64, 1280] x [1280, 1000]
+torch mm         mean: 0.0211 ms
+torch mm + relu  mean: 0.0306 ms
+inductor mm      mean: 0.0268 ms
+Shape: [2048, 768] x [768, 768]
+torch mm         mean: 0.0195 ms
+torch mm + relu  mean: 0.0293 ms
+inductor mm      mean: 0.0276 ms
+Shape: [32, 2048] x [2048, 1000]
+torch mm         mean: 0.0198 ms
+torch mm + relu  mean: 0.0304 ms
+inductor mm      mean: 0.0274 ms
+Shape: [1, 39200] x [39200, 50]
+torch mm         mean: 0.0146 ms
+torch mm + relu  mean: 0.0245 ms
+inductor mm      mean: 0.0305 ms
+Shape: [128, 3072] x [3072, 1000]
+torch mm         mean: 0.0206 ms
+torch mm + relu  mean: 0.0321 ms
+inductor mm      mean: 0.0322 ms
+Shape: [16, 1280] x [1280, 1000]
+torch mm         mean: 0.0239 ms
+torch mm + relu  mean: 0.0309 ms
+inductor mm      mean: 0.0272 ms
+Shape: [10240, 512] x [512, 10240]
+torch mm         mean: 0.4678 ms
+torch mm + relu  mean: 0.7760 ms
+inductor mm      mean: 0.5435 ms
+Shape: [10240, 1024] x [1024, 10240]
+torch mm         mean: 0.9312 ms
+torch mm + relu  mean: 1.2112 ms
+inductor mm      mean: 0.9921 ms
+'''


### PR DESCRIPTION
**Key takeaway: We may be able to achieve up to ~1.3x speedup over plain torch once we generate fused `matmul + relu` triton kernel in inductor**. 

We'd like to know how much performance improvement is possible by fusing matmul and relu in inductor. To know this we need to measure the runtime of matmul alone and matmul followed by a relu. We also compare against inductor (w/ triton mm).

The following are the raw results:

```
Shape: [2048, 768] x [768, 3072]
torch mm         mean: 0.0593 ms
torch mm + relu  mean: 0.0764 ms
inductor mm      mean: 0.0680 ms
Shape: [64, 1280] x [1280, 1000]
torch mm         mean: 0.0211 ms
torch mm + relu  mean: 0.0306 ms
inductor mm      mean: 0.0268 ms
Shape: [2048, 768] x [768, 768]
torch mm         mean: 0.0195 ms
torch mm + relu  mean: 0.0293 ms
inductor mm      mean: 0.0276 ms
Shape: [32, 2048] x [2048, 1000]
torch mm         mean: 0.0198 ms
torch mm + relu  mean: 0.0304 ms
inductor mm      mean: 0.0274 ms
Shape: [1, 39200] x [39200, 50]
torch mm         mean: 0.0146 ms
torch mm + relu  mean: 0.0245 ms
inductor mm      mean: 0.0305 ms
Shape: [128, 3072] x [3072, 1000]
torch mm         mean: 0.0206 ms
torch mm + relu  mean: 0.0321 ms
inductor mm      mean: 0.0322 ms
Shape: [16, 1280] x [1280, 1000]
torch mm         mean: 0.0239 ms
torch mm + relu  mean: 0.0309 ms
inductor mm      mean: 0.0272 ms
Shape: [10240, 512] x [512, 10240]
torch mm         mean: 0.4678 ms
torch mm + relu  mean: 0.7760 ms
inductor mm      mean: 0.5435 ms
Shape: [10240, 1024] x [1024, 10240]
torch mm         mean: 0.9312 ms
torch mm + relu  mean: 1.2112 ms
inductor mm      mean: 0.9921 ms
```

These results show that `torch.matmul + relu` adds around 30% to 50% overhead to `torch.matmul` alone. And the `inductor mm` runtime is about 0 ~ 30% faster than `torch mm + relu`. Although `inductor mm` now only does `matmul`, but once we are able to generate fused `matmul + relu` in inductor, the fused shouldn't add much overhead to that of `inductor mm` due to the kernel is fused, so we can expect about up to 30% speedup then. 
 