### PR TITLE
[inductor] Support rand()/dropout()

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -3,6 +3,7 @@ import contextlib
 import dataclasses
 import functools
 import importlib
+import random
 import unittest
 from unittest.mock import patch
 
@@ -1969,6 +1970,7 @@ class CommonTemplate:
             check_lowp=False,
         )
 
+    @unittest.skipIf(not config.fallback_random, "requires config.fallback_random")
     def test_bernoulli(self):
         def fn(a):
             b = torch.empty_like(a)
@@ -2032,6 +2034,20 @@ class CommonTemplate:
             return aten.new_empty_strided(a, [1, 128, 128], [16384, 128, 1]).fill_(123)
 
         self.common(fn, [torch.randn(55)])
+
+    @patch.object(torchinductor.config.triton, "cudagraphs", True)
+    def test_dropout(self):
+        random.seed(1234)
+        torch.manual_seed(1234)
+
+        @torchdynamo.optimize("inductor")
+        def fn(a):
+            return torch.nn.functional.dropout(a, 0.5, True)
+
+        x = torch.ones(1000, device=self.device, dtype=torch.float32)
+        result = fn(x)
+        self.assertTrue(400 < result.nonzero().shape[0] < 600)
+        self.assertTrue(0.9 < result.mean().item() < 1.1)
 
 
 if HAS_CPU:

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -331,6 +331,8 @@ class KernelArgs:
         assert name not in V.graph.removed_buffers, name
         if name in self.output_buffers:
             return self.output_buffers[name]
+        if name.startswith("seed"):
+            return self._lookup("seed", self.input_buffers, name)
         return self._lookup("in_ptr", self.input_buffers, name)
 
     def output(self, name):
@@ -346,6 +348,9 @@ class KernelArgs:
         self.inplace_buffers[output_name] = buf
 
     def size(self, name):
+        if str(name) == "seed":
+            self.sizevars["seed"] = "seed"
+            return "seed"
         return self._lookup("ks", self.sizevars, name)
 
     def call_names(self):

--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -65,8 +65,8 @@ def cpp_prefix():
             #include <cstdlib>
             #include <iostream>
             #include <limits>
-            #define SLEEF_ENABLE_OMP_SIMD
-            //#include <sleef.h>
+            #include <random>
+            #include <omp.h>
 
             template<typename T>
             inline T mod(T a, T b) { return a % b; }
@@ -74,6 +74,12 @@ def cpp_prefix():
             inline float mod(float a, float b) { return std::fmod(a, b); }
             template<>
             inline double mod(double a, double b) { return std::fmod(a, b); }
+
+            float rand_cpu(unsigned int seed) {
+                static thread_local std::mt19937 gen(seed ^ omp_get_thread_num());
+                static_assert(std::mt19937::min() == 0);
+                return gen() * static_cast<float>(1.0 / (std::mt19937::max() + 1.0));
+            }
             """
         ),
         "h",
@@ -206,6 +212,10 @@ class CppOverrides(OpOverrides):
     @staticmethod
     def and_(a, b):
         return f"{a} && {b}"
+
+    @staticmethod
+    def rand_cpu(seed: sympy.Expr, dtype):
+        return f"static_cast<{DTYPE_TO_CPP[dtype]}>(rand_cpu({seed}));"
 
 
 class CppKernel(Kernel):
@@ -399,17 +409,6 @@ class CppScheduling:
 
     def codegen(self, *groups):
         group, reduction_group = groups
-
-        def check_group1(other_node):
-            other_groups = other_node.group
-            return (
-                check_group2(other_node)
-                or other_groups == groups
-                or other_groups == (group + reduction_group, ())
-            )
-
-        def check_group2(other_node):
-            return other_node.group == (group, ())
 
         kernel_group = self.kernel_group
         scheduler = self.scheduler

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -62,6 +62,7 @@ class WrapperCodeGen(CodeGen):
             f"""
                 from ctypes import c_void_p, c_long
                 import torch
+                import random
                 from torch import empty_strided, as_strided
                 from {codecache.__name__} import CppCodeCache, TritonCodeCache
 
@@ -97,6 +98,8 @@ class WrapperCodeGen(CodeGen):
             ["", "", f"def call({', '.join(V.graph.graph_inputs.keys())}):"]
         )
         with self.prefix.indent():
