### PR TITLE
Compute multilayer reductions in higher precision

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -453,6 +453,14 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(1, 17, 8, 9),))
 
+    def test_multilayer_low_prec(self):
+        def fn(a):
+            return torch.mean(a)
+
+        self.common(
+            fn, ((torch.rand((10, 3, 352, 352), dtype=torch.float16, device="cuda"),))
+        )
+
     def test_min_max_reduction(self):
         def fn(a, b):
             return ((a + b).max(), (a + b).min(), torch.amax(a + 1, keepdim=True))


### PR DESCRIPTION
triton will automatically compute reductions in fp32 if reducing over fp16/bf16
within the kernel. keep the intermediate in fp32 so as to keep the whole reduction
in fp32 and not reduce precision by breaking up the kernel into multiple layers

Fix Super_SloMo in https://github.com/pytorch/torchdynamo/issues/332