### PR TITLE
Propagate guards from ConstDict variables

### DIFF
--- a/tests/test_repros.py
+++ b/tests/test_repros.py
@@ -1321,3 +1321,14 @@ class ReproTests(torchdynamo.testing.TestCase):
             return x
 
         fn(torch.randn(3))
+
+    def test_dict_list_values(self):
+        def inner_fn(args):
+            return [x[1].shape for x in args]
+
+        @torchdynamo.optimize("eager")
+        def fn(tensors):
+            return inner_fn(zip(itertools.count(), tensors["args"]))
+
+        fn({"args": [torch.ones(5, 5), torch.ones(5, 6), torch.ones(5, 7)]})
+        fn({"args": [torch.ones(5, 5)]})

--- a/torchdynamo/variables/base.py
+++ b/torchdynamo/variables/base.py
@@ -54,6 +54,9 @@ class VariableTracker:
                 guards.update(var.guards)
                 for i in var.items:
                     visit(i)
+            elif isinstance(var, variables.ConstDictVariable):
+                guards.update(var.guards)
+                visit(var.items.values())
             else:
                 assert isinstance(var, VariableTracker), typestr(var)
                 guards.update(var.guards)


### PR DESCRIPTION
If a dict input contains a value which is a list of tensors we would not properly propagate guards for the list of tensors. Specifically, torchdynamo generates guards for the tensors but would not propagate the guards for the list itself. As a result, subsequent calls with lists of smaller lengths would cause guard evaluation to crash with list index out of range errors.