### PR TITLE
Reducing overhead of has_tensor_in_frame

### DIFF
--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -163,7 +163,11 @@ def has_tensor_in_frame(frame):
         elif is_namedtuple(obj):
             seen_ids[obj_id] = any([has_tensor(getattr(obj, v)) for v in obj._fields])
             return seen_ids[obj_id]
-        elif hasattr(obj, "__dict__") and len(getattr(obj, "__dict__")):
+        elif (
+            not is_allowed(obj)
+            and hasattr(obj, "__dict__")
+            and len(getattr(obj, "__dict__"))
+        ):
             seen_ids[obj_id] = any([has_tensor(v) for v in obj.__dict__.values()])
             return seen_ids[obj_id]
         else:


### PR DESCRIPTION
For few of the PyTorch tests, PyTorch tests were timing out because has_tensor_in_frame is walking through a very large dict. This PR guards the recursion on custom objects, which significantly cuts down the time.