### PR TITLE
Reduction deps

### DIFF
--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -23,10 +23,13 @@ class MemoryDep(typing.NamedTuple):
     def maybe_swap_sizes(self):
         # swap only in simple cases where index is trivial and
         # there are just 2 sizes
-        if len(self.size) == 2 and len(self.index.args) == 0 and \
-           self.index.name == 'c0':
+        if (
+            len(self.size) == 2
+            and len(self.index.args) == 0
+            and self.index.name == "c0"
+        ):
             size = (self.size[1], self.size[0])
-            index = self.index.subs({"c0" : "c1"})
+            index = self.index.subs({"c0": "c1"})
             return MemoryDep(self.name, index, size)
         else:
             return self
@@ -38,7 +41,7 @@ class MemoryDep(typing.NamedTuple):
             v = sympy.Symbol("_strip_size_tester")
             prefix = "c"
             last_index = f"{prefix}{len(self.size)-1}"
-            expr1 = self.index.subs({last_index : v})
+            expr1 = self.index.subs({last_index: v})
             if expr1 == self.index:
                 size = self.size[:-1]
                 return MemoryDep(self.name, self.index, size)

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -248,11 +248,6 @@ class SchedulerNode(BaseSchedulerNode):
             self.scheduler.fusable_deps.update(
                 w.maybe_swap_sizes() for w in self.read_writes.writes
             )
-        # if broadcast_after_reduce and self.is_reduction():
-        #     self.scheduler.fusable_deps.update(
-        #         w.broadcast_extend_sizes(self._sizes[-1])
-        #         for w in self.read_writes.writes
-        #     )
 
     def get_ranges(self):
         return self._sizes

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -245,9 +245,15 @@ class SchedulerNode(BaseSchedulerNode):
             )
             # reduction not on the last dim swaps the sizes, and downstream
             # dependencies expect unswapped
-            self.scheduler.fusable_deps.update(
-                w.maybe_swap_sizes() for w in self.read_writes.writes
-            )
+            # TODO swapping sizes doesn't work, leads to
+            # File "/scratch/ngimel/work/repos/torchdynamo/torchinductor/sizevars.py", line 130, in guard_equals
+            # if len(right.free_symbols) < len(left.free_symbols):
+            # AttributeError: 'int' object has no attribute 'free_symbols'
+            # even though memory dep looks correct
+
+            # self.scheduler.fusable_deps.update(
+            #     w.maybe_swap_sizes() for w in self.read_writes.writes
+            # )
 
     def get_ranges(self):
         return self._sizes


### PR DESCRIPTION
Downstream reduction dependencies often expect sizes that are different from the reduction writes sizes, and thus are not correctly marked as fusable even when reduction is complete. 
This PR adds couple more MemoryDeps for reduction ops so that dependencies of downstream ops (such as dividing by number of elements for mean, or computing mean and rstd for layer norm) are satisfied and they can be put in the same kernel with reduction. 