### PR TITLE
fix microbenchmarks import path

### DIFF
--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -215,7 +215,7 @@ class WrapperCodeGen(CodeGen):
             output.splice(
                 """
                 from torchdynamo.testing import rand_strided
-                from microbenchmarks.microbench import print_performance
+                from benchmarks.microbenchmarks.microbench import print_performance
                 """,
                 strip=True,
             )


### PR DESCRIPTION
Since microbenchmarks has moved to the benchmarks/ folder, update add_benchmark_harness header to
`from benchmarks.microbenchmarks.microbench import print_performance`