### PR TITLE
[inductor] Update aliased buffer writes with more accurate dependencies

### DIFF
--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -563,6 +563,11 @@ class Kernel(CodeGen):
             def store(name, index, value, mode=None):
                 if mode is None:
                     self.cse.store_cache[name] = value
+                    # If there is an alias, we will also store with the real name which may be used later
+                    if name in V.graph.scheduler.mutation_real_name:
+                        self.cse.store_cache[
+                            V.graph.scheduler.mutation_real_name[name]
+                        ] = value
                 if name not in V.graph.removed_buffers:
                     return self.store(name, index, value, mode=mode)
 

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -62,6 +62,13 @@ class ReadWrites:
             self.index_exprs,
         )
 
+    def with_read_dependency(self, dep: Set[MemoryDep]):
+        return ReadWrites(
+            set.union(self.reads, dep),
+            self.writes,
+            self.index_exprs,
+        )
+
 
 class RecordLoadStore(V.MockHandler):
     def __init__(self, var_ranges, normalize):


### PR DESCRIPTION
Summary: Currently we insert a StarDep for aliased dependency, which will make fusion fail and we end up with more small kernels than necessary. This solves part of the performance problem we have seen in pyhpc_turbulent_kinetic_energy.