+            for name in V.graph.randomness_seeds:
+                self.prefix.writeline(f"{name}.fill_(random.randrange(2**31))")
             V.graph.sizevars.codegen(self.prefix, V.graph.graph_inputs)
 
         for name, value in V.graph.constants.items():

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -99,7 +99,9 @@ class WrapperCodeGen(CodeGen):
         )
         with self.prefix.indent():
             for name in V.graph.randomness_seeds:
-                self.prefix.writeline(f"{name}.fill_(random.randrange(2**31))")
+                self.prefix.writeline(
+                    f"torch.randint(2**31, size=(), dtype=torch.int32, out={name})"
+                )
             V.graph.sizevars.codegen(self.prefix, V.graph.graph_inputs)
 
         for name, value in V.graph.constants.items():

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -8,7 +8,6 @@ from typing import List
 import torch.fx
 
 import torchdynamo.config
-from torchdynamo.optimizations.backends import cudagraphs_inner
 from torchdynamo.optimizations.python_key import python_key_normalize
 from torchdynamo.testing import same
 from torchdynamo.utils import identity
@@ -124,6 +123,7 @@ def compile_fx_inner(
     example_inputs: List[torch.Tensor],
     wrap=identity,
     cudagraphs=None,
+    num_fixed=0,
 ):
     if cudagraphs is None:
         cudagraphs = config.triton.cudagraphs
@@ -142,7 +142,9 @@ def compile_fx_inner(
             and set(graph.device_types) == {"cuda"}
             and not graph.mutated_inputs
         ):
-            return cudagraphs_inner(compiled_fn, example_inputs, copy_outputs=False)
+            return cudagraphify(
+                compiled_fn, example_inputs, static_input_idxs=range(num_fixed)
+            )
         else:
             return compiled_fn
     except Exception:
@@ -152,14 +154,91 @@ def compile_fx_inner(
         raise
 
 
+def no_compile(
+    gm: torch.fx.GraphModule,
+    example_inputs: List[torch.Tensor],
+):
+    return gm.forward
+
+
+def cudagraphify(model, inputs, static_input_idxs=()):
+    """
+    Assumes inputs[static_input_idxs[i]] are always the same memory address
+    """
+    assert isinstance(inputs, (list, tuple))
+    static_inputs = [
+        torch.zeros_like(x) if idx not in static_input_idxs else inputs[idx]
+        for idx, x in enumerate(inputs)
+    ]
+
+    # warmup
+    torch.cuda.synchronize()
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        model(*inputs)
+    stream.synchronize()
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+
+    # record
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        static_outputs = model(*static_inputs)
+    if not isinstance(static_outputs, (list, tuple)):
+        static_outputs = (static_outputs,)
+
+    def run(*new_inputs):
+        assert len(static_inputs) == len(new_inputs)
+        for idx, (dst, src) in enumerate(zip(static_inputs, new_inputs)):
+            if idx in static_input_idxs:
+                assert dst.data_ptr() == src.data_ptr()
+            else:
+                dst.copy_(src)
+        graph.replay()
+        return static_outputs
+
+    return run
+
+
+def count_tangents(fx_g: torch.fx.GraphModule):
+    """
+    Infers which inputs are static for a backwards graph
+    """
+
+    def is_not_gradout(x):
+        return "tangents" not in x.name
+
+    arg_count = 0
+    static_arg_idxs = []
+    for n in fx_g.graph.nodes:
+        if n.op == "placeholder":
+            if is_not_gradout(n):
+                static_arg_idxs.append(arg_count)
+            arg_count += 1
+
+    assert static_arg_idxs == list(range(len(static_arg_idxs)))
+    return len(static_arg_idxs)
+
+
 def compile_fx_training(
-    model: torch.fx.GraphModule, example_inputs: List[torch.Tensor]
+    model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]
 ):
     from torchdynamo.optimizations.backends import aot_autograd
 
