### PR TITLE
Added option use_bmm to enable triton codegen for bmm

### DIFF
--- a/microbenchmarks/inductor_bmm.py
+++ b/microbenchmarks/inductor_bmm.py
@@ -4,7 +4,6 @@ import torchdynamo
 import torchdynamo.config
 import torchinductor.config as config
 
-
 @torchdynamo.optimize("inductor", nopython=True)
 def inductor_aten_bmm(a, b):
     return torch.bmm(a, b)
@@ -25,12 +24,10 @@ def test_total_time(shapes):
         b = torch.randn(b_shape, device='cuda', dtype=a.dtype)
 
         config.triton.use_bmm = False
-        inductor_aten_bmm(a, b)
+        c1 = inductor_aten_bmm(a, b)
 
         config.triton.use_bmm = True
-        c = inductor_triton_bmm(a, b)
-        print(c)
-        print(torch_bmm(a, b))
+        c2 = inductor_triton_bmm(a, b)
 
         torch_ms = time_with_torch_timer(torch_bmm, (a, b)).mean * 1000
 

--- a/microbenchmarks/inductor_bmm.py
+++ b/microbenchmarks/inductor_bmm.py
@@ -1,0 +1,64 @@
+import torch
+from benchmark_helper import time_with_torch_timer
+import torchdynamo
+import torchdynamo.config
+import torchinductor.config as config
+
+
+@torchdynamo.optimize("inductor", nopython=True)
+def inductor_aten_bmm(a, b):
+    return torch.bmm(a, b)
+
+@torchdynamo.optimize("inductor", nopython=True)
+def inductor_triton_bmm(a, b):
+    return torch.bmm(a, b)
+
+def torch_bmm(a, b):
+    return torch.bmm(a, b)
+
+def test_total_time(shapes):
+    print('shape; torch bmm; inductor aten bmm; inductor triton bmm')
+    for i in range(len(shapes)):
+        a_shape, b_shape = shapes[i]
+        print(a_shape, 'x', b_shape, end='; ')
+        a = torch.randn(a_shape, device='cuda', dtype=torch.float16)
+        b = torch.randn(b_shape, device='cuda', dtype=a.dtype)
+
+        config.triton.use_bmm = False
+        inductor_aten_bmm(a, b)
+
+        config.triton.use_bmm = True
+        c = inductor_triton_bmm(a, b)
+        print(c)
+        print(torch_bmm(a, b))
+
+        torch_ms = time_with_torch_timer(torch_bmm, (a, b)).mean * 1000
+
+        config.triton.use_bmm = False
+        ind_aten_ms = time_with_torch_timer(inductor_aten_bmm, (a, b)).mean * 1000
+
+        config.triton.use_bmm = True
+        ind_triton_ms = time_with_torch_timer(inductor_triton_bmm, (a, b)).mean * 1000
+
+        print(torch_ms, ind_aten_ms, ind_triton_ms, sep='; ')
+      
+
+if __name__ == "__main__":
+    shapes = [
+        # BERT (all)
+        ([192, 128, 64], [192, 64, 128]),
+        ([192, 128, 128], [192, 128, 64]),
+        # hf_GPT2 (all)
+        ([12, 1024, 1024], [12, 1024, 64]), 
+        ([12, 1024, 64], [12, 64, 1024]),
+        # hf_Albert (all)
+        ([12, 512, 64], [12, 64, 512]),
+        ([12, 512, 512], [12, 512, 64]),
+    ]
+    
+    test_total_time(shapes)
+
+      
+
+
+

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -92,7 +92,7 @@ class WrapperCodeGen(CodeGen):
                 self.header.writeline(
                     "from torchinductor.triton_ops.batched_matmul import bmm_out as triton_bmm_out"
                 )
-            
+
         self.prefix.writelines(
             ["", "", f"def call({', '.join(V.graph.graph_inputs.keys())}):"]
         )

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -88,6 +88,11 @@ class WrapperCodeGen(CodeGen):
                     "from torchinductor.triton_ops.matmul import matmul_out as triton_mm_out"
                 )
 
+            if config.triton.use_bmm:
+                self.header.writeline(
+                    "from torchinductor.triton_ops.batched_matmul import bmm_out as triton_bmm_out"
+                )
+            
         self.prefix.writelines(
             ["", "", f"def call({', '.join(V.graph.graph_inputs.keys())}):"]
         )

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -65,3 +65,5 @@ class triton:
 
     # enable codegen to use Triton's mm
     use_mm = False
