### PR TITLE
Directly compute sum of a list of floats/ints

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1714,6 +1714,16 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertEqual(y, 11)
         self.assertEqual(z, 61)
 
+    def test_large_reduction_list(self):
+        dtype = torch.float32
+        device = "cpu"
+
+        def check_sum_all(tensor: torch.Tensor) -> None:
+            pylist = tensor.reshape(-1).tolist()
+            self.assertEqual(tensor.sum(), sum(pylist))
+
+        check_sum_all(torch.randn(200000, dtype=dtype, device=device))
+
 
 class TestTracer(JitTestCase):
     def test_jit_save(self):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1720,7 +1720,7 @@ class MiscTests(torchdynamo.testing.TestCase):
 
         def check_sum_all(tensor: torch.Tensor) -> None:
             pylist = tensor.reshape(-1).tolist()
-            self.assertEqual(tensor.sum(), sum(pylist))
+            self.assertTrue(same(tensor.sum(), torch.tensor(sum(pylist))))
 
         check_sum_all(torch.randn(200000, dtype=dtype, device=device))
 

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -397,6 +397,20 @@ class BuiltinVariable(VariableTracker):
             return variables.TupleVariable(items).add_options(self, fn, seq)
 
     def call_sum(self, tx, seq, **kwargs):
+        # Special case for sum on tuple of floats and ints
+        if (
+            isinstance(seq, (variables.ListVariable, variables.TupleVariable))
+            and all(
+                [
+                    isinstance(x, variables.ConstantVariable)
+                    and isinstance(x.value, (int, float))
+                    for x in seq.items
+                ]
+            )
+            and not kwargs
+        ):
+            new_list = [x.value for x in seq.items]
+            return variables.ConstantVariable(sum(new_list))
         if seq.has_unpack_var_sequence(tx):
             start = kwargs.pop(
                 "start", variables.ConstantVariable(0)


### PR DESCRIPTION
In the absence of this PR,  a reduction test case in Pytorch timeouts because we are computing sum of a large list by accumulating one by one.