### PR TITLE
Step 2 of supporting UnspecializedNumpyVariable & UnspecializedPythonVariable

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1614,7 +1614,7 @@ class MiscTests(torchdynamo.testing.TestCase):
             r1 = random.random()
             y = x + random.uniform(10, 20)
             r2 = random.randint(2, 18)
-            return y + r1 - r2
+            return y + r1, r2
 
         x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
         random.seed(1)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1593,6 +1593,20 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 2)
 
+    def test_unspecialized_primitive_variable3(self):
+        # test unspecialized primitive max/min
+        def fn(x, y, z):
+            return z + 1, max(x, y), min(x - 4, y)
+
+        x = np.int64(12)
+        y = 10
+        z = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float64)
+        res1 = fn(x, y, z)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            res2 = fn(x, y, z)
+        self.assertTrue(same(res1, res2))
+
     def test_side_effects_codegen_update_mutated(self):
         # codegen to update mutated variables with side effect
         # should after stack value's codegen

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1609,11 +1609,12 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertTrue(same(res1, res2))
 
     def test_unspecialized_primitive_variable4(self):
-        # no recompilations on random.random
+        # test random functions
         def fn(x):
-            y1 = random.random()
-            y2 = random.random()
-            return x + y1, y1, y2
+            r1 = random.random()
+            y = x + random.uniform(10, 20)
+            r2 = random.randint(2, 18)
+            return y + r1 - r2
 
         x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
         random.seed(1)
@@ -1622,14 +1623,7 @@ class MiscTests(torchdynamo.testing.TestCase):
         with torchdynamo.optimize(cnts):
             random.seed(1)
             res2 = fn(x)
-            for i in range(10):
-                fn(x)
-
-        print(res1)
-        print(res2)
         self.assertTrue(same(res1, res2))
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 1)
 
     def test_side_effects_codegen_update_mutated(self):
         # codegen to update mutated variables with side effect

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -669,7 +669,7 @@ class MiscTests(torchdynamo.testing.TestCase):
             self.assertTrue(same(fn(*args), correct))
             self.assertTrue(same(fn(*args), correct))
         self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 3)
+        self.assertEqual(cnts.op_count, 2)
 
     def test_dict_mutation_side_effect(self):
         def fn(d):
@@ -1591,7 +1591,7 @@ class MiscTests(torchdynamo.testing.TestCase):
             for i in range(10):
                 fn(x, np.int64(i))
         self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 3)
+        self.assertEqual(cnts.op_count, 2)
 
     def test_side_effects_codegen_update_mutated(self):
         # codegen to update mutated variables with side effect

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -669,7 +669,7 @@ class MiscTests(torchdynamo.testing.TestCase):
             self.assertTrue(same(fn(*args), correct))
             self.assertTrue(same(fn(*args), correct))
         self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 2)
+        self.assertEqual(cnts.op_count, 3)
 
     def test_dict_mutation_side_effect(self):
         def fn(d):
@@ -1567,9 +1567,9 @@ class MiscTests(torchdynamo.testing.TestCase):
                 "z": z,
                 "a": np_y.sum(),
                 "b": xy,
-                "c": np_y[0][0] / 68,
+                "c": np_x[0][0] / 68,
                 "d": np_x.sum(),
-            }
+            }, x + np_y.sum() + z
 
         x = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float64)
         y = torch.ones([2, 2], dtype=torch.int64)
@@ -1591,7 +1591,7 @@ class MiscTests(torchdynamo.testing.TestCase):
             for i in range(10):
                 fn(x, np.int64(i))
         self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 2)
+        self.assertEqual(cnts.op_count, 3)
 
     def test_side_effects_codegen_update_mutated(self):
         # codegen to update mutated variables with side effect

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1568,7 +1568,7 @@ class MiscTests(torchdynamo.testing.TestCase):
                 "z": z,
                 "a": np_y.sum(),
                 "b": xy,
-                "c": np_x[0][0] / 68,
+                "c": np_y[0][0] / 68,
                 "d": np_x.sum(),
             }, x + np_y.sum() + z
 

--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -315,7 +315,11 @@ class PyCodegen(object):
                     [
                         self.create_load_global("torch", add=True),
                         self.create_load_attr("tensor"),
-                        arg.load(self),
+                    ]
+                )
+                self.extend_output(arg.load(self))
+                self.extend_output(
+                    [
                         create_instruction("CALL_FUNCTION", 1),
                     ]
                 )

--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -133,14 +133,13 @@ class PyCodegen(object):
 
             if isinstance(value, UnspecializedNumpyVariable):
                 unspec_var = self.tx.output.new_var("unspec")
+                raw_type = type(value.raw_value)
                 output.extend(
                     [
                         self.create_load_attr("item"),
                         create_instruction("CALL_FUNCTION", 0),
                         self.create_store(unspec_var),
-                        self.create_load_global("type", add=True),
-                        self.create_load_const(value.raw_value),
-                        create_instruction("CALL_FUNCTION", 1),
+                        self.create_load_const(raw_type),
                         self.create_load(unspec_var),
                         create_instruction("CALL_FUNCTION", 1),
                     ]
@@ -246,11 +245,7 @@ class PyCodegen(object):
         )
 
     def create_load_const(self, value):
