### PR TITLE
Reduction cache

### DIFF
--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -429,12 +429,14 @@ class CSE:
         name_prefix="tmp",
         iter_buffers=None,
         store_cache=None,
+        reduction_cache=None,
     ):
         self.prefix = prefix
         self.suffix = suffix
         self.cache = {}
         self.name_prefix = name_prefix
         self.store_cache = store_cache or {}
+        self.reduction_cache = reduction_cache or {}
         self.iter_buffer_ids = iter_buffers or itertools.count()
 
     def invalidate(self, keep_vars: typing.Set[str]):

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -363,6 +363,7 @@ class TritonKernel(Kernel):
         self.suffix = IndentedBuffer()
         self.outside_loop_vars = set()
         self.initialize_range_tree()
+        self.reduction_cache = {}
 
     def initialize_range_tree(self):
         names = ["xindex", "yindex", "zindex"][: len(self.numels) - 1] + ["rindex"]
@@ -592,29 +593,34 @@ class TritonKernel(Kernel):
 
         dim = len(self.range_trees) - 1
         result_var = self.cse.newvar()
-        accumulator = f"_{result_var}"
-        self.body.writeline(
-            f"{accumulator} = tl.zeros({self.dense_size_str()}, {triton_compute_type(dtype)}) + {default}"
-        )
+        if (dtype, reduction_type, value) not in self.reduction_cache:
+            self.reduction_cache[(dtype, reduction_type, value)] = result_var
+            accumulator = f"_{result_var}"
+            self.body.writeline(
+                f"{accumulator} = tl.zeros({self.dense_size_str()}, {triton_compute_type(dtype)}) + {default}"
+            )
 
-        updated = value
-        if reduction_type == "min":
-            masks.append(f"({accumulator} > {value})")
-        elif reduction_type == "max":
-            masks.append(f"({accumulator} < {value})")
-        elif reduction_type == "sum":
-            updated = f"{accumulator} + {value}"
+            updated = value
+            if reduction_type == "min":
+                masks.append(f"({accumulator} > {value})")
+            elif reduction_type == "max":
+                masks.append(f"({accumulator} < {value})")
+            elif reduction_type == "sum":
+                updated = f"{accumulator} + {value}"
+            else:
+                raise NotImplementedError(f"reduction_type {reduction_type}")
+
+            cond = " & ".join(masks)
+            self.compute.writeline(
+                f"{accumulator} = tl.where({cond}, {updated}, {accumulator})"
+            )
+
+            self.suffix.writeline(
+                f"{result_var} = tl.reshape(tl.{reduction_type}({accumulator}, {dim}), [{', '.join(sizes)}])"
+            )
         else:
-            raise NotImplementedError(f"reduction_type {reduction_type}")
-
-        cond = " & ".join(masks)
-        self.compute.writeline(
-            f"{accumulator} = tl.where({cond}, {updated}, {accumulator})"
-        )
-
-        self.suffix.writeline(
-            f"{result_var} = tl.reshape(tl.{reduction_type}({accumulator}, {dim}), [{', '.join(sizes)}])"
-        )
+            var_name = self.reduction_cache[(dtype, reduction_type, value)]
+            self.suffix.writeline(f"{result_var} = {var_name}")
         self.inside_reduction = False
         index, mask = self.indexing(index, result_var)
         assert "rmask" not in index

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -363,7 +363,6 @@ class TritonKernel(Kernel):
         self.suffix = IndentedBuffer()
         self.outside_loop_vars = set()
         self.initialize_range_tree()
-        self.reduction_cache = {}
 
     def initialize_range_tree(self):
         names = ["xindex", "yindex", "zindex"][: len(self.numels) - 1] + ["rindex"]
@@ -593,8 +592,8 @@ class TritonKernel(Kernel):
 
         dim = len(self.range_trees) - 1
         result_var = self.cse.newvar()
-        if (dtype, reduction_type, value) not in self.reduction_cache:
-            self.reduction_cache[(dtype, reduction_type, value)] = result_var
+        if (dtype, reduction_type, value) not in self.cse.reduction_cache:
+            self.cse.reduction_cache[(dtype, reduction_type, value)] = result_var
             accumulator = f"_{result_var}"
             self.body.writeline(
                 f"{accumulator} = tl.zeros({self.dense_size_str()}, {triton_compute_type(dtype)}) + {default}"
@@ -619,7 +618,7 @@ class TritonKernel(Kernel):
                 f"{result_var} = tl.reshape(tl.{reduction_type}({accumulator}, {dim}), [{', '.join(sizes)}])"
             )
         else:
-            var_name = self.reduction_cache[(dtype, reduction_type, value)]
+            var_name = self.cse.reduction_cache[(dtype, reduction_type, value)]
             self.suffix.writeline(f"{result_var} = {var_name}")
         self.inside_reduction = False
         index, mask = self.indexing(index, result_var)


### PR DESCRIPTION
Enables cse reduction cache to avoid reducing the same var multiple times. 
I'm not sure when/if it should be invalidated  