### PR TITLE
Add a new backend option for TVM's meta_schedule

### DIFF
--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -583,7 +583,10 @@ def tvm_compile(jit_mod, example_inputs, log_file=None, **kwargs):
 def tvm(subgraph):
     return subgraph.wrap_returns(
         tvm_compile_inner(
-            subgraph.scripted, subgraph.example_inputs, None, cuda=subgraph.is_cuda
+            subgraph.scripted,
+            subgraph.example_inputs,
+            tuning_option=None,
+            cuda=subgraph.is_cuda,
         )
     )
 
@@ -598,7 +601,21 @@ def ansor(subgraph):
         tvm_compile_inner(
             subgraph.scripted,
             subgraph.example_inputs,
-            subgraph.filename("ansor"),
+            tuning_option="auto_scheduler",
+            log_file=subgraph.filename("ansor"),
+            cuda=subgraph.is_cuda,
+        )
+    )
+
+
+@create_backend
+def tvm_meta_schedule(subgraph):
+    return subgraph.wrap_returns(
+        tvm_compile_inner(
+            subgraph.scripted,
+            subgraph.example_inputs,
+            tuning_option="meta_schedule",
+            trials=20000,
             cuda=subgraph.is_cuda,
         )
     )
@@ -611,10 +628,11 @@ def llvm_target():
     return "llvm -mcpu=core-avx2"
 
 
-def tvm_compile_inner(jit_mod, example_inputs, log_file, trials=20000, cuda=False):
+def tvm_compile_inner(
+    jit_mod, example_inputs, tuning_option=None, log_file=None, trials=20000, cuda=False
+):
     # based on functorch version in eager_compile.py
     import tvm
-    from tvm import auto_scheduler
     from tvm import relay
     from tvm.contrib import graph_executor
 
