### PR TITLE
[inductor] Support scatter operations

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -143,6 +143,7 @@ def check_model(self: TestCase, model, example_inputs, tol=1e-4, check_lowp=True
     if has_lowp_args:
         if hasattr(model, "to"):
             model = model.to(torch.float)
+    torch.manual_seed(0)
     correct = model(*upcasted_inputs)
     # downcast the model back if needed
     if has_lowp_args:
@@ -155,6 +156,7 @@ def check_model(self: TestCase, model, example_inputs, tol=1e-4, check_lowp=True
 
     torchdynamo.reset()
     with unittest.mock.patch("torchdynamo.config.raise_on_backend_error", True):
+        torch.manual_seed(0)
         actual = run(*example_inputs)
 
     assert type(actual) == type(correct)
@@ -1902,6 +1904,101 @@ class CommonTemplate:
                 torch.randn(6, 128, 100),
             ],
         )
+
+    def test_index_put1(self):
+        def fn(a, b, c):
+            return (
+                torch.index_put(a, [b], c),
+                torch.index_put_(a + 1, [b + 1], c + 1) + 1,
+            )
+
+        self.common(
+            fn,
+            [
+                torch.randn([800, 256, 7, 7]),
+                torch.randperm(601),
+                torch.randn([601, 256, 7, 7]),
+            ],
+        )
+
+    def test_index_put2(self):
+        def fn(a, b, c):
+            return torch.index_put(a, [b], c, True)
+
+        self.common(
+            fn,
+            [
+                torch.randn([100, 256, 7, 7]),
+                torch.randint(0, 100, size=[600], dtype=torch.int64),
+                torch.randn([600, 256, 7, 7]),
+            ],
+            # workaround for https://github.com/openai/triton/issues/558
+            check_lowp=False,
+        )
+
+    def test_bernoulli(self):
+        def fn(a):
+            b = torch.empty_like(a)
+            return aten.bernoulli_(b), b
+
+        self.common(
+            fn,
+            [
+                torch.randn([100]),
+            ],
+        )
+
+    def test_narrow(self):
+        def fn(x):
+            return aten.narrow(x, 1, 10, 16), aten.narrow(x + 2, 0, 10, 16) + 1
+
+        self.common(fn, [torch.randn(64, 64)])
+
+    def test_as_strided(self):
+        def fn(x):
+            return (
+                aten.as_strided(x, (8, 8, 64), (8 * 64, 64, 1), 0),
+                aten.as_strided(x + 1, (8, 8, 64), (8 * 64, 64, 1), 0) + 2,
+            )
+
+        self.common(fn, [torch.randn(64, 64)])
+
+    def test_select_scatter(self):
+        def fn(x, a, b):
+            return (
+                aten.select_scatter(x, a, 1, 0),
+                aten.select_scatter(x, b, 0, 1),
+            )
+
+        self.common(
+            fn,
+            [
+                torch.randn(8, 197, 38),
+                torch.randn(8, 38),
+                torch.randn(197, 38),
+            ],
+        )
+
+    def test_slice_scatter(self):
+        def fn(x, a):
+            return (
+                aten.slice_scatter(x, a, 2, 10, -10),
+                aten.slice_scatter(x, a[:, :, :40], 2, 10, -10, 2),
+            )
+
+        self.common(
+            fn,
+            [
+                torch.randn(4, 8, 100),
+                torch.randn(4, 8, 80),
+            ],
+        )
+
+    def test_new_empty_strided(self):
+        def fn(a):
+            return aten.new_empty_strided(a, [1, 128, 128], [16384, 128, 1]).fill_(123)
+
+        self.common(fn, [torch.randn(55)])
 
 
 if HAS_CPU:

