### PR TITLE
[inductor] Auto-download gcc12 from conda-forge

### DIFF
--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -34,8 +34,16 @@ class cpp:
     threads = -1  # set to cpu_count()
     simdlen = None
     min_chunk_size = 4096
-    cxx = ("g++-10", "clang++-10", "g++")
-    # cxx = "clang++-12"
+    cxx = (
+        None,  # download gcc12 from conda-forge if conda is installed
+        "g++-12",
+        "g++-11",
+        "g++-10",
+        "clang++-12",
+        "clang++-11",
+        "clang++-10",
+        "g++",
+    )
 
 
 # config specific to codegen/triton.py


### PR DESCRIPTION
On the AWS cluster gcc is too old (gcc-7), so this should make developer experience nicer by getting a modern gcc automatically.