+    def fw_compiler(model: torch.fx.GraphModule, example_inputs):
+        # model.graph.print_tabular()
+        fixed = len(example_inputs) - len(example_inputs_)
+        return compile_fx_inner(model, example_inputs, num_fixed=fixed)
+
+    def bw_compiler(model: torch.fx.GraphModule, example_inputs):
+        fixed = count_tangents(model)
+        return compile_fx_inner(model, example_inputs, num_fixed=fixed)
+
     return aot_autograd(
-        model,
-        example_inputs,
-        fw_compiler=compile_fx_inner,
+        model_,
+        example_inputs_,
+        fw_compiler=fw_compiler,
+        bw_compiler=bw_compiler,
         decompositions=decompositions,
     )

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -188,15 +188,28 @@ def cudagraphify(model, inputs, static_input_idxs=()):
     if not isinstance(static_outputs, (list, tuple)):
         static_outputs = (static_outputs,)
 
-    def run(*new_inputs):
-        assert len(static_inputs) == len(new_inputs)
-        for idx, (dst, src) in enumerate(zip(static_inputs, new_inputs)):
-            if idx in static_input_idxs:
-                assert dst.data_ptr() == src.data_ptr()
-            else:
-                dst.copy_(src)
-        graph.replay()
-        return static_outputs
+    if config.size_asserts:
+
+        def run(*new_inputs):
+            assert len(static_inputs) == len(new_inputs)
+            for idx, (dst, src) in enumerate(zip(static_inputs, new_inputs)):
+                if idx in static_input_idxs:
+                    assert dst.data_ptr() == src.data_ptr()
+                else:
+                    dst.copy_(src)
+            graph.replay()
+            return static_outputs
+
+    else:
+        copy_indices = [
+            idx for idx in range(len(static_inputs)) if idx not in static_input_idxs
+        ]
+
+        def run(*new_inputs):
+            for idx in copy_indices:
+                static_inputs[idx].copy_(new_inputs[idx])
+            graph.replay()
+            return static_outputs
 
     return run
 

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -33,6 +33,10 @@ realize_reads_threshold = 4
 realize_bytes_threshold = 2000
 
 
+# fallback to eager for random/dropout, this is slow bug useful for debugging
+fallback_random = False
+
+
 # config specific to codegen/cpp.pp
 class cpp:
     threads = -1  # set to cpu_count()

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2007,6 +2007,7 @@ class FallbackKernel(ExternKernelAlloc):
                 f"{kernel.__module__.replace('._ops.', '.ops.')}.{kernel.__name__}"
             )
         self.unflatten_args = unflatten_args
+        log.warning(f"Using FallbackKernel: {self.kernel}")
 
     def codegen_args(self):
         @dataclasses.dataclass

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -586,27 +586,6 @@ def _embedding_bag(
     )
 
 
-@register_lowering(aten.native_dropout, type_promote=False)
-def native_dropout(x, p, train):
-    # There is a decomp in core for this, but it produces different answers than eager
-    if train:
-        return list(
-            map(
-                TensorBox.create,
-                ir.FallbackKernel.create(aten.native_dropout, x, p, train),
-            )
-        )
-    return x, ones_like(x, dtype=torch.bool)
-
-
-@register_lowering(aten.bernoulli_, type_promote=False)
-def bernoulli_(x, *args):
-    x.realize()
-    V.graph.realize_users_of(x.get_name())
-    ir.InplaceBernoulliFallback(x, *args)
-    return x
-
-
 def make_fallback(kernel):
     needs_realized_inputs.add(kernel)
 
@@ -617,6 +596,78 @@ def make_fallback(kernel):
             return list(map(TensorBox.create, result))
         else:
             return TensorBox.create(result)