--- a/torchinductor/codecache.py
+++ b/torchinductor/codecache.py
@@ -77,7 +77,7 @@ def cpp_compile_command(input, output, include_pytorch=False):
         r"[ \n]+",
         " ",
         f"""
-            {cpp_compiler()} -shared -fPIC -Wall -std=c++14 -Wno-unused-variable
+            {cpp_compiler()} -shared -fPIC -Wall -std=c++20 -Wno-unused-variable
             {ipaths} {lpaths} {libs}
             -march=native -O3 -ffast-math -fno-finite-math-only -fopenmp
             -o{output} {input}

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -461,7 +461,7 @@ class Kernel(CodeGen):
         finally:
             self.loads = prior
 
-    def store(self, name, index, value):
+    def store(self, name, index, value, mode=None):
         raise NotImplementedError()
 
     def reduction(self, name, dtype, reduction_type, index, value):
@@ -492,10 +492,11 @@ class Kernel(CodeGen):
                 return self.load(name, index, upcast)
 
             @staticmethod
-            def store(name, index, value):
-                self.cse.store_cache[name] = value
+            def store(name, index, value, mode=None):
+                if mode is None:
+                    self.cse.store_cache[name] = value
                 if name not in V.graph.removed_buffers:
-                    return self.store(name, index, value)
+                    return self.store(name, index, value, mode=mode)
 
             @staticmethod
             def reduction(name, dtype, reduction_type, index, value):
@@ -510,6 +511,7 @@ class Kernel(CodeGen):
     def rename_indexing(self, index) -> sympy.Expr:
         if isinstance(index, (list, tuple)):
             return [self.rename_indexing(x) for x in index]
+        index = sympy.expand(index)
         index = sympy.simplify(index.subs(V.graph.sizevars.replacements))
         subs = {
             x: self.args.size(x) for x in index.free_symbols if str(x).startswith("s")

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -5,7 +5,7 @@ debug = False
 dce = False
 
 # assume there will be no backwards
-forward_only = True
+forward_only = False
 
 # assume input tensors are dynamic
 dynamic_shapes = True

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import numbers
 
@@ -9,6 +10,7 @@ from torch._decomp import get_decompositions
 from torchinductor import config
 
 aten = torch.ops.aten
+log = logging.getLogger(__name__)
 
 decompositions = get_decompositions(
     [
@@ -27,19 +29,21 @@ decompositions = get_decompositions(
         aten.glu_backward,
         aten.grid_sampler_2d,
         aten.hardsigmoid,
+        aten.hardsigmoid_backward,
         aten.hardswish,
+        aten.hardswish_backward,
         aten.hardtanh,
+        aten.hardtanh_backward,
         aten.l1_loss,
         aten.leaky_relu,
         aten.leaky_relu_backward,
         aten._log_softmax_backward_data,
         aten.logsumexp.default,
-        aten.masked_fill_,
         aten.max_pool2d_with_indices_backward,
         aten.mse_loss,
+        aten.narrow,
         aten.native_batch_norm,
         aten.native_batch_norm_backward,
-        aten.native_dropout_backward,
         aten.native_group_norm,
         aten.native_layer_norm,
         aten.native_layer_norm_backward,
@@ -49,6 +53,8 @@ decompositions = get_decompositions(
         aten.select_backward,
         aten.select_scatter,
         aten.sigmoid_backward,
+        aten.silu_backward,
+        aten.slice_backward,
         aten._softmax_backward_data,
         aten.stack,
         aten.tanh_backward,
@@ -61,6 +67,9 @@ decompositions.update(aot_autograd_decompositions)
 
 
 def register_decomposition(ops):
+    for op in [ops] if callable(ops) else ops:
+        if op in decompositions:
+            log.warning(f"duplicate decomp: {ops}")
     return functorch._src.decompositions.register_decomposition(ops, decompositions)
 
 
@@ -263,3 +272,13 @@ def baddbmm(self, batch1, batch2, beta=1, alpha=1):
     if not isinstance(beta, numbers.Number) or beta != 1:
         self = self * beta
     return self + result
+
+
+@register_decomposition([aten.index_put])
+def index_put(self, indices, values, accumulate=False):
+    return torch.index_put_(self.clone(), indices, values, accumulate)
+
+
+@register_decomposition([aten.narrow])
+def narrow(self, dim, start, length):
+    return aten.slice(self, dim, start, start + length)

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -96,10 +96,10 @@ class RecordLoadStore(V.MockHandler):
         self._reads.add(MemoryDep(name, canonicalized_index, canonicalized_size))
         return f"load({name}, {index}, {upcast})"
 
-    def store(self, name, index, value):
+    def store(self, name, index, value, mode=None):
         canonicalized_index, canonicalized_size = self.canonicalize(index)
         self._writes.add(MemoryDep(name, canonicalized_index, canonicalized_size))
-        return f"store({name}, {index}, {value})"
+        return f"store({name}, {index}, {value}, {mode})"
 
     def reduction(self, name, dtype, reduction_type, index, value):
         return self.store(name, index, f"reduce_{reduction_type})({value})")

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -217,6 +217,33 @@ class Pointwise(Loops):
 
 
 @dataclasses.dataclass
+class Scatter(Pointwise):
+    output_indexer: Callable[[List[Expr]], Expr]
+    scatter_mode: str = None
+
+    def constant_to_device(self, device):
+        """Move this to a given device. Requires that all reads are to constants."""
+        loader = self.make_loader()
+        loader = patch.object(ConstantBuffer, "override_device", device)(loader)
+        return Scatter(
+            device,
+            self.dtype,
+            loader,
+            self.ranges,
+            self.output_indexer,
+            self.scatter_mode,
+        )
+
+    def store_output(self, output_name, indexer, vars):
+        return ops.store(
+            output_name,
+            indexer(self.output_indexer(vars)),
+            self.inner_fn(vars),
+            mode=self.scatter_mode,
+        )
+
+
+@dataclasses.dataclass
 class Reduction(Loops):
     reduction_ranges: List[Expr]
     reduction_type: str
@@ -1150,7 +1177,7 @@ class Buffer(IRNode):
         return self.layout.device
 
     def get_dtype(self):
-        return self.layout.dtype
+        return getattr(self.layout, "dtype", None)
 
     def get_size(self):
         return self.layout.size
@@ -1737,6 +1764,65 @@ class ExternKernelAlloc(ExternKernel):
 
     def should_allocate(self):
         return False
+
+
+class IndexPutFallback(ExternKernel):
+    # TODO(jansel): delete this when this is fixed:
+    # https://github.com/openai/triton/issues/558
+    kernel = "aten.index_put_"
+
+    def codegen(self, wrapper):
+        x, *indices, values = [t.codegen_reference() for t in self.inputs]
+        (accumulate,) = self.constant_args
+        wrapper.writeline(
+            f"{self.kernel}({x}, [{', '.join(indices)}], {values}, {accumulate!r})"
+        )
+
+    def should_allocate(self):
+        return False
+
+    def get_mutation_names(self):
+        assert isinstance(self.layout, MutationLayout)
+        return (self.layout.target.get_name(),)
+
+    def __init__(self, x, indices, values, accumulate=False):
+        super().__init__(
+            None,
+            MutationLayout(x),
+            self.unwrap_storage([x, *indices, values]),
+            [accumulate],
+        )
+        self.name = V.graph.register_buffer(self)
+
+
+class InplaceBernoulliFallback(ExternKernel):
+    """
+    This needs to be a custom class to handle mutation properly
+    """
+
+    kernel = "aten.bernoulli_"
+
+    def codegen(self, wrapper):
+        (x,) = [t.codegen_reference() for t in self.inputs]
+        wrapper.writeline(
+            f"{self.kernel}({x}, {', '.join(map(repr, self.constant_args))})"
+        )
+
+    def should_allocate(self):
+        return False
+
+    def get_mutation_names(self):
+        assert isinstance(self.layout, MutationLayout)
+        return (self.layout.target.get_name(),)
+
+    def __init__(self, x, *constant_args):
+        super().__init__(
+            None,
+            MutationLayout(x),
+            self.unwrap_storage([x]),
+            constant_args,
+        )
+        self.name = V.graph.register_buffer(self)
 
 
 class MatrixMultiply(ExternKernelOut):
@@ -2407,9 +2493,9 @@ class LoopBodyBlock:
                 index = add_index(index, "reads")
                 return self._inner.load(name, index, upcast)
 
-            def store(self, name, index, value):
+            def store(self, name, index, value, mode=None):
                 index = add_index(index, "writes")
-                return self._inner.store(name, index, value)
+                return self._inner.store(name, index, value, mode)
 
             def reduction(self, name, dtype, reduction_type, index, value):
                 index = add_index(index, "writes")

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -23,6 +23,7 @@ from .virtualized import ops
 lowerings = {}
 aten = torch.ops.aten
 needs_realized_inputs = {
+    aten.as_strided,
     aten.avg_pool2d,
     aten.bmm,
     aten.constant_pad_nd,
@@ -417,6 +418,22 @@ def slice_(x, dim, start, end, step=1):
     return TensorBox(ir.SliceView.create(x.data, dim, start, end, step))
 
 
+@register_lowering(aten.as_strided)
+def as_strided(x, size, stride, storage_offset=None):
+    x.realize()
+    if not ir.is_storage_and_layout(x):
+        raise NotImplementedError(f"unrealized as_strided({x}, ...)")
+    storage, old_layout = ir.as_storage_and_layout(x)
+    new_layout = ir.FixedLayout(
+        old_layout.device,
+        old_layout.dtype,
+        [sympy.expand(s) for s in size],
+        [sympy.expand(s) for s in stride],
+        sympy.expand(storage_offset or 0),
+    )
+    return TensorBox(ir.ReinterpretView(storage, new_layout))
+
+
 @register_lowering(aten.cat)
 def cat(inputs, dim=0):
     if len(inputs) == 1:
@@ -551,6 +568,14 @@ def native_dropout(x, p, train):
     return x, ones_like(x, dtype=torch.bool)
 
 
+@register_lowering(aten.bernoulli_, type_promote=False)
+def bernoulli_(x, *args):
+    x.realize()
+    V.graph.realize_users_of(x.get_name())
+    ir.InplaceBernoulliFallback(x, *args)
+    return x
+
+
 def make_fallback(kernel):
     needs_realized_inputs.add(kernel)
 
@@ -566,19 +591,22 @@ def make_fallback(kernel):
 if has_torchvision_roi_align():
     make_fallback(torch.ops.torchvision.roi_align)
 
-make_fallback(aten._cudnn_rnn)
-make_fallback(aten.convolution_backward)
-make_fallback(aten.sort)
-make_fallback(aten.topk)
-make_fallback(aten.randperm)
-make_fallback(aten.grid_sampler_2d)
-make_fallback(aten.avg_pool2d_backward)
+# TODO(jansel): we should implement decomps for these
 make_fallback(aten._adaptive_avg_pool2d_backward)
+make_fallback(aten.avg_pool2d_backward)
+make_fallback(aten.convolution_backward)
+make_fallback(aten._cudnn_rnn)
+make_fallback(aten._cudnn_rnn_backward)
 make_fallback(aten._fused_moving_avg_obs_fq_helper)
+make_fallback(aten.grid_sampler_2d)
 make_fallback(aten.max_pool2d_with_indices_backward)
 make_fallback(aten.native_batch_norm_backward)
+make_fallback(aten.native_dropout_backward)
+make_fallback(aten.randperm)
 make_fallback(aten.reflection_pad2d_backward)
-make_fallback(aten._cudnn_rnn_backward)
+make_fallback(aten.sort)
+make_fallback(aten.topk)
+make_fallback(aten.upsample_bilinear2d_backward)
 make_fallback(aten.upsample_nearest2d_backward)
 
 
@@ -688,6 +716,96 @@ def triu(x, diagonal=0):
     return Pointwise.create(
         device=x.get_device(),
         dtype=dtype,
+        inner_fn=inner_fn,
+        ranges=list(x.get_size()),
+    )
+
+
+@register_lowering(aten.select_scatter)
+def select_scatter(x, src, dim: int, index: int):
+    x_loader = x.make_loader()
+    dim = _validate_dim(x, dim, 0)
+    src = expand(unsqueeze(src, dim), x.get_size())
+    src_loader = src.make_loader()
+
+    def inner_fn(idx):
+        return ops.where(
+            ops.eq(
+                ops.index_expr(idx[dim], torch.int32),
+                ops.constant(index, torch.int32),
+            ),
+            src_loader(idx),
+            x_loader(idx),
+        )
+
+    return Pointwise.create(
+        device=x.get_device(),
+        dtype=x.get_dtype(),
+        inner_fn=inner_fn,
+        ranges=list(x.get_size()),
+    )
+
+
+@register_lowering(aten.slice_scatter)
+def slice_scatter(x, src, dim=0, start=None, end=None, step=1):
+    x_loader = x.make_loader()
+    dim = _validate_dim(x, dim, 0)
+    dim_size = x.get_size()[dim]
+    if start is not None and start < 0:
+        start = start + dim_size
+    if end is not None and end < 0:
+        end = end + dim_size
+    if start is None:
+        start = 0
+    if end is None or V.graph.sizevars.maybe_guard_leq(x.get_size()[dim], end):
+        end = dim_size
+
+    src_size = list(x.get_size())
+    src_size[dim] = ir.IndexingDiv(sympy.expand(end - start), sympy.expand(step))
+    src = expand(src, src_size)
+    src_loader = src.make_loader()
+
+    def inner_fn(idx):
+        idx_dim = ops.index_expr(idx[dim], torch.int32)
+        src_idx = list(idx)
+        src_idx[dim] = ir.IndexingDiv(idx[dim] - start, step)
+
+        mask = []
+        if start != 0:
+            mask.append(
+                ops.ge(
+                    idx_dim,
+                    ops.index_expr(sympy.expand(start), torch.int32),
+                )
+            )
+        if end != dim_size:
+            mask.append(
+                ops.lt(
+                    idx_dim,
+                    ops.index_expr(sympy.expand(end), torch.int32),
+                )
+            )
+        if step != 1:
+            mask.append(
+                ops.eq(
+                    ops.index_expr(
+                        ir.ModularIndexing(idx[dim] - start, 1, step), torch.int32
+                    ),
+                    ops.constant(0, torch.int32),
+                )
+            )
+        assert mask
+        mask = functools.reduce(ops.and_, mask)
+        src_val = ops.masked(mask, lambda: src_loader(src_idx), 0.0)
+        return ops.where(
+            mask,
+            src_val,
+            x_loader(idx),
+        )
+
+    return Pointwise.create(
+        device=x.get_device(),
+        dtype=x.get_dtype(),
         inner_fn=inner_fn,
         ranges=list(x.get_size()),
     )
@@ -846,6 +964,46 @@ register_lowering(aten.new_zeros)(new_constant(0))
 register_lowering(aten.new_ones)(new_constant(1))
 
 
+@register_lowering(aten.empty_strided)
+def empty_strided(
+    size, stride, *, dtype=None, layout=None, device=None, pin_memory=None
+):
+    assert isinstance(size, (list, type))
+    assert isinstance(stride, (list, type))
+    assert not pin_memory
+    assert not layout or layout == torch.strided
+    dtype = decode_dtype(dtype) or torch.get_default_dtype()
+    device = device or torch.tensor(0.0).device
+    pointwise = _full(fill_value=0, device=device, dtype=dtype, size=size)
+    if tuple(ir.FlexibleLayout.contiguous_strides(size)) == tuple(stride):
+        # fast path, no need to realize it
+        return pointwise
+    print(size, stride)
+    pointwise.realize()
+    buffer = pointwise.data.data
+    assert isinstance(buffer, ir.ComputedBuffer)
+    buffer.layout = ir.FixedLayout(
+        device=device,
+        dtype=dtype,
+        size=[sympy.expand(s) for s in size],
+        stride=[sympy.expand(s) for s in stride],
+    )
+    return pointwise
+
+
+@register_lowering(aten.new_empty_strided)
+def new_empty_strided(
+    x, size, stride, *, dtype=None, layout=None, device=None, pin_memory=None
+):
+    if dtype is None:
+        dtype = x.get_dtype()
+    if device is None:
+        device = x.get_device()
+    return empty_strided(
+        size, stride, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory
+    )
+
+
 @register_lowering(torch.full)
 def full(size, fill_value, **kwargs):
     return tensor_constructor(fill_value)(size, **kwargs)
@@ -947,6 +1105,63 @@ def index(x, indices):
         inner_fn=fn,
         ranges=output_size,
     )
+
+
+@register_lowering(aten.index_put_, type_promote=False)
+def index_put_(self, indices, values, accumulate=False):
+    values = to_dtype(values, self.get_dtype())
+    assert isinstance(self, TensorBox)
+    self.realize()
+    V.graph.realize_users_of(self.get_name())
+
+    if ir.is_triton(self.get_device()) and accumulate:
+        # Workaround broken tl.atomic_add
+        # https://gist.github.com/jansel/dcb795f8594689aad87b967d40e9bf5d
+        for idx in indices:
+            idx.realize()
+        values.realize()
+        ir.IndexPutFallback(self, indices, values, accumulate)
+        return self
+
+    iter_ranges = []
+    index_loaders = []
+
+    for s_size, idx, v_size in itertools.zip_longest(
+        self.get_size(), indices, values.get_size()
+    ):
+        assert s_size is not None
+        assert v_size is not None
+        if idx is not None:
+            (i_size,) = idx.get_size()
+            iter_ranges.append(V.graph.sizevars.guard_equals(i_size, v_size))
+            index_loaders.append(idx.make_loader())
+        else:
+            iter_ranges.append(V.graph.sizevars.guard_equals(s_size, v_size))
+            index_loaders.append(None)
+
+    def output_indexer(index):
+        assert len(index) == len(index_loaders)
+        index = list(index)
+        for i, loader in enumerate(index_loaders):
+            if loader is not None:
+                index[i] = ops.indirect_indexing(loader([index[i]]))
+        return index
+
+    scatter = ir.Scatter(
+        device=self.get_device(),
+        dtype=self.get_dtype(),
+        inner_fn=values.make_loader(),
+        ranges=iter_ranges,
+        output_indexer=output_indexer,
+        scatter_mode="atomic_add" if accumulate else None,
+    )
+    buffer = ir.ComputedBuffer(
+        None,
+        ir.MutationLayout(self),
+        scatter,
+    )
+    buffer.name = V.graph.register_buffer(buffer)
+    return self
 
 
 @register_lowering(aten.index_select, type_promote=False)
@@ -1074,7 +1289,7 @@ def constant_pad_2d(x, padding, fill_value):
 
 
 @register_lowering(aten.constant_pad_nd)
-def constant_pad_nd(x, padding, fill_value):
+def constant_pad_nd(x, padding, fill_value=0):
     assert len(padding) == 4
     return constant_pad_2d(x, padding, fill_value)
 
@@ -1532,6 +1747,8 @@ register_pointwise(aten.ge, type_promote=False, override_dtype=torch.bool)
 register_pointwise(aten.gt, type_promote=False, override_dtype=torch.bool)
 register_pointwise(aten.eq, type_promote=False, override_dtype=torch.bool)
 register_pointwise(aten.ne, type_promote=False, override_dtype=torch.bool)
+register_pointwise(aten.__and__, type_promote=False, override_dtype=torch.bool)
+register_pointwise(aten.__or__, type_promote=False, override_dtype=torch.bool)
 
 
 def register_inplace(aten_op, outplace_op):

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -999,7 +999,6 @@ def empty_strided(
     if tuple(ir.FlexibleLayout.contiguous_strides(size)) == tuple(stride):
         # fast path, no need to realize it
         return pointwise
-    print(size, stride)
     pointwise.realize()
     buffer = pointwise.data.data
     assert isinstance(buffer, ir.ComputedBuffer)

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -334,9 +334,9 @@ class SimplifyIndexing(V.WrapperHandler):
         index = V.graph.sizevars.simplify_with_ranges(index, self._var_ranges)
         return self._inner.load(name, index, upcast)
 
-    def store(self, name, index, value):
+    def store(self, name, index, value, mode=None):
         index = V.graph.sizevars.simplify_with_ranges(index, self._var_ranges)
-        return self._inner.store(name, index, value)
+        return self._inner.store(name, index, value, mode=mode)
 
     def reduction(self, name, dtype, reduction_type, index, value):
         index = V.graph.sizevars.simplify_with_ranges(index, self._var_ranges)


### PR DESCRIPTION
Generated code for index_put:
```
@triton.jit
def kernel1(in_ptr0, in_ptr1, out_ptr0, ks0, ks1, ks2, xnumel, XBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK])
    xmask = xindex < xnumel
    x0_next = xindex // (ks2*(ks1*ks1))
    x1 = x0_next
    x2 = xindex
    x0 = xindex % (ks2*(ks1*ks1))
    tmp0 = tl.load(in_ptr0 + x1, xmask)
    tmp1 = tl.load(in_ptr1 + x2, xmask).to(tl.float32)
    tl.store(out_ptr0 + x0 + (ks2*tmp0*(ks1*ks1)) + tl.zeros([XBLOCK], tl.int32), tmp1, xmask)
```

And CPU:
```
extern "C" void kernel(const float* __restrict__ in_ptr0,
                       const long* __restrict__ in_ptr1,
                       const float* __restrict__ in_ptr2,
                       float* __restrict__ out_ptr0,
                       const long ks0,
                       const long ks1,
                       const long ks2,
                       const long ks3)
{
    #pragma omp parallel num_threads(16)
    {
        #pragma omp for nowait
        for(long i0=0; i0<ks1*ks2*(ks0*ks0); ++i0)
        {
            auto tmp0 = in_ptr0[i0];
            out_ptr0[i0] = tmp0;
        }
        #pragma omp barrier
        #pragma omp for nowait
        for(long i0=0; i0<ks3; ++i0)
        {
            #pragma GCC ivdep
            for(long i1=0; i1<ks2*(ks0*ks0); ++i1)
            {
                auto tmp0 = in_ptr1[i0];
                auto tmp1 = in_ptr2[i1 + (i0*ks2*(ks0*ks0))];
                out_ptr0[i1 + (ks2*tmp0*(ks0*ks0))] = tmp1;
            }
        }
    }
}
```