### PR TITLE
[inductor] Improve fusing of tiled + untiled

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -1891,6 +1891,15 @@ class CommonTemplate:
             ],
         )
 
+    @patch.object(config.triton, "max_tiles", 2)
+    def test_fuse_tiled(self):
+        def fn(a, b, c):
+            return a + b, c + 1
+
+        self.common(
+            fn, [torch.randn(128, 1), torch.randn(1, 128), torch.randn(128, 128)]
+        )
+
     def test_expand_as(self):
         def fn(a, b):
             return aten.expand_as(a, b), aten.expand_as(a + 1, b + 1) + 1

--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -391,7 +391,6 @@ class CppScheduling:
 
             # first any pointwise sharing same loops
             for node in scheduler.pop_group((group + reduction_group, ())):
-                scheduler.maybe_remove_buffer(node, check_group1)
                 node.run(vars, reduction_vars)
                 node.mark_fusable()
 
@@ -408,7 +407,6 @@ class CppScheduling:
                 # we can fuse in some extra pointwise into the suffix
                 with kernel.write_to_suffix():
                     for node in scheduler.pop_group((group, ())):
-                        scheduler.maybe_remove_buffer(node, check_group2)
                         node.run(vars, ())
                         node.mark_fusable()
 

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -3,6 +3,7 @@ import dataclasses
 import functools
 import itertools
 import math
+import operator
 from typing import Dict
 from typing import List
 
@@ -397,6 +398,76 @@ class TritonKernel(Kernel):
             for length, ranges in zip(lengths, self.range_trees)
         ]
 
