### PR TITLE
Cleanup in ExactWeakKeyDictionary

### DIFF
--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -74,14 +74,13 @@ class ExactWeakKeyDictionary:
         self.values[idx] = value
 
     def _remove_id(self, idx):
-        if idx in self.values:
-            del self.values[idx]
         if idx in self.refs:
+            del self.values[idx]
             del self.refs[idx]
 
     def clear(self):
-        self.values.clear()
         self.refs.clear()
+        self.values.clear()
 
 
 def istype(obj, allowed_types):

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -74,8 +74,9 @@ class ExactWeakKeyDictionary:
         self.values[idx] = value
 
     def _remove_id(self, idx):
-        if idx in self.refs:
+        if idx in self.values:
             del self.values[idx]
+        if idx in self.refs:
             del self.refs[idx]
 
     def clear(self):


### PR DESCRIPTION
I have not really debugged why we need this in the first place. But many new warnings have come up after this fix - https://github.com/pytorch/torchdynamo/issues/477. I have seen this while running pytest and even huggingface.py tests.

cc @ezyang 