### PR TITLE
Fix correctness checking code and non-deterministic benchmarks

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -580,6 +580,9 @@ class BenchmarkRunner:
     def set_tolerance(self, is_training, current_device, name):
         raise NotImplementedError()
 
+    def clone_inputs(inputs):
+        return tree_map(lambda x: torch.clone(x) if isinstance(x, torch.Tensor) else x, inputs)
+
     def run_one_model(
         self,
         name,
@@ -602,12 +605,12 @@ class BenchmarkRunner:
                 assert not torchdynamo.utils.is_jit_model(submod)
 
             torch.manual_seed(1337)
-            correct_result = model_iter_fn(copy.deepcopy(model), torch.clone(example_inputs))
+            correct_result = model_iter_fn(copy.deepcopy(model), self.clone_inputs(example_inputs))
 
             torch.manual_seed(1337)
             if current_name not in self.non_deterministic_models:
                 correct_rerun_result = model_iter_fn(
-                    copy.deepcopy(model), torch.clone(example_inputs)
+                    copy.deepcopy(model), self.clone_inputs(example_inputs)
                 )
                 if not same(correct_result, correct_rerun_result):
                     print("INCORRECT - Variation in Eager runs itself")

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -580,11 +580,6 @@ class BenchmarkRunner:
     def set_tolerance(self, is_training, current_device, name):
         raise NotImplementedError()
 
-    def clone_inputs(self, inputs):
-        return tree_map(
-            lambda x: torch.clone(x) if isinstance(x, torch.Tensor) else x, inputs
-        )
-
     def run_one_model(
         self,
         name,
@@ -608,13 +603,13 @@ class BenchmarkRunner:
 
             torch.manual_seed(1337)
             correct_result = model_iter_fn(
-                copy.deepcopy(model), self.clone_inputs(example_inputs)
+                copy.deepcopy(model), torchdynamo.utils.clone_inputs(example_inputs)
             )
 
             torch.manual_seed(1337)
             if current_name not in self.non_deterministic_models:
                 correct_rerun_result = model_iter_fn(
-                    copy.deepcopy(model), self.clone_inputs(example_inputs)
+                    copy.deepcopy(model), torchdynamo.utils.clone_inputs(example_inputs)
                 )
                 if not same(correct_result, correct_rerun_result):
                     print("INCORRECT - Variation in Eager runs itself")

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -581,7 +581,9 @@ class BenchmarkRunner:
         raise NotImplementedError()
 
     def clone_inputs(self, inputs):
-        return tree_map(lambda x: torch.clone(x) if isinstance(x, torch.Tensor) else x, inputs)
+        return tree_map(
+            lambda x: torch.clone(x) if isinstance(x, torch.Tensor) else x, inputs
+        )
 
     def run_one_model(
         self,
@@ -605,7 +607,9 @@ class BenchmarkRunner:
                 assert not torchdynamo.utils.is_jit_model(submod)
 
             torch.manual_seed(1337)
-            correct_result = model_iter_fn(copy.deepcopy(model), self.clone_inputs(example_inputs))
+            correct_result = model_iter_fn(
+                copy.deepcopy(model), self.clone_inputs(example_inputs)
+            )
 
             torch.manual_seed(1337)
             if current_name not in self.non_deterministic_models:

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -580,7 +580,7 @@ class BenchmarkRunner:
     def set_tolerance(self, is_training, current_device, name):
         raise NotImplementedError()
 
-    def clone_inputs(inputs):
+    def clone_inputs(self, inputs):
         return tree_map(lambda x: torch.clone(x) if isinstance(x, torch.Tensor) else x, inputs)
 
     def run_one_model(

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -602,12 +602,12 @@ class BenchmarkRunner:
                 assert not torchdynamo.utils.is_jit_model(submod)
 
             torch.manual_seed(1337)
-            correct_result = model_iter_fn(copy.deepcopy(model), example_inputs)
+            correct_result = model_iter_fn(copy.deepcopy(model), torch.clone(example_inputs))
 
             torch.manual_seed(1337)
             if current_name not in self.non_deterministic_models:
                 correct_rerun_result = model_iter_fn(
-                    copy.deepcopy(model), example_inputs
+                    copy.deepcopy(model), torch.clone(example_inputs)
                 )
                 if not same(correct_result, correct_rerun_result):
                     print("INCORRECT - Variation in Eager runs itself")

--- a/benchmarks/torchbench.py
+++ b/benchmarks/torchbench.py
@@ -101,8 +101,6 @@ REQUIRE_EVEN_HIGHER_TOLERANCE = {
 
 # non-deterministic output / cant check correctness
 NONDETERMINISTIC = {
-    "pyhpc_turbulent_kinetic_energy",
-    "pyhpc_isoneutral_mixing",
 }
 
 

--- a/benchmarks/torchbench.py
+++ b/benchmarks/torchbench.py
@@ -100,8 +100,7 @@ REQUIRE_EVEN_HIGHER_TOLERANCE = {
 
 
 # non-deterministic output / cant check correctness
-NONDETERMINISTIC = {
-}
+NONDETERMINISTIC = {}
 
 
 # These benchmarks took >600s on an i9-11900K CPU


### PR DESCRIPTION
The upstream pyhpc model code modifies input data (https://github.com/dionhaefner/pyhpc-benchmarks/blob/master/benchmarks/turbulent_kinetic_energy/tke_pytorch.py#L258), so running two consecutive runs of `model(*example_inputs)` will have different results, as inputs are different.

This PR clones the input every time it runs correctness check, so that inputs are the same.