### PR TITLE
Added more shapes to the inductor mm test

### DIFF
--- a/microbenchmarks/benchmark_helper.py
+++ b/microbenchmarks/benchmark_helper.py
@@ -2,16 +2,12 @@ import torch
 import time
 from torch.utils.benchmark import Timer
 
-def time_with_torch_timer(fn, args, string_id="function", kwargs={}, 
-                            iters=100, mean=True, median=False):
+def time_with_torch_timer(fn, args, kwargs={}, iters=100):
     env = {"args": args, "kwargs": kwargs, "fn": fn}
     fn_call = "fn(*args, **kwargs)"
     
     # Measure end-to-end time
     timer = Timer(stmt=f"{fn_call}", globals=env)
-    
     tt = timer.timeit(iters)
-    if mean:
-        print(f"{string_id}\t mean: {tt.mean * 1000:.4f} ms")
-    if median:
-        print(f"{string_id}\t median: {tt.median * 1000:.4f} ms")
+
+    return tt

--- a/microbenchmarks/inductor_mm.py
+++ b/microbenchmarks/inductor_mm.py
@@ -1,4 +1,5 @@
 import torch
+import triton
 from benchmark_helper import time_with_torch_timer
 import torchdynamo
 import torchdynamo.config
@@ -14,15 +15,16 @@ def inductor_triton_mm(a, b):
     return torch.mm(a, b)
 
 def torch_mm(a, b):
-    return torch.matmul(a, b)
+    return torch.mm(a, b)
 
-def alexnet_matmuls():
-    a_shapes = [[128, 9216], [128, 4096], [128, 4096]]
-    b_shapes = [[9216, 4096], [4096, 4096], [4096, 1000]]
-    for i in range(len(a_shapes)):
-        a_shape = a_shapes[i]
-        b_shape = b_shapes[i]
-        print("Shape:", a_shape, 'x', b_shape)
+def triton_mm(a, b):
+    return triton.ops.matmul(a, b)
+
+def test_total_time(shapes):
+    print('shape; torch mm; triton mm; inductor aten mm; inductor triton mm')
+    for i in range(len(shapes)):
+        a_shape, b_shape = shapes[i]
+        print(a_shape, 'x', b_shape, end='; ')
         a = torch.randn(a_shape, device='cuda', dtype=torch.float16)
         b = torch.randn(b_shape, device='cuda', dtype=a.dtype)
 
@@ -32,35 +34,93 @@ def alexnet_matmuls():
         config.triton.use_mm = True
         inductor_triton_mm(a, b)
 
-        time_with_torch_timer(torch_mm, (a, b), string_id="torch mm")
+        torch_ms = time_with_torch_timer(torch_mm, (a, b)).mean * 1000
+
+        triton_ms = time_with_torch_timer(triton_mm, (a, b)).mean * 1000
 
         config.triton.use_mm = False
-        time_with_torch_timer(inductor_aten_mm, (a, b), string_id="inductor aten mm")
+        ind_aten_ms = time_with_torch_timer(inductor_aten_mm, (a, b)).mean * 1000
 
         config.triton.use_mm = True
-        time_with_torch_timer(inductor_triton_mm, (a, b), string_id="inductor triton mm")
+        ind_triton_ms = time_with_torch_timer(inductor_triton_mm, (a, b)).mean * 1000
+
+        print(torch_ms, triton_ms, ind_aten_ms, ind_triton_ms, sep='; ')
+
+        torchdynamo.reset()
+
+def test_GPU_time(shapes):
+    print('shape; torch mm; triton mm; inductor aten mm; inductor triton mm')
+    for i in range(len(shapes)):
+        a_shape, b_shape = shapes[i]
+        print(a_shape, 'x', b_shape, end='; ')
+        a = torch.randn(a_shape, device='cuda', dtype=torch.float16)
+        b = torch.randn(b_shape, device='cuda', dtype=a.dtype)
+
+        config.triton.use_mm = False
+        inductor_aten_mm(a, b)
+
+        config.triton.use_mm = True
+        inductor_triton_mm(a, b)
+
+        torch_ms, _, _ = triton.testing.do_bench(lambda: torch_mm(a, b))
+        triton_ms, _, _ = triton.testing.do_bench(lambda: triton_mm(a, b))
+        ind_aten_ms, _, _ = triton.testing.do_bench(lambda: inductor_aten_mm(a, b))
+        ind_triton_ms, _, _ = triton.testing.do_bench(lambda: inductor_triton_mm(a, b))
+        print(torch_ms, triton_ms, ind_aten_ms, ind_triton_ms, sep='; ')
+
+        torchdynamo.reset()
       
 
 if __name__ == "__main__":