-        assert (
-            is_safe_constant(value)
-            or is_numpy_int_type(value)
-            or is_numpy_float_type(value)
-        ), f"unsafe constant {value}"
+        assert is_safe_constant(value), f"unsafe constant {value}"
         return self._create_load_const(value)
 
     @staticmethod

--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -141,6 +141,13 @@ class PyCodegen(object):
                         create_instruction("BINARY_SUBSCR"),
                     ]
                 )
+            if isinstance(value, UnspecializedPythonVariable) and value.need_unwrap:
+                output.extend(
+                    [
+                        self.create_load_attr("item"),
+                        create_instruction("CALL_FUNCTION", 0),
+                    ]
+                )
         elif isinstance(value, NNModuleVariable):
             parts = value.module_key.split(".")
             if parts[0] in self.code_options["co_varnames"]:

--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -54,7 +54,6 @@ class PyCodegen(object):
         root: torch.nn.Module = None,
         graph_output_var: str = None,
         tempvars=None,
-        random_values_var=None,
     ):
         self.root = root
         self.top_of_stack = None
@@ -67,7 +66,6 @@ class PyCodegen(object):
         self.code_options = self.tx.output.code_options
         self.cell_and_freevars = self.tx.cell_and_freevars
         self.new_var = self.tx.output.new_var
-        self.random_values_var = random_values_var
 
     def graph_output_vars(self):
         return [x.variable for x in self.graph_outputs.values()]
@@ -333,7 +331,7 @@ class PyCodegen(object):
                 [
                     self.create_load_global("_generate_random_values", add=True),
                     create_instruction("CALL_FUNCTION", 0),
-                    self.create_store(self.random_values_var),
+                    self.create_store(self.tx.output.random_values_var),
                 ]
             )
 

--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -1,6 +1,5 @@
 import collections
 import dataclasses
-import random
 import re
 import sys
 import types

--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -15,8 +15,6 @@ from .bytecode_transformation import unique_id
 from .exc import unimplemented
 from .source import AttrSource
 from .source import Source
-from .utils import is_numpy_float_type
-from .utils import is_numpy_int_type
 from .utils import is_safe_constant
 from .utils import istype
 from .utils import rot_n_helper

--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -310,7 +310,7 @@ class PyCodegen(object):
 
         graphargs = self.tx.output.graphargs
         for arg in graphargs:
-            if arg.is_unspecialized_primitive:
+            if arg.unspecialized_primitive_info is not None:
                 self.extend_output(
                     [
                         self.create_load_global("torch", add=True),
@@ -318,6 +318,12 @@ class PyCodegen(object):
                     ]
                 )
                 self.extend_output(arg.load(self))