@@ -626,7 +644,12 @@ def tvm_compile_inner(jit_mod, example_inputs, log_file, trials=20000, cuda=Fals
     else:
         dev = tvm.cpu(0)
         target = tvm.target.Target(llvm_target())
-    if log_file is not None:
+
+    if tuning_option == "auto_scheduler":
+        from tvm import auto_scheduler
+
+        if log_file is None:
+            log_file = tempfile.NamedTemporaryFile()
         if not os.path.exists(log_file):
             tasks, task_weights = auto_scheduler.extract_tasks(
                 mod["main"], params, target
@@ -656,10 +679,43 @@ def tvm_compile_inner(jit_mod, example_inputs, log_file, trials=20000, cuda=Fals
                 opt_level=3, config={"relay.backend.use_auto_scheduler": True}
             ):
                 lib = relay.build(mod, target=target, params=params)
-    else:
+    elif tuning_option == "meta_schedule":
+        from tvm.meta_schedule import TuneConfig
+        from tvm.meta_schedule.database import JSONDatabase
+        from tvm.meta_schedule.tune import tune_relay
+        from os import path as osp
+
+        with tempfile.TemporaryDirectory() as work_dir:
+            if log_file != None:
+                assert osp.isdir(
+                    log_file
+                ), "TVM's meta_schedule requires a directory for storing log files."
+                work_dir = log_file
+            lib: tvm.runtime.Module = tune_relay(
+                mod=mod,
+                params=params,
+                target=target,
+                config=TuneConfig(
+                    strategy="evolutionary",
+                    num_trials_per_iter=32,
+                    max_trials_per_task=20000,
+                    max_trials_global=trials,
+                ),
+                work_dir=work_dir,
+                database=JSONDatabase(
+                    osp.join(work_dir, "workload.json"),
+                    osp.join(work_dir, "records.json"),
+                ),
+            )
+    elif tuning_option == None:
         # no autotuning (for debugging)
         with tvm.transform.PassContext(opt_level=10):
             lib = relay.build(mod, target=target, params=params)
+    else:
+        raise NotImplementedError(
+            "This tuning option is invalid/not implemented for torchdynamo's TVM-related backend. "
+            "There are three available options including None, auto_scheduler and meta_schedule."
+        )
 
     m = graph_executor.GraphModule(lib["default"](dev))
 
@@ -678,7 +734,7 @@ def tvm_compile_inner(jit_mod, example_inputs, log_file, trials=20000, cuda=Fals
             if arg.dim() != 0:
                 m.set_input(
                     f"inp_{idx}",
-                    tvm.nd.from_dlpack(torch.utils.dlpack.to_dlpack(arg)),
+                    tvm.nd.array(arg.numpy(), dev),
                 )
         m.run()
         return [to_torch_tensor(m.get_output(i)) for i in range(m.get_num_outputs())]

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -625,121 +625,125 @@ def tvm_meta_schedule(subgraph):
 def llvm_target():
     if "avx512" in open("/proc/cpuinfo").read():
         return "llvm -mcpu=skylake-avx512"
-    return "llvm -mcpu=core-avx2"
+    return "llvm -mcpu=core-avx2 -num-cores 12"
 
 
 def tvm_compile_inner(
     jit_mod, example_inputs, tuning_option=None, log_file=None, trials=20000, cuda=False
 ):
-    # based on functorch version in eager_compile.py
-    import tvm
-    from tvm import relay
-    from tvm.contrib import graph_executor
+    try:
+        import tvm
+        from tvm import relay
+        from tvm.contrib import graph_executor
 
-    shape_list = [(f"inp_{idx}", i.shape) for idx, i in enumerate(example_inputs)]
-    mod, params = relay.frontend.from_pytorch(jit_mod, shape_list)
-    if cuda:
-        dev = tvm.cuda(0)
-        target = tvm.target.cuda()
-    else:
-        dev = tvm.cpu(0)
-        target = tvm.target.Target(llvm_target())
+        shape_list = [(f"inp_{idx}", i.shape) for idx, i in enumerate(example_inputs)]
+        mod, params = relay.frontend.from_pytorch(jit_mod, shape_list)
+        if cuda:
+            dev = tvm.cuda(0)
+            target = tvm.target.cuda()
+        else:
+            dev = tvm.cpu(0)
+            target = tvm.target.Target(llvm_target())
 
-    if tuning_option == "auto_scheduler":
-        from tvm import auto_scheduler
+        if tuning_option == "auto_scheduler":
+            from tvm import auto_scheduler
 
-        if log_file is None:
-            log_file = tempfile.NamedTemporaryFile()
-        if not os.path.exists(log_file):
-            tasks, task_weights = auto_scheduler.extract_tasks(
-                mod["main"], params, target
-            )
-            for task in tasks:
-                print(task.compute_dag)
-            else:
-                print("No tasks")
-            if len(tasks) != 0:
-                tuner = auto_scheduler.TaskScheduler(tasks, task_weights)
-                if not os.path.exists(log_file):
-                    assert trials > 0
-                    tune_option = auto_scheduler.TuningOptions(
-                        num_measure_trials=trials,
-                        measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
-                        early_stopping=2000,
-                    )
-                    try:
-                        tuner.tune(tune_option)
-                    except Exception:
-                        if os.path.exists(log_file):
-                            os.unlink(log_file)
-                        raise
-
-        with auto_scheduler.ApplyHistoryBest(log_file):
-            with tvm.transform.PassContext(
-                opt_level=3, config={"relay.backend.use_auto_scheduler": True}
-            ):
-                lib = relay.build(mod, target=target, params=params)
-    elif tuning_option == "meta_schedule":
-        from tvm.meta_schedule import TuneConfig
-        from tvm.meta_schedule.database import JSONDatabase
-        from tvm.meta_schedule.tune import tune_relay
-        from os import path as osp
-
-        with tempfile.TemporaryDirectory() as work_dir:
-            if log_file != None:
-                assert osp.isdir(
-                    log_file
-                ), "TVM's meta_schedule requires a directory for storing log files."
-                work_dir = log_file
-            lib: tvm.runtime.Module = tune_relay(
-                mod=mod,
-                params=params,
-                target=target,
-                config=TuneConfig(
-                    strategy="evolutionary",
-                    num_trials_per_iter=32,
-                    max_trials_per_task=20000,
-                    max_trials_global=trials,
-                ),
-                work_dir=work_dir,
-                database=JSONDatabase(
-                    osp.join(work_dir, "workload.json"),
-                    osp.join(work_dir, "records.json"),
-                ),
-            )
-    elif tuning_option == None:
-        # no autotuning (for debugging)
-        with tvm.transform.PassContext(opt_level=10):
-            lib = relay.build(mod, target=target, params=params)
-    else:
-        raise NotImplementedError(
-            "This tuning option is invalid/not implemented for torchdynamo's TVM-related backend. "
-            "There are three available options including None, auto_scheduler and meta_schedule."
-        )
-
-    m = graph_executor.GraphModule(lib["default"](dev))
-
-    def to_torch_tensor(nd_tensor):
-        """A helper function to transfer a NDArray to torch.tensor."""
-        if nd_tensor.dtype == "bool":
-            # DLPack does not support boolean so it can't be handled by
-            # torch.utils.dlpack.from_pack. Workaround by going through
-            # numpy, although this brings additional data copy overhead.
-            return torch.from_numpy(nd_tensor.numpy())
-        return torch.utils.dlpack.from_dlpack(nd_tensor.to_dlpack())
-
-    def exec_tvm(*args):
-        args = [a.contiguous() for a in args]
-        for idx, arg in enumerate(args, 0):
-            if arg.dim() != 0:
-                m.set_input(
-                    f"inp_{idx}",
-                    tvm.nd.array(arg.numpy(), dev),
+            if log_file is None:
+                log_file = tempfile.NamedTemporaryFile()
+            if not os.path.exists(log_file):
+                tasks, task_weights = auto_scheduler.extract_tasks(
+                    mod["main"], params, target
                 )
-        m.run()
-        return [to_torch_tensor(m.get_output(i)) for i in range(m.get_num_outputs())]
+                for task in tasks:
+                    print(task.compute_dag)
+                else:
+                    print("No tasks")
+                if len(tasks) != 0:
+                    tuner = auto_scheduler.TaskScheduler(tasks, task_weights)
+                    if not os.path.exists(log_file):
+                        assert trials > 0
+                        tune_option = auto_scheduler.TuningOptions(
+                            num_measure_trials=trials,
+                            measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
+                            early_stopping=2000,
+                        )
+                        try:
+                            tuner.tune(tune_option)
+                        except Exception:
+                            if os.path.exists(log_file):
+                                os.unlink(log_file)
+                            raise
 
-    return exec_tvm
+            with auto_scheduler.ApplyHistoryBest(log_file):
+                with tvm.transform.PassContext(
+                    opt_level=3, config={"relay.backend.use_auto_scheduler": True}
+                ):
+                    lib = relay.build(mod, target=target, params=params)
+        elif tuning_option == "meta_schedule":
+            from tvm.meta_schedule import TuneConfig
+            from tvm.meta_schedule.database import JSONDatabase
+            from tvm.meta_schedule.tune import tune_relay
+            from os import path as osp
+
+            with tempfile.TemporaryDirectory() as work_dir:
+                if log_file != None:
+                    assert osp.isdir(
+                        log_file
+                    ), "TVM's meta_schedule requires a directory for storing log files."
+                    work_dir = log_file
+                lib: tvm.runtime.Module = tune_relay(
+                    mod=mod,
+                    params=params,
+                    target=target,
+                    config=TuneConfig(
+                        strategy="evolutionary",
+                        num_trials_per_iter=32,
+                        max_trials_per_task=32,
+                        max_trials_global=trials,
+                    ),
+                    work_dir=work_dir,
+                    database=JSONDatabase(
+                        osp.join(work_dir, "workload.json"),
+                        osp.join(work_dir, "records.json"),
+                    ),
+                )
+        elif tuning_option == None:
+            # no autotuning (for debugging)
+            with tvm.transform.PassContext(opt_level=10):
+                lib = relay.build(mod, target=target, params=params)
+        else:
+            raise NotImplementedError(
+                "This tuning option is invalid/not implemented for torchdynamo's TVM-related backend. "
+                "There are three available options including None, auto_scheduler and meta_schedule."
+            )
+
+        m = graph_executor.GraphModule(lib["default"](dev))
+
+        def to_torch_tensor(nd_tensor):
+            """A helper function to transfer a NDArray to torch.tensor."""
+            if nd_tensor.dtype == "bool":
+                # DLPack does not support boolean so it can't be handled by
+                # torch.utils.dlpack.from_pack. Workaround by going through
+                # numpy, although this brings additional data copy overhead.
+                return torch.from_numpy(nd_tensor.numpy())
+            return torch.utils.dlpack.from_dlpack(nd_tensor.to_dlpack())
+
+        def exec_tvm(*args):
+            args = [a.contiguous() for a in args]
+            for idx, arg in enumerate(args, 0):
+                if arg.dim() != 0:
+                    m.set_input(
+                        f"inp_{idx}",
+                        tvm.nd.array(arg.numpy(), dev),
+                    )
+            m.run()
+            return [
+                to_torch_tensor(m.get_output(i)) for i in range(m.get_num_outputs())
+            ]
+
+        return exec_tvm
+    except Exception:
+        return jit_mod  # explicit fall back to eager
 
 
 @functools.lru_cache(None)

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -680,10 +680,11 @@ def tvm_compile_inner(
                 ):
                     lib = relay.build(mod, target=target, params=params)
         elif tuning_option == "meta_schedule":
+            from os import path as osp
+
             from tvm.meta_schedule import TuneConfig
             from tvm.meta_schedule.database import JSONDatabase
             from tvm.meta_schedule.tune import tune_relay
-            from os import path as osp
 
             with tempfile.TemporaryDirectory() as work_dir:
                 if log_file != None:

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -625,7 +625,7 @@ def tvm_meta_schedule(subgraph):
 def llvm_target():
     if "avx512" in open("/proc/cpuinfo").read():
         return "llvm -mcpu=skylake-avx512"
-    return "llvm -mcpu=core-avx2 -num-cores 12"
+    return "llvm -mcpu=core-avx2"
 
 
 def tvm_compile_inner(
@@ -733,6 +733,8 @@ def tvm_compile_inner(
             args = [a.contiguous() for a in args]
             for idx, arg in enumerate(args, 0):
                 if arg.dim() != 0:
+                    if arg.requires_grad:
+                        arg = arg.detach()
                     m.set_input(
                         f"inp_{idx}",
                         tvm.nd.array(arg.numpy(), dev),

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -569,7 +569,7 @@ def tvm_compile(jit_mod, example_inputs, log_file=None, **kwargs):
     if jit_mod is None:
         return None
     try:
-        return tvm_compile_inner(jit_mod, example_inputs, log_file, **kwargs)
+        return tvm_compile_inner(jit_mod, example_inputs, None, log_file, **kwargs)
     except Exception as e:
         if log_file and os.path.exists(log_file):
             os.unlink(log_file)
@@ -742,7 +742,9 @@ def tvm_compile_inner(
             ]
 
         return exec_tvm
-    except Exception:
+    except Exception as ex:
+        log.exception("tvm error")
+        print(ex)
         return jit_mod  # explicit fall back to eager
 
 

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -744,7 +744,6 @@ def tvm_compile_inner(
         return exec_tvm
     except Exception as ex:
         log.exception("tvm error")
-        print(ex)
         return jit_mod  # explicit fall back to eager
 
 

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -687,7 +687,7 @@ def tvm_compile_inner(
             from tvm.meta_schedule.tune import tune_relay
 
             with tempfile.TemporaryDirectory() as work_dir:
-                if log_file != None:
+                if log_file is not None:
                     assert osp.isdir(
                         log_file
                     ), "TVM's meta_schedule requires a directory for storing log files."
@@ -708,7 +708,7 @@ def tvm_compile_inner(
                         osp.join(work_dir, "records.json"),
                     ),
                 )
-        elif tuning_option == None:
+        elif tuning_option is None:
             # no autotuning (for debugging)
             with tvm.transform.PassContext(opt_level=10):
                 lib = relay.build(mod, target=target, params=params)
@@ -743,7 +743,7 @@ def tvm_compile_inner(
             ]
 
         return exec_tvm
-    except Exception as ex:
+    except Exception:
         log.exception("tvm error")
         return jit_mod  # explicit fall back to eager
 


### PR DESCRIPTION
Hi all,

This PR intends to add a new backend option of TVM's new tuning framework - meta_schedule, for torchdynamo. Meta schedule is the next-generational tuning framework for TVM, combining the approaches of AutoTVM and Ansor and providing a programmatic way to define the space of automatic tuning and enable more efficient tuning primitives like auto-tensorization. More details of this new tuning framework can be found [here](https://github.com/apache/tvm-rfcs/blob/main/rfcs/0005-meta-schedule-autotensorir.md) in the rendered RFC. 

cc: @jansel @xuzhao9 