### PR TITLE
Skipping the namedtuple subclass constructor

### DIFF
--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -215,6 +215,15 @@ def convert_frame_assert(compiler_fn: Callable, one_graph=True):
         if code.co_name == "<module>" and code.co_filename == "<string>":
             return None
 
+        if (
+            code.co_name == "<lambda>"
+            and code.co_filename == "<string>"
+            and not bool(frame.f_builtins)
+        ):
+            # namedtuple subclass constructor. Empty builtins cause issue with
+            # len keyword in LIST_LEN guard.
+            return None
+
         if is_generator(code):
             unimplemented("generator")
         if cache_size >= config.cache_size_limit:


### PR DESCRIPTION
Skipping the frame arising from this piece of code

https://github.com/python/cpython/blob/3.10/Lib/collections/__init__.py#L410-L414

![image](https://user-images.githubusercontent.com/13822661/173210098-37ac81bb-8875-454e-ad32-4fd2f907c95d.png)

This resolves close to 200 issues in PyTorch tests.