### PR TITLE
Extend new to new_empty for tensor.shape

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -539,6 +539,13 @@ class FunctionTests(torchdynamo.testing.TestCase):
         z = x.new(y.size())
         assert z.size() == y.size()
 
+    @requires_static_shapes
+    @make_test
+    def test_tensor_new_with_shape(x):
+        y = torch.rand(5, 8)
+        z = x.new(y.shape)
+        assert z.size() == y.size()
+
     # # This is to test the new syntax for pattern matching
     # # ("match ... case ...") added on python 3.10.
     # # Uncomment these test cases if you run on 3.10+

--- a/torchdynamo/variables/lists.py
+++ b/torchdynamo/variables/lists.py
@@ -255,6 +255,15 @@ class SizeVariable(TupleVariable):
         return build_torch_size
 
 
+class ShapeVariable(TupleVariable):
+    """
+    Represents tensor.shape(...) and helps differentiate between a constant
+    TupleVariable and ShapeVariable.
+    """
+
+    pass
+
+
 class NamedTupleVariable(TupleVariable):
     def __init__(self, items, tuple_cls, **kwargs):
         super().__init__(items, **kwargs)

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -21,6 +21,7 @@ from ..utils import proxy_args_kwargs
 from .base import MutableLocal
 from .base import VariableTracker
 from .base import typestr
+from .lists import ShapeVariable
 from .lists import SizeVariable
 
 
@@ -228,7 +229,8 @@ class TensorVariable(VariableTracker):
         elif name == "is_cuda" and self.device is not None:
             result = ConstantVariable(self.device.type == "cuda", **options)
         elif name == "shape" and self.size is not None:
-            result = ConstantVariable(self.size, **options)
+            sizes = [variables.ConstantVariable(x) for x in self.size]
+            result = ShapeVariable(sizes, **options)
         elif name == "requires_grad" and self.requires_grad is not None:
             result = ConstantVariable(self.requires_grad, **options)
         elif name == "is_quantized" and self.is_quantized is not None:
@@ -335,7 +337,7 @@ class TensorVariable(VariableTracker):
             if (
                 name == "new"
                 and len(args) == 1
-                and isinstance(args[0], SizeVariable)
+                and isinstance(args[0], (SizeVariable, ShapeVariable))
                 and not config.dynamic_shapes
             ):
                 name = "new_empty"


### PR DESCRIPTION
An extension of https://github.com/pytorch/torchdynamo/pull/195

Supports tensor.new(tensor.shape) as well now.

Created a new ShapeVariable just to differentiate between Constant tuple and tensor shape.

cc @yanboliang