### PR TITLE
[inductor] Add a metric to count the number of generated kernels

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -150,6 +150,8 @@ def check_model(self: TestCase, model, example_inputs, tol=1e-4, check_lowp=True
         if hasattr(model, "to"):
             model = model.to(torch.half)
 
+    torchinductor.metrics.reset()
+
     @torchdynamo.optimize_assert(functools.partial(compile_fx, cudagraphs=False))
     def run(*ex):
         return model(*ex)
@@ -409,6 +411,7 @@ class CommonTemplate:
                 torch.randn(26),
             ),
         )
+        self.assertEqual(torchinductor.metrics.generated_kernel_count, 1)
 
     def test_sum1(self):
         def fn(a, b):

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -11,6 +11,7 @@ from itertools import chain
 import sympy
 from sympy.printing.printer import Printer
 
+from .. import metrics
 from ..utils import unique
 from ..virtualized import V
 from ..virtualized import ops
@@ -488,6 +489,7 @@ class Kernel(CodeGen):
 
     def __init__(self, args=None):
         super().__init__()
+        metrics.generated_kernel_count += 1
         self.args = args or KernelArgs()
         self.loads = IndentedBuffer()
         self.compute = IndentedBuffer()

--- a/torchinductor/metrics.py
+++ b/torchinductor/metrics.py
@@ -1,0 +1,8 @@
+# counter for tracking how many kernels have been generated
+generated_kernel_count = 0
+
+
+# reset all counters
+def reset():
+    global generated_kernel_count
+    generated_kernel_count = 0


### PR DESCRIPTION
Summary: This can be used to prevent a regression on our fusion result.