### PR TITLE
Support for lazy modules

### DIFF
--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env pytest
 
 from copy import deepcopy
+from re import L
 
 import torch
 from torch.nn import functional as F
+from torch.nn.modules.lazy import LazyModuleMixin
+from torch.nn.parameter import Parameter
+from torch.nn.parameter import UninitializedParameter
 
 import torchdynamo.testing
 from torchdynamo.eval_frame import unsupported
@@ -401,6 +405,32 @@ class DenseNetBlocks(torch.nn.Module):
         return self.layers(x)
 
 
+class MaterializedModule(torch.nn.Module):
+    """Once the below lazy module is initialized with its first input,
+    it is transformed into this module."""
+
+    param: Parameter
+
+    def __init__(self):
+        super().__init__()
+        self.register_parameter("param", None)
+
+    def forward(self, x):
+        return x
+
+
+class LazyModule(LazyModuleMixin, MaterializedModule):
+    param: UninitializedParameter
+    cls_to_become = MaterializedModule
+
+    def __init__(self):
+        super().__init__()
+        self.param = UninitializedParameter()
+
+    def initialize_parameters(self, x):
+        self.param.materialize(x.shape)
+
+
 def requires_grad1(module: torch.nn.Module, recurse: bool = False) -> bool:
     requires_grad = any([p.requires_grad for p in module.parameters(recurse)])
     return requires_grad
@@ -776,3 +806,39 @@ class NNModuleTests(torchdynamo.testing.TestCase):
         self.assertEqual(cnt.op_count, 1)
         self.assertTrue(torchdynamo.testing.same(pre, opt_pre))
         self.assertTrue(torchdynamo.testing.same(out1, out_post))
+
+    def test_lazy_module(self):
+        m = LazyModule()
+        x = isinstance(m, LazyModuleMixin)
+
+        input_shape = (16, 3, 6, 7, 8)
+        cnt = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnt):
+
+            def test_dynamic_module():
+                module = LazyModule()
+                input = torch.ones(*input_shape)
+                module(input)
+                self.assertTrue(
+                    isinstance(module, MaterializedModule),
+                    "Module should be transformed to an instance of MaterializedModule.",
+                )
+                self.assertEqual(module.param.shape, input.shape)
+
+            test_dynamic_module()
+
+        # test with a static module in torch.*
+        module = torch.nn.modules.LazyBatchNorm3d(
+            affine=False, track_running_stats=False
+        )
+        with torchdynamo.optimize(cnt):
+
+            def run_test():
+                input = torch.ones(*input_shape)
+                module(input)  # fully materialized
+                self.assertTrue(
+                    isinstance(module, torch.nn.modules.batchnorm.BatchNorm3d),
+                    "Module should be transformed to an instance of BatchNorm3d.",
+                )
+
+            run_test()

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -808,9 +808,6 @@ class NNModuleTests(torchdynamo.testing.TestCase):
         self.assertTrue(torchdynamo.testing.same(out1, out_post))
 
     def test_lazy_module(self):
-        m = LazyModule()
-        x = isinstance(m, LazyModuleMixin)
-
         input_shape = (16, 3, 6, 7, 8)
         cnt = torchdynamo.testing.CompileCounter()
         with torchdynamo.optimize(cnt):

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env pytest
 
 from copy import deepcopy
-from re import L
 
 import torch
 from torch.nn import functional as F

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -121,8 +121,10 @@ def istensor(obj):
         obj, (torch.Tensor, torch.nn.Parameter, *config.traceable_tensor_subclasses)
     )
 
+
 def is_lazy_module(mod):
     return isinstance(mod, LazyModuleMixin)
+
 
 @functools.lru_cache(4096)
 def print_once(*args):

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -20,6 +20,7 @@ import numpy as np
 import tabulate
 import torch
 from torch import fx
+from torch.nn.modules.lazy import LazyModuleMixin
 
 import torchdynamo.config
 
@@ -120,6 +121,8 @@ def istensor(obj):
         obj, (torch.Tensor, torch.nn.Parameter, *config.traceable_tensor_subclasses)
     )
 
+def is_lazy_module(mod):
+    return isinstance(mod, LazyModuleMixin)
 
 @functools.lru_cache(4096)
 def print_once(*args):

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -15,6 +15,7 @@ from ..exc import TorchRuntimeError
 from ..exc import unimplemented
 from ..source import AttrSource
 from ..utils import clone_tensor
+from ..utils import is_lazy_module
 from ..utils import istype
 from ..utils import product
 from ..utils import proxy_args_kwargs
@@ -85,7 +86,12 @@ class TensorVariable(VariableTracker):
                         )
                     elif op == "call_module":
                         assert nnmodule is not None
-                        example_value = copy.deepcopy(nnmodule)(*args, **kwargs)
+                        # In the case of a lazy module, we want to run
+                        # the pre-hooks which initialize it
+                        if is_lazy_module(nnmodule):
+                            example_value = nnmodule(*args, **kwargs)
+                        else:
+                            example_value = copy.deepcopy(nnmodule)(*args, **kwargs)
                 except RuntimeError:
                     # Track the assertion when the pytorch execution raises
                     # assertion


### PR DESCRIPTION
Added fixes to support [lazy modules](https://pytorch.org/docs/stable/generated/torch.nn.modules.lazy.LazyModuleMixin.html) in torchdynamo. The main issue that needed to be addressed is that LazyModules register some hooks which are run when a module is called. Torchdynamo typically calls the `forward` method instead of `__call__`  so these hooks were never run. In the case of LazyModules we now run and trace the `__call__` method, and allow the original module to be mutated. In the future, we could do this for all modules, but there were cases where torchdynamo does not yet support functionality used in all hooks.