### PR TITLE
Improve recompilation warning

### DIFF
--- a/tests/test_recompile_ux.py
+++ b/tests/test_recompile_ux.py
@@ -100,7 +100,7 @@ class RecompileUxTests(torchdynamo.testing.TestCase):
         self.assertTrue(
             logs.records[0]
             .getMessage()
-            .startswith("torchdynamo hit recompilation cache limit")
+            .startswith("torchdynamo hit config.cache_size_limit")
         )
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -243,13 +243,15 @@ def convert_frame_assert(compiler_fn: Callable, one_graph=True):
                 return f"'{code.co_name}' ({code.co_filename}:{code.co_firstlineno})"
 
             def format_guard_failures(code):
-                return f"{str(guard_failures[code])}"
+                # For the common case, it's sufficient to see just the most recent failure.
+                # We could add a verbose mode if needed
+                return f"{str(guard_failures[code][-1])}"
 
             assert code in guard_failures, "TODO(whc) any other recompile reasons?"
             log.warning(
-                f"torchdynamo hit recompilation cache limit ({config.cache_size_limit}) "
-                f"for function {format_func_info(code)}, "
-                f"due to the following guard failures: {format_guard_failures(code)}"
+                f"torchdynamo hit config.cache_size_limit ({config.cache_size_limit})\n"
+                f"   function: {format_func_info(code)}\n"
+                f"   reasons:  {format_guard_failures(code)}\n"
                 f"to diagnose recompilation issues, see {troubleshooting_url}."
             )
             unimplemented("cache_size_limit reached")


### PR DESCRIPTION
- default to printing only the most recent guard failure not one failure for each cache miss
- reformat the text to be (hopefully) more readable and useful

Motivation:
While in some cases, knowing the individual failure reasons for each of (say, 64) cache misses could be useful, i practice it is probably good enough to know the most recent one since they tend to be similar reasons (such as incrementing counters or new object ids triggering the same type of guard).

Previously:
torchdynamo hit recompilation cache limit (64) for function 'toy_example' (example.py:5), due to the following guard failures: [['___guarded_code.valid'], {... 62 more times...}, ['___guarded_code.valid']]to diagnose recompilation issues, see https://github.com/pytorch/torchdynamo/blob/main/TROUBLESHOOTING.md

Now:
torchdynamo hit config.cache_size_limit (64)
   function: 'toy_example' (example.py:5)
   reasons:  ['___guarded_code.valid']