+                if arg.unspecialized_primitive_info.from_callable:
+                    self.extend_output(
+                        [
+                            create_instruction("CALL_FUNCTION", 0),
+                        ]
+                    )
                 self.extend_output(
                     [
                         create_instruction("CALL_FUNCTION", 1),

--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -129,6 +129,7 @@ class PyCodegen(object):
                 self._create_load_const(graph_outputs[graph_outputs_key].index)
             )
             output.append(create_instruction("BINARY_SUBSCR"))
+
             if isinstance(value, UnspecializedNumpyVariable):
                 output.extend(
                     [
@@ -139,13 +140,6 @@ class PyCodegen(object):
                         create_instruction("CALL_FUNCTION", 1),
                         self._create_load_const(0),
                         create_instruction("BINARY_SUBSCR"),
-                    ]
-                )
-            elif isinstance(value, UnspecializedPythonVariable):
-                output.extend(
-                    [
-                        self.create_load_attr("item"),
-                        create_instruction("CALL_FUNCTION", 0),
                     ]
                 )
         elif isinstance(value, NNModuleVariable):

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -32,6 +32,7 @@ from .utils import count_calls
 from .utils import counters
 from .variables.nn_module import NNModuleVariable
 from .variables.tensor import TensorVariable
+from .variables.tensor import UnspecializedPrimitiveVariable
 
 
 class FakeRootModule(torch.nn.Module):
@@ -235,6 +236,9 @@ class OutputGraph(fx.Tracer):
 
         if (
             stack_values
+            and all(
+                not isinstance(v, UnspecializedPrimitiveVariable) for v in stack_values
+            )
             and all(isinstance(x, TensorVariable) for x in stack_values)
             and len(set(stack_values)) == len(stack_values)
             and self.side_effects.is_empty()

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -159,6 +159,13 @@ class OutputGraph(fx.Tracer):
                 name,
             )
 
+    def update_co_varnames(self, name):
+        """Ensure self.code_options.co_varnames contains name"""
+        if name not in self.code_options["co_varnames"]:
+            self.code_options["co_varnames"] = tuple(
+                self.code_options["co_varnames"]
+            ) + (name,)
+
     def add_submodule(self, mod: torch.nn.Module, *names, **options):
         if is_dynamic_nn_module(mod):
             return variables.UnspecializedNNModuleVariable(mod, **options)

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -32,7 +32,8 @@ from .utils import count_calls
 from .utils import counters
 from .variables.nn_module import NNModuleVariable
 from .variables.tensor import TensorVariable
-from .variables.tensor import UnspecializedPrimitiveVariable
+from .variables.tensor import UnspecializedNumpyVariable
+from .variables.tensor import UnspecializedPythonVariable
 
 
 class FakeRootModule(torch.nn.Module):
@@ -244,7 +245,10 @@ class OutputGraph(fx.Tracer):
         if (
             stack_values
             and all(
-                not isinstance(v, UnspecializedPrimitiveVariable) for v in stack_values
+                not isinstance(
+                    v, (UnspecializedNumpyVariable, UnspecializedPythonVariable)
+                )
+                for v in stack_values
             )
             and all(isinstance(x, TensorVariable) for x in stack_values)
             and len(set(stack_values)) == len(stack_values)

--- a/torchdynamo/source.py
+++ b/torchdynamo/source.py
@@ -72,9 +72,6 @@ class RandomValueSource(Source):
             create_instruction("BINARY_SUBSCR"),
         ]
 
-    def guard_source(self):
-        return GuardSource.LOCAL
-
     def name(self):
         return rename_implicit(f"random_value_{self.random_call_index}")
 

--- a/torchdynamo/source.py
+++ b/torchdynamo/source.py
@@ -67,7 +67,7 @@ class RandomValueSource(Source):
 
     def reconstruct(self, codegen):
         return [
-            codegen.create_load("_torchdynamo_random_values", add=True),
+            codegen.create_load("___random_values", add=True),
             codegen.create_load_const(self.random_call_index),
             create_instruction("BINARY_SUBSCR"),
         ]

--- a/torchdynamo/source.py
+++ b/torchdynamo/source.py
@@ -67,7 +67,7 @@ class RandomValueSource(Source):
 
     def reconstruct(self, codegen):
         return [
-            codegen.create_load("___random_values", add=True),
+            codegen.create_load(codegen.random_values_var),
             codegen.create_load_const(self.random_call_index),
             create_instruction("BINARY_SUBSCR"),
         ]

--- a/torchdynamo/source.py
+++ b/torchdynamo/source.py
@@ -67,7 +67,7 @@ class RandomValueSource(Source):
 
     def reconstruct(self, codegen):
         return [
-            codegen.create_load(codegen.random_values_var),
+            codegen.create_load(codegen.tx.output.random_values_var),
             codegen.create_load_const(self.random_call_index),
             create_instruction("BINARY_SUBSCR"),
         ]

--- a/torchdynamo/source.py
+++ b/torchdynamo/source.py
@@ -62,6 +62,24 @@ class LocalSource(Source):
 
 
 @dataclasses.dataclass
+class RandomValueSource(Source):
+    random_call_index: int
+
+    def reconstruct(self, codegen):
+        return [
+            codegen.create_load("_torchdynamo_random_values", add=True),
+            codegen.create_load_const(self.random_call_index),
+            create_instruction("BINARY_SUBSCR"),
+        ]
+
+    def guard_source(self):
+        return GuardSource.LOCAL
+
+    def name(self):
+        return rename_implicit(f"random_value_{self.random_call_index}")
+
+
+@dataclasses.dataclass
 class GlobalSource(Source):
     global_name: str
 

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1160,6 +1160,7 @@ class InstructionTranslatorBase(object):
         self.f_code: types.CodeType = f_code
 
         self.checkpoint = None
+        self.random_call_count = 0
 
         if sys.version_info >= (3, 10):
             from .resume_execution import CO_ASYNC_GENERATOR

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -68,6 +68,7 @@ from .variables.misc import UnknownVariable
 from .variables.misc import WithExitFunctionVariable
 from .variables.nn_module import NNModuleVariable
 from .variables.tensor import TensorVariable
+from .variables.tensor import UnspecializedPrimitiveVariable
 from .variables.torch import TorchVariable
 from .variables.user_defined import UserDefinedVariable
 
@@ -1204,6 +1205,21 @@ class InstructionTranslator(InstructionTranslatorBase):
             for k in vars
             if k in f_locals
         )
+        # wrap some python float/int as UnspecializedPrimitiveVariable which is 1-element tensor,
+        # so need to update the value to tensor.
+        cg = PyCodegen(self)
+        for k, v in list(self.symbolic_locals.items()):
+            if isinstance(v, UnspecializedPrimitiveVariable):
+                self.LOAD_GLOBAL(cg.create_load_global("torch", add=True))
+                self.LOAD_ATTR(cg.create_load_attr("tensor"))
+                self.push(self.pop())
+                self.push(None)
+                self.LOAD_FAST(cg.create_load(k))
+                self.CALL_METHOD(create_instruction("CALL_METHOD", 1))
+                tensor_var = self.pop()
+                args = dict(tensor_var.__dict__)
+                self.push(UnspecializedPrimitiveVariable(**args))
+                self.STORE_FAST(cg.create_store(k))
 
         # symbolic_locals contains the mapping from original f_locals to the
         # Variable objects. During the Variable building phase, each object also

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1205,21 +1205,6 @@ class InstructionTranslator(InstructionTranslatorBase):
             for k in vars
             if k in f_locals
         )
