### PR TITLE
Disable TorchDynamo on frames created by fx symbolic tracing

### DIFF
--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -281,6 +281,9 @@ class TorchPatcher:
         torch.jit.trace_module = disable(torch.jit.trace_module)
         torch.jit._get_trace_graph = disable(torch.jit._get_trace_graph)
 
+        # symbolic_trace creates new frames. We disable Dynamo on such frames
+        torch.fx.symbolic_trace = disable(torch.fx.symbolic_trace)
+
         torch.onnx.export_to_pretty_string = disable(torch.onnx.export_to_pretty_string)
         torch.distributions.Distribution.set_default_validate_args(False)
 


### PR DESCRIPTION
@jansel Does it make sense? Basically, symbolic tracing creates new frames and Dynamo starts to modify them and then given them back to Fx tracer. Therefore, I am just disabling it.