### PR TITLE
Fix guard propagation for tuple iterators

### DIFF
--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1235,6 +1235,7 @@ class InstructionTranslator(InstructionTranslatorBase):
                         GuardBuilder.LIST_LENGTH,
                         GuardBuilder.DICT_KEYS,
                         GuardBuilder.ODICT_KEYS,
+                        GuardBuilder.TUPLE_ITERATOR_LEN,
                     )
                 ]
                 self.output.guards.update(index_guards)


### PR DESCRIPTION
In some pytorch tests, length guards for tuple iterators were not propagated correctly, resulting in crashes due to invalid lengths.