### PR TITLE
Check if kwargs has key "fp16_mode" when determining the precision

### DIFF
--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -349,7 +349,7 @@ def fx2trt(subgraph, **kwargs):
             )
             return None
 
-        if kwargs["fp16_mode"]:
+        if "fp16_mode" in kwargs and kwargs["fp16_mode"]:
             precision = LowerPrecision.FP16
         else:
             precision = LowerPrecision.FP32


### PR DESCRIPTION
The following code will break because `kwargs` is empty dict:
```
with torchdynamo.optimize("fx2trt"):
    # run-something
```