### PR TITLE
use fake tensors when deep copying model to check mutation

### DIFF
--- a/torchdynamo/optimizations/analysis.py
+++ b/torchdynamo/optimizations/analysis.py
@@ -7,6 +7,12 @@ from torch.fx.node import map_aggregate
 from torch.fx.passes.shape_prop import ShapeProp
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
 
+from ..utils import fake_tensors_available
+
+if fake_tensors_available:
+    from ..utils import deepcopy_to_fake_tensor
+    from ..utils import wrap_to_fake_tensor
+
 
 class ShapeAliasingAndMutationProp(ShapeProp):
     def __init__(self, *args, **kwargs):
@@ -104,9 +110,18 @@ class ShapeAliasingAndMutationProp(ShapeProp):
 def has_mutation(gm, example_inputs):
     """Check if the graph module has any form of mutation"""
     # TODO - moco gives bad accuracy with Aliasing. gm is getting mutated in a bad way.
-    new_gm = copy.deepcopy(gm)
-    ShapeAliasingAndMutationProp(new_gm).run(*example_inputs)
+    fake_mode = FakeTensorMode()
 
+    if fake_tensors_available and config.fake_tensor_propagation:
+        fake_mode = FakeTensorMode()
+        fake_wrapper = functools.partial(wrap_to_fake_tensor, fake_mode=fake_mode)
+        example_inputs = tree_map(fake_wrapper, example_inputs)
+        new_gm = deepcopy_to_fake_tensor(gm, fake_mode)
+    else:
+        new_gm = copy.deepcopy(gm)
+        example_inputs = copy.deepcopy(example_inputs)
+
+    ShapeAliasingAndMutationProp(new_gm).run(*example_inputs)
     for node in new_gm.graph.nodes:
         if node.meta["is_mutation"] or node.meta["is_input_mutation"]:
             return True

--- a/torchdynamo/optimizations/analysis.py
+++ b/torchdynamo/optimizations/analysis.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import itertools
 import operator
 
@@ -6,10 +7,14 @@ import torch
 from torch.fx.node import map_aggregate
 from torch.fx.passes.shape_prop import ShapeProp
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
+from torch.utils._pytree import tree_map
 
+from .. import config
 from ..utils import fake_tensors_available
 
 if fake_tensors_available:
+    from torch._subclasses import FakeTensorMode  # noqa: F401
+
     from ..utils import deepcopy_to_fake_tensor
     from ..utils import wrap_to_fake_tensor
 
@@ -110,7 +115,6 @@ class ShapeAliasingAndMutationProp(ShapeProp):
 def has_mutation(gm, example_inputs):
     """Check if the graph module has any form of mutation"""
     # TODO - moco gives bad accuracy with Aliasing. gm is getting mutated in a bad way.
-    fake_mode = FakeTensorMode()
 
     if fake_tensors_available and config.fake_tensor_propagation:
         fake_mode = FakeTensorMode()

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -15,7 +15,6 @@ from ..utils import fake_tensors_available
 
 if fake_tensors_available:
     from torch._subclasses import FakeTensor
-    from ..utils import wrap_fake_exception
     from ..utils import wrap_to_fake_tensor
     from ..utils import deepcopy_to_fake_tensor
 
@@ -101,8 +100,15 @@ class TensorVariable(VariableTracker):
                 options.update(cls.specialize(example_value))
             return cls(proxy, **options)
 
-        fake_wrapper = functools.partial(wrap_to_fake_tensor, fake_mode=tx.fake_mode)
         use_fake_tensors = fake_tensors_available and config.fake_tensor_propagation
+        if use_fake_tensors:
+            fake_wrapper = functools.partial(
+                wrap_to_fake_tensor, fake_mode=tx.fake_mode
+            )
+            # python errors if the import isnt here
+            from ..utils import wrap_fake_exception
+        else:
+            wrap_fake_exception = lambda func: func()
 
         with preserve_rng_state():
             if example_value is None:

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -108,7 +108,9 @@ class TensorVariable(VariableTracker):
             # python errors if the import isnt here
             from ..utils import wrap_fake_exception
         else:
-            wrap_fake_exception = lambda func: func()
+
+            def wrap_fake_exception(func):
+                return func()
 
         with preserve_rng_state():
             if example_value is None:


### PR DESCRIPTION
Otherwise the deepcopy introduces memory overheads.

Partial fix for https://github.com/pytorch/torchdynamo/issues/468