+
+
+if config.fallback_random:
+
+    @register_lowering(aten.native_dropout, type_promote=False)
+    def native_dropout(x, p, train):
+        # There is a decomp in core for this, but it produces different answers than eager
+        if train:
+            return list(
+                map(
+                    TensorBox.create,
+                    ir.FallbackKernel.create(aten.native_dropout, x, p, train),
+                )
+            )
+        return x, ones_like(x, dtype=torch.bool)
+
+    @register_lowering(aten.bernoulli_, type_promote=False)
+    def bernoulli_(x, *args):
+        x.realize()
+        V.graph.realize_users_of(x.get_name())
+        ir.InplaceBernoulliFallback(x, *args)
+        return x
+
+    make_fallback(aten.rand)
+else:
+    # native_dropout handled in decomps
+    # bernoulli_ handled in decomps
+
+    @register_lowering(aten.rand)
+    def rand(
+        *size, dtype=None, layout=0, device=None, pin_memory=False, memory_format=None
+    ):
+        assert not pin_memory
+        assert layout in (0, torch.strided)
+        assert memory_format in (None, torch.contiguous_format)
+        device = decode_device(device)
+        dtype = dtype or torch.get_default_dtype()
+        if len(size) == 1 and isinstance(size[0], (list, tuple, torch.Size)):
+            size = tuple(size[0])
+        size = [sympy.expand(s) for s in size]
+        offset = V.graph.increment_randomness_offset(sympy_product(size))
+
+        if device.type == "cuda":
+            random_pos = ir.FixedLayout(
+                device,
+                dtype,
+                size,
+                ir.FlexibleLayout.contiguous_strides(size),
+                offset=offset,
+            ).make_indexer()
+            seed_buffer = V.graph.random_seed_buffer(device)
+
+            def inner_fn(index):
+                return ops.rand(
+                    ops.load(seed_buffer, sympy.Integer(0)),
+                    ops.index_expr(random_pos(index), torch.int32),
+                )
+
+        else:
+            # on CPU we use mt19937 which doesn't use the offset
+            # TODO(jansel): we should rewrite CPU RNG to be closer to cuda and deterministic
+            seed_var = V.graph.sizevars.seed()
+
+            def inner_fn(index):
+                return ops.rand_cpu(ops.index_expr(seed_var, torch.int32), dtype)
+
+        return Pointwise.create(
+            device=device,
+            dtype=dtype,
+            inner_fn=inner_fn,
+            ranges=list(size),
+        )
 
 
 if has_torchvision_roi_align():
@@ -633,7 +684,6 @@ make_fallback(aten._fused_moving_avg_obs_fq_helper)
 make_fallback(aten.grid_sampler_2d)
 make_fallback(aten.max_pool2d_with_indices_backward)
 make_fallback(aten.native_batch_norm_backward)
-make_fallback(aten.native_dropout_backward)
 make_fallback(aten.randperm)
 make_fallback(aten.reflection_pad2d_backward)
 make_fallback(aten.sort)
@@ -942,31 +992,9 @@ def _full(fill_value, device, dtype, size):
     )
 
 
-def constant_like(fill_value):
-    def _constant_like(
-        x, *, dtype=None, device=None, layout=0, pin_memory=False, memory_format=None
-    ):
-        assert not pin_memory
-        assert layout in (0, torch.strided)
-        assert memory_format in (None, torch.contiguous_format)
-        if dtype is None:
-            dtype = x.get_dtype()
-        else:
-            dtype = decode_dtype(dtype)
-        device = device or x.get_device()
-        return _full(fill_value, device, dtype, x.get_size())
-
-    return _constant_like
-
-
-empty_like = register_lowering(aten.empty_like)(constant_like(0))
-zeros_like = register_lowering(aten.zeros_like)(constant_like(0))
-ones_like = register_lowering(aten.ones_like)(constant_like(1))
-
-
 @register_lowering(aten.full_like)
 def full_like(x, fill_value, **kwargs):
-    return constant_like(fill_value)(x, **kwargs)
+    return create_tensor_like(tensor_constructor(fill_value))(x, **kwargs)
 
 
 def tensor_constructor(fill_value):
@@ -981,15 +1009,54 @@ def tensor_constructor(fill_value):
         dtype = dtype or torch.get_default_dtype()
         if len(size) == 1 and isinstance(size[0], (list, tuple, torch.Size)):
             size = tuple(size[0])
-        size = [sympy.Integer(s) for s in size]
+        size = [sympy.expand(s) for s in size]
         return _full(fill_value, device, dtype, size)
 
     return inner
 
 