+
+    use_bmm = False

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1776,6 +1776,15 @@ class MatrixMultiply(ExternKernelOut):
 class BatchMatrixMultiply(ExternKernelOut):
     kernel = "aten.bmm.out"
 
+    def __init__(self, layout, inputs, constant_args=(), output_view=None):
+        super().__init__(layout, inputs, constant_args, output_view)
+        if (
+            config.triton.use_bmm
+            and len(inputs) > 0
+            and inputs[0].get_device().type == "cuda"
+        ):
+            self.kernel = "triton_bmm_out"
+
     @classmethod
     def create(cls, a, b):
         b1, m, k1 = a.get_size()

--- a/torchinductor/triton_ops/batched_matmul.py
+++ b/torchinductor/triton_ops/batched_matmul.py
@@ -1,0 +1,254 @@
+import torch
+import triton
+import triton.language as tl
+from triton.ops.matmul_perf_model import early_config_prune
+from triton.ops.matmul_perf_model import estimate_matmul_time
+
+
+def init_to_zero(name):
+    return lambda nargs: nargs[name].zero_()
+
+
+def get_configs_io_bound():
+    configs = []
+    for num_stages in [2, 3, 4, 5, 6]:
+        for block_m in [16, 32]:
+            for block_k in [32, 64]:
+                for block_n in [32, 64, 128, 256]:
+                    num_warps = 2 if block_n <= 64 else 4
+                    configs.append(
+                        triton.Config(
+                            {
+                                "BLOCK_M": block_m,
+                                "BLOCK_N": block_n,
+                                "BLOCK_K": block_k,
+                                "SPLIT_K": 1,
+                            },
+                            num_stages=num_stages,
+                            num_warps=num_warps,
+                        )
+                    )
+                    # split_k
+                    for split_k in [2, 4, 8, 16]:
+                        configs.append(
+                            triton.Config(
+                                {
+                                    "BLOCK_M": block_m,
+                                    "BLOCK_N": block_n,
+                                    "BLOCK_K": block_k,
+                                    "SPLIT_K": split_k,
+                                },
+                                num_stages=num_stages,
+                                num_warps=num_warps,
+                                pre_hook=init_to_zero("C"),
+                            )
+                        )
+    return configs
+
+
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0,
+    }
+)
+@triton.autotune(
+    configs=[
+        # basic configs for compute-bound matmuls
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=5,
+            num_warps=2,
+        ),
+        # good for int8
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=5,
+            num_warps=2,
+        ),
+    ]
+    + get_configs_io_bound(),
+    key=["M", "N", "K"],
+    prune_configs_by={
+        "early_config_prune": early_config_prune,
+        "perf_model": estimate_matmul_time,
+        "top_k": 10,
+    },
+)
+@triton.jit
+def _kernel(
+    A,
+    B,
+    C,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    ACC_TYPE: tl.constexpr,
+):
+    # matrix multiplication
+
+    pid = tl.program_id(0)
+    pid_z = tl.program_id(1)
+    bid = tl.program_id(2)
+    grid_m = (M + BLOCK_M - 1) // BLOCK_M
+    grid_n = (N + BLOCK_N - 1) // BLOCK_N
+    # re-order program ID for better L2 performance
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // (group_size)
+    # do matrix multiplication
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    rk = pid_z * BLOCK_K + tl.arange(0, BLOCK_K)
+    # pointers
+    A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
+    B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
+    A += bid * M * K
+    B += bid * K * N
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+    for k in range(K, 0, -BLOCK_K * SPLIT_K):
+        if EVEN_K:
+            a = tl.load(A)
+            b = tl.load(B)
+        else:
+            a = tl.load(A, mask=rk[None, :] < k, other=0.0)
+            b = tl.load(B, mask=rk[:, None] < k, other=0.0)
+        acc += tl.dot(a, b)
+        A += BLOCK_K * SPLIT_K * stride_ak
+        B += BLOCK_K * SPLIT_K * stride_bk
+    acc = acc.to(C.dtype.element_ty)
+    # rematerialize rm and rn to save registers
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    C = C + (rm[:, None] * stride_cm + rn[None, :] * stride_cn)
+    C += bid * M * N
+    mask = (rm < M)[:, None] & (rn < N)[None, :]
+    # handles write-back with reduction-splitting
+    if SPLIT_K == 1:
+        tl.store(C, acc, mask=mask)
+    else:
+        tl.atomic_add(C, acc, mask=mask)
+
+
+def bmm_out(a, b, out):
+    device = a.device
+    # handle non-contiguous inputs if necessary
+    if a.stride(0) > 1 and a.stride(1) > 1:
+        a = a.contiguous()
+    if b.stride(0) > 1 and b.stride(1) > 1:
+        b = b.contiguous()
+    # checks constraints
+    assert a.shape[2] == b.shape[1], "incompatible dimensions"
+    B, M, K = a.shape
+    _, _, N = b.shape
+    # allocates output
+    c = out
+    # c = torch.empty((B, M, N), device=device, dtype=a.dtype)
+    # accumulator types
+    ACC_TYPE = (
+        tl.float32
+        if a.dtype in [torch.float16, torch.bfloat16, torch.float32]
+        else tl.int32
+    )
+    # launch kernel
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        META["SPLIT_K"],
+        B,
+    )
+    _kernel[grid](a, b, c, M, N, K, K, 1, N, 1, N, 1, GROUP_M=8, ACC_TYPE=ACC_TYPE)