-        # wrap some python float/int as UnspecializedPrimitiveVariable which is 1-element tensor,
-        # so need to update the value to tensor.
-        cg = PyCodegen(self)
-        for k, v in list(self.symbolic_locals.items()):
-            if isinstance(v, UnspecializedPrimitiveVariable):
-                self.LOAD_GLOBAL(cg.create_load_global("torch", add=True))
-                self.LOAD_ATTR(cg.create_load_attr("tensor"))
-                self.push(self.pop())
-                self.push(None)
-                self.LOAD_FAST(cg.create_load(k))
-                self.CALL_METHOD(create_instruction("CALL_METHOD", 1))
-                tensor_var = self.pop()
-                args = dict(tensor_var.__dict__)
-                self.push(UnspecializedPrimitiveVariable(**args))
-                self.STORE_FAST(cg.create_store(k))
 
         # symbolic_locals contains the mapping from original f_locals to the
         # Variable objects. During the Variable building phase, each object also

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -68,7 +68,6 @@ from .variables.misc import UnknownVariable
 from .variables.misc import WithExitFunctionVariable
 from .variables.nn_module import NNModuleVariable
 from .variables.tensor import TensorVariable
-from .variables.tensor import UnspecializedPrimitiveVariable
 from .variables.torch import TorchVariable
 from .variables.user_defined import UserDefinedVariable
 

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1160,7 +1160,7 @@ class InstructionTranslatorBase(object):
         self.f_code: types.CodeType = f_code
 
         self.checkpoint = None
-        self.random_call_count = 0
+        self.random_calls: List[tuple] = []
 
         if sys.version_info >= (3, 10):
             from .resume_execution import CO_ASYNC_GENERATOR

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -361,7 +361,9 @@ def rot_n_helper(n):
 def is_safe_constant(v):
     if istype(v, (tuple, frozenset)):
         return all(map(is_safe_constant, v))
-    return istype(v, (types.CodeType, int, float, bool, str, bytes, type(None), slice))
+    return istype(
+        v, (types.CodeType, int, float, bool, str, bytes, type(None), slice, type(type))
+    )
 
 
 def check_constant_args(args, kwargs):

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -6,6 +6,7 @@ import gc
 import inspect
 import itertools
 import logging
+import math
 import operator
 import re
 import sys
@@ -429,8 +430,10 @@ def same(a, b, cos_similarity=False, tol=1e-4, equal_nan=False):
             return res >= 0.99
         else:
             return torch.allclose(a, b, atol=tol, rtol=tol, equal_nan=equal_nan)
-    elif isinstance(a, (str, int, float, type(None), bool, torch.device)):
+    elif isinstance(a, (str, int, type(None), bool, torch.device)):
         return a == b
