### PR TITLE
Shape guard and isinstance fixes

### DIFF
--- a/tests/test_repros.py
+++ b/tests/test_repros.py
@@ -727,6 +727,18 @@ class TransformerEncoderLayer(nn.Module):
         return self.ff_block(x)
 
 
+class TestModule(torch.nn.Module):
+    def inner_fn(self, left, right):
+        return tuple(left) == tuple(right)
+
+    def fn(self, tensor):
+        if type(tensor) is int:
+            return False
+
+        torch.add(tensor, tensor)
+        return self.inner_fn(tensor.shape, (1, 2, 3))
+
+
 class ReproTests(torchdynamo.testing.TestCase):
     def test_do_paste_mask(self):
         torchdynamo.utils.counters.clear()
@@ -1275,3 +1287,29 @@ class ReproTests(torchdynamo.testing.TestCase):
             return torch.ops.aten.absolute(x)
 
         fn(torch.randn(3))
+
+    def test_guard_ordering_shape_fail(self):
+        # If a function which takes a tensor has an inner function which
+        # is compiled and generates a guard on its shape,
+        # they are evaluated in the wrong order. So if on a subsequent call
+        # an int is passed instead of a tensor, guard evaluation will crash
+        # with a "no attribute: shape" error
+        m = TestModule()
+        with torchdynamo.optimize("eager"):
+            m.fn(torch.ones((5, 5)))
+            m.fn(-3)
+
+    def test_tensor_isinstance_tuple(self):
+        @torchdynamo.optimize("eager")
+        def fn():
+            t = torch.ones(5, 5)
+            if not isinstance(t, (int, torch.Tensor)):
+                msg = str.format(
+                    "{0} is not an instance of {1}",
+                    type(t),
+                    (int, torch.Tensor),
+                )
+                raise ValueError(msg)
+            return True
+
+        fn()

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -311,7 +311,9 @@ def convert_frame_assert(compiler_fn: Callable, one_graph=True):
                 print()
             assert output.guards is not None
             CleanupManager.instance[code] = output.cleanups
-            return GuardedCode(code, output.guards, frame.f_locals, frame.f_globals)
+            return GuardedCode(
+                code, sorted(output.guards), frame.f_locals, frame.f_globals
+            )
         except (Unsupported, TorchRuntimeError):
             debug_print("WONT CONVERT")
             raise

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -311,9 +311,7 @@ def convert_frame_assert(compiler_fn: Callable, one_graph=True):
                 print()
             assert output.guards is not None
             CleanupManager.instance[code] = output.cleanups
-            return GuardedCode(
-                code, sorted(output.guards), frame.f_locals, frame.f_globals
-            )
+            return GuardedCode(code, output.guards, frame.f_locals, frame.f_globals)
         except (Unsupported, TorchRuntimeError):
             debug_print("WONT CONVERT")
             raise

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -279,12 +279,9 @@ class TensorVariable(VariableTracker):
 
         # Add a guard for type matching, these guards are checked before tensor guards
         # In some cases, a <tensor>.<attr> guard can be evaluated first, and break if
-        # <tensor> is later changed another type
-        try:
-            if result is not None:
-                result = result.add_guard(self.create_guard(GuardBuilder.TYPE_MATCH))
-        except NotImplementedError:
-            pass
+        # <tensor> is later changed to another type
+        if result is not None and self.source is not None:
+            result = result.add_guard(self.create_guard(GuardBuilder.TYPE_MATCH))
 
         if result is None:
             raise NotImplementedError()


### PR DESCRIPTION
Fixes two issues:
* isinstance would return false when called on a tensor and tuple containing the tensor type
* shape guards are sometimes be evaluated before tensor guards, causing guards to crash if the function involved was later called on a type without the shape attribute, this adds an additional type guard when adding shape guards

See the attached issues for more details.