### PR TITLE
Flag to skip printing of Dynamo internal exceptions

### DIFF
--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -15,11 +15,14 @@ except ImportError:
 # print out lots of stuff
 debug = False
 
-# verify the correctness of optimized backend
-verify_correctness = False
-
 # an unreasonable amount of debug printouts
 trace = False
+
+# print the torchdynamo internal exceptions
+print_internal_exceptions = True
+
+# verify the correctness of optimized backend
+verify_correctness = False
 
 # need this many ops to create an FX graph
 minimum_call_count = 1

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -314,17 +314,21 @@ def convert_frame_assert(compiler_fn: Callable, one_graph=True):
             CleanupManager.instance[code] = output.cleanups
             return GuardedCode(code, output.guards, frame.f_locals, frame.f_globals)
         except (Unsupported, TorchRuntimeError, BackendCompilerFailed):
-            debug_print("WONT CONVERT")
+            if config.debug or config.trace or config.print_internal_exceptions:
+                debug_print("WONT CONVERT")
             raise
         except Exception:
-            debug_print("WONT CONVERT")
-            sys.stderr.write("=" * 10 + " TorchDynamo Stack Trace " + "=" * 10 + "\n")
-            traceback.print_exc()
-            sys.stderr.write(
-                "=" * 10 + " Exception (above) while processing " + "=" * 10 + "\n"
-            )
-            traceback.print_stack(frame)
-            sys.stderr.write("=" * 10 + " End debug info " + "=" * 10 + "\n")
+            if config.debug or config.trace or config.print_internal_exceptions:
+                debug_print("WONT CONVERT")
+                sys.stderr.write(
+                    "=" * 10 + " TorchDynamo Stack Trace " + "=" * 10 + "\n"
+                )
+                traceback.print_exc()
+                sys.stderr.write(
+                    "=" * 10 + " Exception (above) while processing " + "=" * 10 + "\n"
+                )
+                traceback.print_stack(frame)
+                sys.stderr.write("=" * 10 + " End debug info " + "=" * 10 + "\n")
             raise InternalTorchDynamoError()
 
     return wrap_convert_context(_convert_frame_assert)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -319,11 +319,12 @@ class InstructionTranslatorBase(object):
         ):
             raise
         except Exception as e:
-            sys.stderr.write(
-                f"ERROR FROM offset={self.current_instruction.offset} "
-                f"filename {self.code_options.get('co_filename')} "
-                f"{self.lineno} {typestr(e)}\n"
-            )
+            if config.debug or config.trace or config.print_internal_exceptions:
+                sys.stderr.write(
+                    f"ERROR FROM offset={self.current_instruction.offset} "
+                    f"filename {self.code_options.get('co_filename')} "
+                    f"{self.lineno} {typestr(e)}\n"
+                )
             raise
         finally:
             # Cleanup the outputGraph to delete the held tensors. We perform the


### PR DESCRIPTION
This keeps logs cleaner and helps with PyTorch test debugging

cc @ezyang 