+    elif isinstance(a, float):
+        return math.isclose(a, b, rel_tol=tol, abs_tol=tol)
     elif is_numpy_int_type(a) or is_numpy_float_type(a):
         return (type(a) is type(b)) and (a == b)
     elif type(a).__name__ in (

--- a/torchdynamo/variables/__init__.py
+++ b/torchdynamo/variables/__init__.py
@@ -31,6 +31,7 @@ from .misc import WithExitFunctionVariable
 from .nn_module import NNModuleVariable
 from .nn_module import UnspecializedNNModuleVariable
 from .tensor import TensorVariable
+from .tensor import UnspecializedPrimitiveVariable
 from .torch import TorchVariable
 from .user_defined import UserDefinedClassVariable
 from .user_defined import UserDefinedObjectVariable
@@ -66,6 +67,7 @@ __all__ = [
     "TupleVariable",
     "UnknownVariable",
     "UnspecializedNNModuleVariable",
+    "UnspecializedPrimitiveVariable",
     "UserDefinedClassVariable",
     "UserDefinedObjectVariable",
     "UserFunctionVariable",

--- a/torchdynamo/variables/__init__.py
+++ b/torchdynamo/variables/__init__.py
@@ -31,7 +31,8 @@ from .misc import WithExitFunctionVariable
 from .nn_module import NNModuleVariable
 from .nn_module import UnspecializedNNModuleVariable
 from .tensor import TensorVariable
-from .tensor import UnspecializedPrimitiveVariable
+from .tensor import UnspecializedNumpyVariable
+from .tensor import UnspecializedPythonVariable
 from .torch import TorchVariable
 from .user_defined import UserDefinedClassVariable
 from .user_defined import UserDefinedObjectVariable
@@ -67,7 +68,8 @@ __all__ = [
     "TupleVariable",
     "UnknownVariable",
     "UnspecializedNNModuleVariable",
-    "UnspecializedPrimitiveVariable",
+    "UnspecializedNumpyVariable",
+    "UnspecializedPythonVariable",
     "UserDefinedClassVariable",
     "UserDefinedObjectVariable",
     "UserFunctionVariable",

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -8,8 +8,8 @@ import types
 from abc import ABCMeta
 from typing import Any
 from typing import List
-import numpy as np
 
+import numpy as np
 import torch
 
 import torchdynamo

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -362,6 +362,7 @@ class VariableBuilder:
                 tx=self.tx,
                 proxy=proxy,
                 example_value=wrapped_value,
+                raw_value=value,
                 **guards_options,
             )
         else:
@@ -369,6 +370,7 @@ class VariableBuilder:
                 tx=self.tx,
                 proxy=proxy,
                 example_value=wrapped_value,
+                raw_value=value,
                 **guards_options,
             )
 

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -24,7 +24,7 @@ from ..guards import GuardBuilder
 from ..side_effects import SideEffects
 from ..source import AttrSource
 from ..source import GetItemSource
-from ..source import LocalSource
+from ..source import RandomValueSource
 from ..source import Source
 from ..source import TupleIteratorGetItemSource
 from ..utils import getfile
@@ -349,7 +349,7 @@ class VariableBuilder:
         self.tx.output.graphargs.append(
             GraphArg(self.get_source(), wrapped_value, True)
         )
-        if isinstance(self.get_source(), LocalSource):
+        if not isinstance(self.get_source(), RandomValueSource):
             guards_options = {"guards": self.make_guards(GuardBuilder.TYPE_MATCH)}
         else:
             guards_options = {}

--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -29,7 +29,6 @@ from ..source import Source
 from ..source import TupleIteratorGetItemSource
 from ..utils import getfile
 from ..utils import is_namedtuple
-from ..utils import is_numpy_float_type
 from ..utils import is_numpy_int_type
 from ..utils import istensor
 from ..utils import istype

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -7,6 +7,7 @@ import types
 from typing import Dict
 from typing import List
 
+import numpy as np
 import torch
 
 from torchdynamo.guards import GuardBuilder

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -2,7 +2,6 @@ import functools
 import inspect
 import itertools
 import math
-import numpy
 import operator
 import types
 from typing import Dict

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -163,11 +163,8 @@ class BuiltinVariable(VariableTracker):
             for i in itertools.chain(args, kwargs.values())
         )
 
