### PR TITLE
Remove unnecessary call to clone in torchdynamo context entry

### DIFF
--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -109,9 +109,9 @@ def wrap_convert_context(fn):
     @functools.wraps(fn)
     def _fn(*args, **kwargs):
         prior_grad_mode = torch.is_grad_enabled()
-        rng_state = torch.clone(torch.random.get_rng_state())
+        rng_state = torch.random.get_rng_state()
         if torch.cuda.is_available():
-            cuda_rng_state = torch.clone(torch.cuda.get_rng_state())
+            cuda_rng_state = torch.cuda.get_rng_state()
         prior_fwd_from_src = torch.fx.graph_module._forward_from_src
         torch.fx.graph_module._forward_from_src = fx_forward_from_src_skip_result
         try:


### PR DESCRIPTION
This call to `clone` causes a segfault in some (~30) pytorch tests. It's unnecessary because the tensor returned is already independent from the rng. See [this code](https://pytorch.org/docs/stable/_modules/torch/random.html#get_rng_state:~:text=.contextmanager%0Adef-,fork_rng,-\(devices%3D) for confirmation

