### PR TITLE
Fix for `any` decomposition

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -831,7 +831,7 @@ class CommonTemplate:
                 aten._to_copy(a, dtype=6),
                 aten._to_copy(b + 1, dtype=6),
                 aten.to(b, torch.float64),
-                aten.to(b, torch.bool)
+                aten.to(b, torch.bool),
             )
 
         self.common(

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -831,6 +831,7 @@ class CommonTemplate:
                 aten._to_copy(a, dtype=6),
                 aten._to_copy(b + 1, dtype=6),
                 aten.to(b, torch.float64),
+                aten.to(b, torch.bool)
             )
 
         self.common(
@@ -1829,12 +1830,13 @@ class CommonTemplate:
     def test_any(self):
         def fn(x):
             return (
+                x.any(-1),
                 x.isinf().any(),
                 torch.all(x.isinf(), dim=0),
                 torch.all(torch.logical_not(x.isinf())),
             )
 
-        self.common(fn, [torch.randn(64)])
+        self.common(fn, [-torch.rand(64)])
         tmp = torch.randn(16, 8)
         tmp[1, 1] = float("inf")
         self.common(fn, [tmp])

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -47,7 +47,7 @@ class TritonOverrides(OpOverrides):
     def to_dtype(x, dtype: torch.dtype):
         triton_type_name = str(dtype).split(".")[-1]
         if triton_type_name == "bool":
-            triton_type_name = "int1"
+            return f"({x} != 0)"
         if triton_type_name in ("float16", "bfloat16"):
             triton_type_name = "float32"
         return f"{x}.to(tl.{triton_type_name})"

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1491,6 +1491,7 @@ sqrt = register_pointwise(aten.sqrt)
 square = register_pointwise(aten.square)
 sub = register_pointwise(aten.sub)
 
+register_pointwise(aten.abs)
 register_pointwise(aten.bitwise_and)
 register_pointwise(aten.bitwise_not, override_bool="logical_not")
 register_pointwise(aten.bitwise_or)

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1287,6 +1287,8 @@ def make_reduction(reduction_type: str, override_dtype=None):
         assert (
             reduction_type in ("sum", "amax", "amin", "any") or axis is None
         ), "TODO: max with index"
+        if reduction_type == "any":
+            x = to_dtype(x, torch.bool)
         size = x.get_size()
         axis = set(_validate_reduction_axis(x, axis))
 
@@ -1489,7 +1491,6 @@ sqrt = register_pointwise(aten.sqrt)
 square = register_pointwise(aten.square)
 sub = register_pointwise(aten.sub)
 
-register_pointwise(aten.abs)
 register_pointwise(aten.bitwise_and)
 register_pointwise(aten.bitwise_not, override_bool="logical_not")
 register_pointwise(aten.bitwise_or)


### PR DESCRIPTION
Previously it produced wrong results for tensor consisting of negative and 0 elements