+    def split_and_set_ranges(self, lengths: List[List[sympy.Expr]]):
+        """
+        We may want to fuse `for i0 in s0*s1` into a tiled kernel with groups (s0, s1).
+
+        To do this we need to split up the iteration space of i0 into something like:
+            for i1 in s0:
+              for i2 in s1:
+                i0 = i1*s1 + i2
+                ....
+
+        This function matches and resplits lengths to the groups of
+        this kernel to enable tiled + non-tiled fusions.
+        """
+        sv = V.graph.sizevars
+        new_ranges = [[] for _ in self.range_trees]
+        remaining = [sv.simplify(rt.numel) for rt in self.range_trees]
+        var_count = itertools.count()
+
+        def add_range(i, expr):
+            expr = sv.simplify(expr)
+            if not sv.maybe_guard_multiple_of(remaining[i], expr):
+                raise CantSplit()
+            # guard on the last item out
+            sv.maybe_guard_equals(remaining[i], expr)
+            remaining[i] = ir.IndexingDiv(remaining[i], expr)
+            new_ranges[i].append(expr)
+            return next(var_count)
+
+        def make_combined(size, idx1, idx2):
+            def getter(flat_vars):
+                return size * flat_vars[idx1] + flat_vars[idx2]
+
+            return getter
+
+        return_getters_groups = []
+        current_group = 0
+        for length_group in lengths:
+            return_getters = []
+            for size in length_group:
+                while (
+                    current_group < len(remaining)
+                    and sv.size_hint(remaining[current_group]) == 1
+                ):
+                    # scroll to next group with remaining elements
+                    current_group += 1
+
+                if sv.size_hint(size) > sv.size_hint(remaining[current_group]):
+                    # need to break size in two
+                    if not sv.maybe_guard_multiple_of(size, remaining[current_group]):
+                        raise CantSplit()
+                    size1 = remaining[current_group]
+                    size2 = ir.IndexingDiv(size, remaining[current_group])
+                    return_getters.append(
+                        make_combined(
+                            size2,
+                            add_range(current_group, size1),
+                            add_range(current_group + 1, size2),
+                        )
+                    )
+                else:
+                    return_getters.append(
+                        operator.itemgetter(add_range(current_group, size))
+                    )
+
+            return_getters_groups.append(return_getters)
+
+        assert all(s == 1 for s in remaining)
+        itervars = list(itertools.chain(*self.set_ranges(*new_ranges)))
+        return [[fn(itervars) for fn in fns] for fns in return_getters_groups]
+
     def indexing(self, index: sympy.Expr, copy_shape=None):
         """
         Compute the index and mask to pass to tl.load() or tl.store()
@@ -697,33 +768,12 @@ class TritonScheduling:
         wrapper = V.graph.wrapper_code
         scheduler = self.scheduler
 
-        def is_group_matching(other_node):
-            _, other_groups = other_node.group
-            if groups == other_groups:
-                return True
-            if len(groups) == 2 and groups[-1] != 1:
-                group, reduction_group = groups
-                if other_groups == (group * reduction_group, sympy.Integer(1)):
-                    sizes, _ = other_node.get_ranges()
-                    split = split_sizes(sizes, group, reduction_group)
-                    return split is not None
-                return other_groups == (group, sympy.Integer(1))
-            elif len(groups) == 3:
-                tile1, tile2, _ = groups
-                if other_groups == (tile1 * tile2, sympy.Integer(1)):
-                    sizes, _ = node.get_ranges()
-                    split = split_sizes(sizes, tile1, tile2)
-                    return split is not None
-
-            return False
-
         reduction_nodes = []
         reschedule = []
         with scheduler.kernel(TritonKernel(*groups)) as kernel:
             for _ in scheduler.iter_fixed_point():
                 # scheduler.pop_group will keep iterating all reachable fusable nodes
                 for node in scheduler.pop_group(groups):
-                    scheduler.maybe_remove_buffer(node, check_group=is_group_matching)
                     node.run(*kernel.set_ranges(*node.get_ranges()))
                     if kernel.inside_reduction:
                         reduction_nodes.append(node)
@@ -740,16 +790,11 @@ class TritonScheduling:
                     for node in scheduler.pop_group(
                         (group * reduction_group, sympy.Integer(1)),
                     ):
-                        sizes, _ = node.get_ranges()
-                        split = split_sizes(sizes, group, reduction_group)
-                        if split is None:
-                            reschedule.append(node)
-                        else:
-                            scheduler.maybe_remove_buffer(
-                                node, check_group=is_group_matching
-                            )
-                            node.run(*kernel.set_ranges(sizes[:split], sizes[split:]))
+                        try:
+                            node.run(*kernel.split_and_set_ranges(node.get_ranges()))
                             node.mark_fusable()
+                        except CantSplit:
+                            reschedule.append(node)
 
                     # we mark reductions fusable here as they rely on the loop break below
                     for node in reduction_nodes:
@@ -760,9 +805,6 @@ class TritonScheduling:
                     # disable_reduction() will close the current reduction loop
                     with kernel.disable_reduction():
                         for node in scheduler.pop_group((group, sympy.Integer(1))):
-                            scheduler.maybe_remove_buffer(
-                                node, check_group=is_group_matching
-                            )
                             node.run(*kernel.set_ranges(*node.get_ranges()))
                             node.mark_fusable()
 
@@ -772,18 +814,11 @@ class TritonScheduling:
                     for node in scheduler.pop_group(
                         (tile1 * tile2, sympy.Integer(1)),
                     ):
-                        sizes, _ = node.get_ranges()
-                        split = split_sizes(sizes, tile1, tile2)
-                        if split is None:
-                            reschedule.append(node)
-                        else:
-                            scheduler.maybe_remove_buffer(
-                                node, check_group=is_group_matching
-                            )
-                            node.run(
-                                *kernel.set_ranges(sizes[:split], sizes[split:], [])
-                            )
+                        try:
+                            node.run(*kernel.split_and_set_ranges(node.get_ranges()))
                             node.mark_fusable()
+                        except CantSplit:
+                            reschedule.append(node)
 
         kernel_name = wrapper.next_kernel_name()
         if config.triton.many_files:
@@ -800,8 +835,5 @@ class TritonScheduling:
         pass
 
 
-def split_sizes(sizes, prod1, prod2):
-    for i in range(len(sizes)):
-        if sympy_product(sizes[:i]) == prod1 and sympy_product(sizes[i:]) == prod2:
-            return i
-    return None
+class CantSplit(Exception):
+    pass

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -511,13 +511,6 @@ class Scheduler:
                 V.graph.removed_buffers.add(node.get_name())
         self.nodes = updated_nodes
 
-    def maybe_remove_buffer(self, node: SchedulerNode, check_group: Callable):
-        name = node.get_name()
-        if name in self.mutation_renames:
-            return
-        if node.can_remove_buffer(check_group=check_group):
-            V.graph.removed_buffers.add(name)
-
     def enqueue(self, node):
         if isinstance(node, (tuple, list)):
             for n in node:

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -4,7 +4,6 @@ import dataclasses
 import functools
 import itertools
 from typing import Any
-from typing import Callable
 from typing import Dict
 from typing import List
 

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -176,6 +176,18 @@ class SizeVarAllocator(object):
         """return the larger of left and right, and guard on that choice"""
         return -self.guard_min(-left, -right)
 
+    def maybe_guard_multiple_of(self, numerator, denominator):
+        """if denominator divides numerator, return True and guard on that fact"""
+        if sympy.gcd(numerator, denominator) == denominator:
+            # can prove it symbolically
+            return True
+        if self.size_hint(numerator) % self.size_hint(denominator) == 0:
+            from .ir import ModularIndexing
+
+            self.guard_equals(ModularIndexing(numerator, 1, denominator), 0)
+            return True
+        return False
+
     def guard_static_shape(self, left):
         right = self.size_hint(left)
         self.guard_equals(left, sympy.Integer(right))


### PR DESCRIPTION
@pyjhzwh this is the improvement I promised.  It should make fusing conv_template+pointwise easier.

Before:
```
@triton.jit
def kernel0(in_ptr0, in_ptr1, out_ptr0, ks0, xnumel, ynumel, XBLOCK : tl.constexpr, YBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK, 1])
    xmask = xindex < xnumel
    yoffset = tl.program_id(1) * YBLOCK
    yindex = yoffset + tl.reshape(tl.arange(0, YBLOCK), [1, YBLOCK])
    ymask = yindex < ynumel
    x0 = xindex
    y1 = yindex
    tmp0 = tl.load(in_ptr0 + x0, xmask).to(tl.float32)
    tmp1 = tl.load(in_ptr1 + y1, ymask).to(tl.float32)
    tmp2 = tmp0 + tmp1
    tl.store(out_ptr0 + y1 + (ks0*x0), tmp2, xmask & ymask)

@triton.jit
def kernel1(in_ptr0, out_ptr0, ks0, xnumel, XBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK])
    xmask = xindex < xnumel
    x0 = xindex
    tmp0 = tl.load(in_ptr0 + x0, xmask).to(tl.float32)
    tmp1 = 1
    tmp2 = tmp0 + tmp1
    tl.store(out_ptr0 + x0, tmp2, xmask)
```


After
```
@triton.jit
def kernel0(in_ptr0, in_ptr1, in_ptr2, out_ptr0, out_ptr1, ks0, xnumel, ynumel, XBLOCK : tl.constexpr, YBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK, 1])
    xmask = xindex < xnumel
    yoffset = tl.program_id(1) * YBLOCK
    yindex = yoffset + tl.reshape(tl.arange(0, YBLOCK), [1, YBLOCK])
    ymask = yindex < ynumel
    x0 = xindex
    y1 = yindex
    tmp0 = tl.load(in_ptr0 + x0, xmask).to(tl.float32)
    tmp1 = tl.load(in_ptr1 + y1, ymask).to(tl.float32)
    tmp3 = tl.load(in_ptr2 + y1 + (ks0*x0), xmask & ymask).to(tl.float32)
    tmp2 = tmp0 + tmp1
    tmp4 = 1
    tmp5 = tmp3 + tmp4
    tl.store(out_ptr0 + y1 + (ks0*x0), tmp2, xmask & ymask)
    tl.store(out_ptr1 + y1 + (ks0*x0), tmp5, xmask & ymask)
```