-    alexnet_matmuls()
+    shapes = [
+        # alexnet
+        ([128, 9216], [9216, 4096]),
+        ([128, 4096], [4096, 4096]),
+        ([128, 4096], [4096, 1000]),
+        # BERT
+        ([2048, 768], [768, 768]),
+        ([2048, 768], [768, 3072]),
+        ([2048, 3072], [3072, 768]),
+        # hf_GPT2
+        ([1024, 768], [768, 768]),
+        ([1024, 768], [768, 3072]),
+        ([1024, 3072], [3072, 768]),
+        ([1024, 768], [768, 2304]),
+    ]
+    print('test total time')
+    test_total_time(shapes)
+
+    print('test GPU time')
+    test_GPU_time(shapes)
 
       
 
 
 
-
-# Results preview
+# Results Preview on AWS AI cluster
 '''
-Shape: [128, 9216] x [9216, 4096]
-torch mm         mean: 0.0880 ms
-inductor aten mm         mean: 0.2163 ms
-inductor triton mm       mean: 0.2043 ms
-Shape: [128, 4096] x [4096, 4096]
-torch mm         mean: 0.0341 ms
-inductor aten mm         mean: 0.0997 ms
-inductor triton mm       mean: 0.1002 ms
-Shape: [128, 4096] x [4096, 1000]
-torch mm         mean: 0.0215 ms
-inductor aten mm         mean: 0.0310 ms
-inductor triton mm       mean: 0.0375 ms
+test total time
+shape; torch mm; triton mm; inductor aten mm; inductor triton mm
+[128, 9216] x [9216, 4096]; 0.07240759208798409; 0.10885953903198242; 0.20063146017491817; 0.20054904278367758
+[128, 4096] x [4096, 4096]; 0.03640300128608942; 0.10960095096379519; 0.09948539081960917; 0.0996188772842288
+[128, 4096] x [4096, 1000]; 0.02215010579675436; 0.12592008337378502; 0.031120930798351765; 0.0370654184371233
+[2048, 768] x [768, 768]; 0.023501068353652954; 0.10804693214595318; 0.03004650119692087; 0.0276932492852211
+[2048, 768] x [768, 3072]; 0.045639658346772194; 0.10883208829909563; 0.062736920081079; 0.06480381824076176
+[2048, 3072] x [3072, 768]; 0.054093082435429096; 0.10804777964949608; 0.08744294755160809; 0.07766005117446184
+[1024, 768] x [768, 768]; 0.021525858901441097; 0.10909941978752613; 0.02656651195138693; 0.02683836966753006
+[1024, 768] x [768, 3072]; 0.027319076471030712; 0.10825308971107006; 0.040118801407516; 0.039282338693737984
+[1024, 3072] x [3072, 768]; 0.034132059663534164; 0.10594133753329515; 0.05069758277386427; 0.04572632722556591
+[1024, 768] x [768, 2304]; 0.02529360819607973; 0.10486091021448374; 0.03724239766597748; 0.036449190229177475
+test GPU time
+shape; torch mm; triton mm; inductor aten mm; inductor triton mm
+[128, 9216] x [9216, 4096]; 0.09113600105047226; 0.09011200070381165; 0.21606400609016418; 0.21606400609016418
+[128, 4096] x [4096, 4096]; 0.053247999399900436; 0.05222399905323982; 0.1157120019197464; 0.1157120019197464
+[128, 4096] x [4096, 1000]; 0.026623999699950218; 0.02969600073993206; 0.04710400104522705; 0.05222399905323982
+[2048, 768] x [768, 768]; 0.02457600086927414; 0.020479999482631683; 0.04095999896526337; 0.03993599861860275
+[2048, 768] x [768, 3072]; 0.05119999870657921; 0.05222399905323982; 0.07475200295448303; 0.07577600330114365
+[2048, 3072] x [3072, 768]; 0.05939200147986412; 0.05222399905323982; 0.09830400347709656; 0.0870399996638298
+[1024, 768] x [768, 768]; 0.01945599913597107; 0.016383999958634377; 0.03276799991726875; 0.03276799991726875
+[1024, 768] x [768, 3072]; 0.03174399957060814; 0.03276799991726875; 0.053247999399900436; 0.053247999399900436
+[1024, 3072] x [3072, 768]; 0.04403200000524521; 0.03379200026392937; 0.06860800087451935; 0.062463998794555664
+[1024, 768] x [768, 2304]; 0.02969600073993206; 0.02969600073993206; 0.04915200173854828; 0.048128001391887665
 '''


### PR DESCRIPTION
Revised the `inductor_mm.py` microbenchmark, and added more shapes from TorchBench. The results are shown in this [post](https://fb.workplace.com/groups/348579864025213/permalink/348726040677262/). Basically `inductor triton mm` achieved comparable performance with `inductor aten mm` on all these shapes.