### PR TITLE
Removing generation field from the patched nn.Module

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1734,6 +1734,6 @@ class TestTracer(JitTestCase):
 
             return torch.jit.trace(f, (torch.rand(3, 4),))
 
-        eager = fn()
+        fn()
         with torchdynamo.optimize("eager"):
-            dynamo = fn()
+            fn()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1710,6 +1710,7 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertEqual(y, 11)
         self.assertEqual(z, 61)
 
+
 class TestTracer(JitTestCase):
     def test_jit_save(self):
         def fn():

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -10,6 +10,7 @@ from torch.nn.parameter import UninitializedParameter
 
 import torchdynamo.testing
 from torchdynamo.eval_frame import unsupported
+from torchdynamo.mutation_guard import GenerationTracker
 
 from . import test_functions
 
@@ -682,18 +683,18 @@ class NNModuleTests(torchdynamo.testing.TestCase):
             pass
 
         m1 = torch.nn.Linear(10, 10)
-        prev_generation = m1.generation
+        prev_generation = GenerationTracker.get_generation_value(m1)
         cur_generation = prev_generation + 1
 
         with torchdynamo.optimize_assert(cnt):
             m2 = torch.nn.Linear(10, 10)
 
-        self.assertEqual(m1.generation, prev_generation)
-        self.assertEqual(m2.generation, cur_generation)
+        self.assertEqual(GenerationTracker.get_generation_value(m1), prev_generation)
+        self.assertEqual(GenerationTracker.get_generation_value(m2), cur_generation)
         # check that newly constructed instances
         # also have the same generation (even if copied from an old instance)
         m3 = deepcopy(m1)
-        self.assertEqual(m3.generation, cur_generation)
+        self.assertEqual(GenerationTracker.get_generation_value(m3), cur_generation)
 
     def test_simple_torch_function(self):
         def foo(x):

--- a/torchdynamo/mutation_guard.py
+++ b/torchdynamo/mutation_guard.py
@@ -56,10 +56,11 @@ def ensure_patched(cls):
 class GenerationTracker:
     generation = 0
     dynamic_classes = ExactWeakKeyDictionary()
+    generation_values = ExactWeakKeyDictionary()
 
     @classmethod
     def tag(cls, obj):
-        obj.generation = cls.generation
+        cls.generation_values[obj] = cls.generation
 
     @staticmethod
     def mark_class_dynamic(cls):
@@ -67,8 +68,17 @@ class GenerationTracker:
         GenerationTracker.dynamic_classes[cls] = True
 
     @classmethod
+    def get_generation_value(cls, obj):
+        if obj not in cls.generation_values:
+            return -1
+        return cls.generation_values[obj]
+
+    @classmethod
     def check(cls, obj):
-        return getattr(obj, "generation", -1) == cls.generation
+        return (
+            obj in cls.generation_values
+            and cls.generation_values[obj] == cls.generation
+        )
 
 
 def is_dynamic_nn_module(obj):


### PR DESCRIPTION
Asking for comments here.

Current patching adds a new field `generation` into the Module object. `torch.jit.save` and `torch.jit.load` causes problems because of this. 