-    def wrap_as_unspecialized_if_needed(self, tensor_variable, *args, **kwargs):
-        """
-        Wrap a `TensorVariable` as an `UnspecializedNumpyVariable` or `UnspecializedPythonVariable` if needed.
-        """
-        if all(
+    def unspec_numpy_args(self, *args, **kwargs):
+        return all(
             isinstance(
                 i,
                 (
@@ -177,25 +174,53 @@ class BuiltinVariable(VariableTracker):
                 ),
             )
             for i in itertools.chain(args, kwargs.values())
-        ):
-            if any(
-                isinstance(x, variables.UnspecializedNumpyVariable)
-                for x in itertools.chain(args, kwargs.values())
+        ) and any(
+            isinstance(x, variables.UnspecializedNumpyVariable)
+            for x in itertools.chain(args, kwargs.values())
+        )
+
+    def unspec_python_args(self, *args, **kwargs):
+        return all(
+            isinstance(
+                i,
+                (
+                    variables.UnspecializedPythonVariable,
+                    variables.ConstantVariable,
+                ),
+            )
+            for i in itertools.chain(args, kwargs.values())
+        ) and any(
+            isinstance(x, variables.UnspecializedPythonVariable)
+            for x in itertools.chain(args, kwargs.values())
+        )
+
+    @staticmethod
+    def unwrap_unspec_args_kwargs(args, kwargs):
+        unwrapped_args = []
+        unwrapped_kwargs = {}
+        for x in args:
+            if isinstance(
+                x,
+                (
+                    variables.UnspecializedNumpyVariable,
+                    variables.UnspecializedPythonVariable,
+                ),
             ):
-                return variables.UnspecializedNumpyVariable.from_tensor_variable(
-                    tensor_variable
-                )
+                unwrapped_args.append(x.raw_value)
             else:
-                need_unwrap = any(
-                    x.need_unwrap
-                    for x in itertools.chain(args, kwargs.values())
-                    if isinstance(x, variables.UnspecializedPythonVariable)
-                )
-                return variables.UnspecializedPythonVariable.from_tensor_variable(
-                    tensor_variable, need_unwrap
-                )
-        else:
-            return tensor_variable
+                unwrapped_args.append(x.as_python_constant())
+        for k, v in kwargs:
+            if isinstance(
+                x,
+                (
+                    variables.UnspecializedNumpyVariable,
+                    variables.UnspecializedPythonVariable,
+                ),
+            ):
+                unwrapped_kwargs.update({k: v.raw_value})
+            else:
+                unwrapped_kwargs.update({k: v.as_python_constant()})
+        return unwrapped_args, unwrapped_kwargs
 
     def call_function(
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
@@ -224,16 +249,37 @@ class BuiltinVariable(VariableTracker):
                 ):
                     # Work around weird bug in hf_T5
                     fn, args = operator.add, [args[1], args[0]]
-                result = variables.TensorVariable.create(
-                    tx,
-                    tx.output.create_proxy(
-                        "call_function",
-                        fn,
-                        *proxy_args_kwargs(args, kwargs),
-                    ),
-                    **options,
+                proxy = tx.output.create_proxy(
+                    "call_function",
+                    fn,
+                    *proxy_args_kwargs(args, kwargs),
                 )
-                return self.wrap_as_unspecialized_if_needed(result, *args, **kwargs)
+                if self.unspec_numpy_args(*args, **kwargs):
+                    _args, _kwargs = self.unwrap_unspec_args_kwargs(args, kwargs)
+                    raw_value = self.fn(*_args, **_kwargs)
+                    return variables.UnspecializedNumpyVariable.create(
+                        tx,
+                        proxy,
+                        raw_value=raw_value,
+                        **options,
+                    )
+                elif self.unspec_python_args(*args, **kwargs):
+                    _args, _kwargs = self.unwrap_unspec_args_kwargs(args, kwargs)
+                    raw_value = self.fn(*_args, **_kwargs)
+                    need_unwrap = any(
+                        x.need_unwrap
+                        for x in itertools.chain(args, kwargs.values())
+                        if isinstance(x, variables.UnspecializedPythonVariable)
+                    )
+                    return variables.UnspecializedPythonVariable.create(
+                        tx,
+                        proxy,
+                        raw_value=raw_value,
+                        need_unwrap=need_unwrap,
+                        **options,
+                    )
+                else:
+                    return variables.TensorVariable.create(tx, proxy, **options)
 
             except NotImplementedError:
                 unimplemented(f"partial tensor op: {self} {args} {kwargs}")
@@ -291,7 +337,43 @@ class BuiltinVariable(VariableTracker):
                 fn = {max: torch.maximum, min: torch.minimum}[self.fn]
                 result = variables.TorchVariable(fn).call_function(tx, [a, b], {})
 
-            return self.wrap_as_unspecialized_if_needed(result, a, b)
+            # return unspec if both a, b are unspec or const
+            if all(
+                isinstance(
+                    i,
+                    (
+                        variables.UnspecializedNumpyVariable,
+                        variables.UnspecializedPythonVariable,
+                        variables.ConstantVariable,
+                    ),
+                )
+                for i in [a, b]
+            ):
+                if b.is_python_constant():
+                    raw_b = b.as_python_constant()
+                else:
+                    raw_b = b.raw_value
+                if self.fn is max:
+                    raw_res = max(a.raw_value, raw_b)
+                else:
+                    raw_res = min(a.raw_value, raw_b)
+
+                if isinstance(raw_res, np.number):
+                    return variables.UnspecializedNumpyVariable.from_tensor_variable(
+                        result, raw_res
+                    )
+                else:
+                    need_unwrap = any(
+                        x.need_unwrap
+                        for x in [a, b]
+                        if isinstance(x, variables.UnspecializedPythonVariable)
+                    )
+                    return variables.UnspecializedPythonVariable.from_tensor_variable(
+                        result, raw_res, need_unwrap
+                    )
+            # otherwise return tensor
+            else:
+                return result
         else:
             unimplemented(f"unsupported min / max over args {str(a)}, {str(b)}")
 

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -186,8 +186,13 @@ class BuiltinVariable(VariableTracker):
                     tensor_variable
                 )
             else:
+                need_unwrap = any(
+                    x.need_unwrap
+                    for x in itertools.chain(args, kwargs.values())
+                    if isinstance(x, variables.UnspecializedPythonVariable)
+                )
                 return variables.UnspecializedPythonVariable.from_tensor_variable(
-                    tensor_variable
+                    tensor_variable, need_unwrap
                 )
         else:
             return tensor_variable

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -5,6 +5,7 @@ import operator
 from contextlib import contextmanager
 from typing import Dict
 from typing import List
+import numpy as np
 
 import torch.fx
 import torch.random
@@ -552,7 +553,8 @@ class UnspecializedPrimitiveVariable(TensorVariable):
     e.g, int, float, np.int, np.float, etc
     """
 
-    @classmethod
-    def from_tensor_variable(cls, tensor_variable):
-        # Convert a `TensorVariable` instance into an `UnspecializedPrimitiveVariable` instance.
-        return cls(**dict(tensor_variable.__dict__))
+    def __init__(self, proxy, **kwargs):
+        assert "is_numpy_primitive" in kwargs
+        is_numpy_primitive = kwargs.pop("is_numpy_primitive")
+        super(UnspecializedPrimitiveVariable, self).__init__(proxy, **kwargs)
+        self.is_numpy_primitive = is_numpy_primitive

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -173,9 +173,14 @@ class TensorVariable(VariableTracker):
             and proxy.node.target == "item"
             and config.capture_scalar_outputs
         ):
-            return UnspecializedPrimitiveVariable.create(
-                tx=tx, proxy=proxy, example_value=torch.tensor(example_value)
-            )
+            if isinstance(example_value, np.number):
+                return UnspecializedNumpyVariable.create(
+                    tx=tx, proxy=proxy, example_value=torch.tensor(example_value)
+                )
+            else:
+                return UnspecializedPythonVariable.create(
+                    tx=tx, proxy=proxy, example_value=torch.tensor(example_value)
+                )
         else:
             assert (
                 False

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -176,6 +176,7 @@ class TensorVariable(VariableTracker):
                 tx=tx,
                 proxy=proxy,
                 example_value=torch.tensor(example_value),
+                raw_value=example_value,
                 need_unwrap=False,
                 **options,
             )
@@ -555,10 +556,17 @@ class UnspecializedNumpyVariable(TensorVariable):
     This is a 1-element tensor represents unspecialized numpy float/int.
     """
 
+    def __init__(self, proxy: torch.fx.Proxy, **kwargs):
+        raw_value = kwargs.pop("raw_value", True)
+        super(UnspecializedNumpyVariable, self).__init__(proxy, **kwargs)
+        self.raw_value = raw_value
+
     @classmethod
-    def from_tensor_variable(cls, tensor_variable):
+    def from_tensor_variable(cls, tensor_variable, raw_value):
         # Convert a `TensorVariable` instance into an `UnspecializedNumpyVariable` instance.
-        return UnspecializedNumpyVariable(**dict(tensor_variable.__dict__))
+        return UnspecializedNumpyVariable(
+            **dict(tensor_variable.__dict__), raw_value=raw_value
+        )
 
 
 class UnspecializedPythonVariable(TensorVariable):
@@ -567,13 +575,17 @@ class UnspecializedPythonVariable(TensorVariable):
     """
 
     def __init__(self, proxy: torch.fx.Proxy, **kwargs):
+        raw_value = kwargs.pop("raw_value", True)
         need_unwrap = kwargs.pop("need_unwrap", True)
         super(UnspecializedPythonVariable, self).__init__(proxy, **kwargs)
+        self.raw_value = raw_value
         self.need_unwrap = need_unwrap
 
     @classmethod
-    def from_tensor_variable(cls, tensor_variable, need_unwrap=True):
+    def from_tensor_variable(cls, tensor_variable, raw_value, need_unwrap=True):
         # Convert a `TensorVariable` instance into an `UnspecializedPythonVariable` instance.
         return UnspecializedPythonVariable(
-            **dict(tensor_variable.__dict__), need_unwrap=need_unwrap
+            **dict(tensor_variable.__dict__),
+            raw_value=raw_value,
+            need_unwrap=need_unwrap,
         )

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from typing import Dict
 from typing import List
 
-import numpy as np
 import torch.fx
 import torch.random
 from torch.fx.immutable_collections import immutable_list

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -552,4 +552,7 @@ class UnspecializedPrimitiveVariable(TensorVariable):
     e.g, int, float, np.int, np.float, etc
     """
 
-    pass
+    @classmethod
+    def from_tensor_variable(cls, tensor_variable):
+        # Convert a `TensorVariable` instance into an `UnspecializedPrimitiveVariable` instance.
+        return cls(**dict(tensor_variable.__dict__))

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -547,14 +547,23 @@ class TensorWithTFOverrideVariable(VariableTracker):
             return tx.inline_user_function_return(tf_func_var, tf_args, {})
 
 
-class UnspecializedPrimitiveVariable(TensorVariable):
+class UnspecializedNumpyVariable(TensorVariable):
     """
-    This is a 1-element tensor represents unspecialized primitive type,
-    e.g, int, float, np.int, np.float, etc
+    This is a 1-element tensor represents unspecialized numpy float/int.
     """
 
-    def __init__(self, proxy, **kwargs):
-        assert "is_numpy_primitive" in kwargs
-        is_numpy_primitive = kwargs.pop("is_numpy_primitive")
-        super(UnspecializedPrimitiveVariable, self).__init__(proxy, **kwargs)
-        self.is_numpy_primitive = is_numpy_primitive
+    @classmethod
+    def from_tensor_variable(cls, tensor_variable):
+        # Convert a `TensorVariable` instance into an `UnspecializedNumpyVariable` instance.
+        return UnspecializedNumpyVariable(**dict(tensor_variable.__dict__))
+
+
+class UnspecializedPythonVariable(TensorVariable):
+    """
+    This is a 1-element tensor represents unspecialized python float/int.
+    """
+
+    @classmethod
+    def from_tensor_variable(cls, tensor_variable):
+        # Convert a `TensorVariable` instance into an `UnspecializedPythonVariable` instance.
+        return UnspecializedPythonVariable(**dict(tensor_variable.__dict__))

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -5,8 +5,8 @@ import operator
 from contextlib import contextmanager
 from typing import Dict
 from typing import List
-import numpy as np
 
+import numpy as np
 import torch.fx
 import torch.random
 from torch.fx.immutable_collections import immutable_list

--- a/torchdynamo/variables/user_defined.py
+++ b/torchdynamo/variables/user_defined.py
@@ -137,11 +137,12 @@ class UserDefinedObjectVariable(UserDefinedVariable):
     @staticmethod
     @functools.lru_cache(None)
     def _supported_random_functions():
+        # func : example value
         fns = {
-            random.random,
-            random.randint,
-            random.randrange,
-            random.uniform,
+            random.random: 0.5,
+            random.randint: 10,
+            random.randrange: 20,
+            random.uniform: 1.5,
         }
         return fns
 
@@ -223,7 +224,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             and all(k.is_python_constant() for k in args)
             and all(v.is_python_constant() for v in kwargs.values())
         ):