--- a/torchinductor/triton_ops/batched_matmul.py
+++ b/torchinductor/triton_ops/batched_matmul.py
@@ -1,4 +1,5 @@
 from enum import auto
+
 import torch
 import triton
 import triton.language as tl
@@ -16,8 +17,7 @@ def init_to_zero(name):
     }
 )
 @triton.autotune(
-    configs=
-    [
+    configs=[
         # basic configs for compute-bound matmuls
         triton.Config(
             {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
@@ -64,7 +64,6 @@ def init_to_zero(name):
             num_stages=5,
             num_warps=2,
         ),
-
         # additional configs
         triton.Config(
             {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 64, "SPLIT_K": 1},
@@ -91,7 +90,6 @@ def init_to_zero(name):
             num_stages=2,
             num_warps=4,
         ),
-
         # additional configs for K = 64
         triton.Config(
             {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 64, "SPLIT_K": 1},
@@ -118,9 +116,6 @@ def init_to_zero(name):
             num_stages=1,
             num_warps=4,
         ),
-
-
-
         triton.Config(
             {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
             num_stages=4,
@@ -141,8 +136,6 @@ def init_to_zero(name):
             num_stages=5,
             num_warps=2,
         ),
-
-
         triton.Config(
             {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
             num_stages=1,
@@ -165,9 +158,7 @@ def init_to_zero(name):
         ),
     ],
     # + get_configs_io_bound(),
-
     key=["M", "N", "K"],
-
     #
     # key=["M", "N", "K"],
     # prune_configs_by={

--- a/torchinductor/triton_ops/batched_matmul.py
+++ b/torchinductor/triton_ops/batched_matmul.py
@@ -151,7 +151,7 @@ def get_configs_io_bound():
     prune_configs_by={
         "early_config_prune": early_config_prune,
         "perf_model": estimate_matmul_time,
-        "top_k": 10,
+        "top_k": 18,
     },
 )
 @triton.jit

--- a/torchinductor/triton_ops/batched_matmul.py
+++ b/torchinductor/triton_ops/batched_matmul.py
@@ -1,10 +1,9 @@
-from enum import auto
-
 import torch
 import triton
 import triton.language as tl
-from triton.ops.matmul_perf_model import early_config_prune
-from triton.ops.matmul_perf_model import estimate_matmul_time
+
+# from triton.ops.matmul_perf_model import early_config_prune
+# from triton.ops.matmul_perf_model import estimate_matmul_time
 
 
 def init_to_zero(name):
@@ -271,7 +270,7 @@ def bmm_out(a, b, out):
     #     B,
     # )
 
-    autotuner = _kernel[grid].kernel
+    # autotuner = _kernel[grid].kernel
     _kernel[grid](a, b, c, M, N, K, K, 1, N, 1, N, 1, GROUP_M=8, ACC_TYPE=ACC_TYPE)
     # print(autotuner.best_config)
     # print(autotuner.configs_timings)


### PR DESCRIPTION
Added an initial triton implementation of bmm and an option `use_bmm` to enable that in torchinductor. Modified `ir.py` and `wrapper.py` similarly as before.