-register_lowering([torch.empty, aten.empty])(tensor_constructor(0))
-register_lowering([torch.zeros, aten.zeros])(tensor_constructor(0))
-register_lowering([torch.ones, aten.ones])(tensor_constructor(1))
+empty = register_lowering([torch.empty, aten.empty])(tensor_constructor(0))
+zeros = register_lowering([torch.zeros, aten.zeros])(tensor_constructor(0))
+ones = register_lowering([torch.ones, aten.ones])(tensor_constructor(1))
+
+
+def create_tensor_like(creation_fn):
+    """
+    Shim to convert X_like(...) into X(...).  For example zeros_like() into zeros().
+    """
+
+    def _constant_like(
+        x, *, dtype=None, device=None, layout=0, pin_memory=False, memory_format=None
+    ):
+        assert not pin_memory
+        assert layout in (0, torch.strided)
+        assert memory_format in (None, torch.contiguous_format)
+        if dtype is None:
+            dtype = x.get_dtype()
+        else:
+            dtype = decode_dtype(dtype)
+        device = device or x.get_device()
+        size = list(x.get_size())
+        return creation_fn(
+            size,
+            dtype=dtype,
+            device=device,
+            layout=layout,
+            pin_memory=pin_memory,
+            memory_format=memory_format,
+        )
+
+    return _constant_like
+
+
+def constant_like(fill_value):
+    return create_tensor_like(tensor_constructor(fill_value))
+
+
+empty_like = register_lowering(aten.empty_like)(create_tensor_like(empty))
+zeros_like = register_lowering(aten.zeros_like)(create_tensor_like(zeros))
+ones_like = register_lowering(aten.ones_like)(create_tensor_like(ones))
+rand_like = register_lowering(aten.rand_like)(create_tensor_like(rand))
 
 
 def new_constant(fill_value):

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -264,7 +264,9 @@ class SizeVarAllocator(object):
         """Assign all symbolic shapes to locals"""
 
         if self.need_seed:
-            code.writeline("seed = random.randrange(2**31)")
+            code.writeline(
+                "seed = torch.randint(2**31, size=(), dtype=torch.int32).item()"
+            )
 
         @functools.lru_cache(None)
         def sizeof(name):

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -40,8 +40,19 @@ class SizeVarAllocator(object):
         self.var_to_val: Dict[Expr, int] = collections.OrderedDict()
         self.guards = []
         self.replacements = {}
+        self.need_seed = False
         if not zero_one_const:
             self.val_to_var.clear()
+
+    def seed(self):
+        """
+        Seed is a special variable used to hold the rng seed for a graph.
+
+        Note this is only used by the CPU backend, we put seeds in a
+        1-element tensor for the CUDA backend.
+        """
+        self.need_seed = True
+        return sympy.Symbol("seed")
 
     def simplify(self, expr):
         return sympy.expand(expr).subs(self.replacements)
@@ -251,6 +262,9 @@ class SizeVarAllocator(object):
 
     def codegen(self, code, graph_inputs):
         """Assign all symbolic shapes to locals"""
+
+        if self.need_seed:
+            code.writeline("seed = random.randrange(2**31)")
 
         @functools.lru_cache(None)
         def sizeof(name):


### PR DESCRIPTION
Example output:
```
seed_cuda_0 = None  # 94243ad63b02490aa7e207bad45cb26ee512c3d7571c22796c9e2de91622ecb9

@pointwise_heuristics(size_hints=[1024])
@triton.jit
def kernel0(seed0, in_ptr1, out_ptr0, ks0, xnumel, XBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK])
    xmask = xindex < xnumel
    x0 = xindex
    tmp0 = tl.load(seed0 + 0, None)
    tmp6 = tl.load(in_ptr1 + x0, xmask)
    tmp1 = x0
    tmp2 = tl.rand(tmp0, tmp1)
    tmp3 = 0.5
    tmp4 = tmp2 > tmp3
    tmp5 = tmp4.to(tl.float32)
    tmp7 = tmp5 * tmp6
    tmp8 = 2.0
    tmp9 = tmp7 * tmp8
    tl.store(out_ptr0 + x0, tmp9, xmask)


def call(arg0):
    seed_cuda_0.fill_(random.randrange(2**31))
    arg0_size = arg0.size()
    s0 = arg0_size[0]
    buf0 = empty_strided((s0, ), (1, ), device='cuda', dtype=torch.float32)
    kernel0[grid(s0)](seed_cuda_0, arg0, buf0, s0, s0)
    return (buf0, )

```