-            example_value = 0.5
+            example_value = self._supported_random_functions()[self.value]
             source = RandomValueSource(random_call_index=len(tx.random_calls))
             tx.random_calls.append(
                 (

--- a/torchdynamo/variables/user_defined.py
+++ b/torchdynamo/variables/user_defined.py
@@ -1,6 +1,6 @@
-import functools
 import collections
 import dataclasses
+import functools
 import importlib
 import inspect
 import random

--- a/torchdynamo/variables/user_defined.py
+++ b/torchdynamo/variables/user_defined.py
@@ -203,13 +203,16 @@ class UserDefinedObjectVariable(UserDefinedVariable):
     def call_function(
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
     ) -> "VariableTracker":
-        from .builder import UnspecializedPrimitiveInfo
         from .builder import VariableBuilder
 
         if self.value is random.random:
-            example_value = random.random()
-            return VariableBuilder(tx, self.source).wrap_unspecialized_primitive(
-                example_value, UnspecializedPrimitiveInfo(True)
+            from torchdynamo.source import RandomValueSource
+
+            example_value = 0.5
+            source = RandomValueSource(random_call_index=tx.random_call_count)
+            tx.random_call_count += 1
+            return VariableBuilder(tx, source).wrap_unspecialized_primitive(
+                example_value,
             )
 
         return super().call_function(tx, args, kwargs)

--- a/torchdynamo/variables/user_defined.py
+++ b/torchdynamo/variables/user_defined.py
@@ -203,8 +203,8 @@ class UserDefinedObjectVariable(UserDefinedVariable):
     def call_function(
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
     ) -> "VariableTracker":
-        from .builder import VariableBuilder
         from .builder import UnspecializedPrimitiveInfo
+        from .builder import VariableBuilder
 
         if self.value is random.random:
             example_value = random.random()

--- a/torchdynamo/variables/user_defined.py
+++ b/torchdynamo/variables/user_defined.py
@@ -15,6 +15,7 @@ from ..guards import Guard
 from ..guards import GuardBuilder
 from ..source import AttrSource
 from ..source import ODictGetItemSource
+from ..source import RandomValueSource
 from ..utils import is_namedtuple_cls
 from ..utils import namedtuple_fields
 from .base import MutableLocal
@@ -206,13 +207,11 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         from .builder import VariableBuilder
 
         if self.value is random.random:
-            from torchdynamo.source import RandomValueSource
-
             example_value = 0.5
             source = RandomValueSource(random_call_index=tx.random_call_count)
             tx.random_call_count += 1
             return VariableBuilder(tx, source).wrap_unspecialized_primitive(
-                example_value,
+                example_value
             )
 
         return super().call_function(tx, args, kwargs)

--- a/torchdynamo/variables/user_defined.py
+++ b/torchdynamo/variables/user_defined.py
@@ -2,6 +2,7 @@ import collections
 import dataclasses
 import importlib
 import inspect
+import random
 import types
 from typing import Dict
 from typing import List
@@ -198,6 +199,20 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 )
 
         return super().call_method(tx, name, args, kwargs)
+
+    def call_function(
+        self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
+    ) -> "VariableTracker":
+        from .builder import VariableBuilder
+        from .builder import UnspecializedPrimitiveInfo
+
+        if self.value is random.random:
+            example_value = random.random()
+            return VariableBuilder(tx, self.source).wrap_unspecialized_primitive(
+                example_value, UnspecializedPrimitiveInfo(True)
+            )
+
+        return super().call_function(tx, args, kwargs)
 
     def _check_for_getattribute(self):
         try:


### PR DESCRIPTION
This is follow up of https://github.com/pytorch/torchdynamo/pull/321, so please aware of changes in that PR when you review this one. (I think we should combine these two PRs together, my bad!)

[TorchDynamo supports unspecialized primitive type design doc](https://docs.google.com/document/d/1UxbO0XmXixXqukOeFkWNV-9-6F6AZ71dpNmdNL1cWQw/edit#)

major changes:
* Add ```UnspecializedNumpyVariable``` and ```UnspecializedPythonVariable```.
* Update the builtin function logic:
  * Tensor op others -> Tensor
  * Unspecialized op (Unspecialized, Constant) -> Unspecialized
 * Initial implementation to support ```random``` functions.

