### PR TITLE
[inductor] Fix bug with invalidated reuse

### DIFF
--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -438,11 +438,13 @@ class CSE:
         self.store_cache = store_cache or {}
         self.reduction_cache = reduction_cache or {}
         self.iter_buffer_ids = iter_buffers or itertools.count()
+        self.invalidated_stores = set()
 
     def invalidate(self, keep_vars: typing.Set[str]):
         for name, tmp in list(self.store_cache.items()):
             if tmp not in keep_vars:
                 del self.store_cache[name]
+                self.invalidated_stores.add(name)
         self.cache = {k: v for k, v in self.cache.items() if v in keep_vars}
 
     def clone(self):
@@ -497,6 +499,7 @@ class Kernel(CodeGen):
         self.compute = IndentedBuffer()
         self.stores = DeferredIndentedBuffer()
         self.cse = CSE(self.newvar_prefix, self.suffix)
+        self.must_keep_buffers = set()
 
     @contextlib.contextmanager
     def swap_buffers(self, lb, cb=None, sb=None):
@@ -552,6 +555,10 @@ class Kernel(CodeGen):
 
             @staticmethod
             def load(name: str, index: sympy.Expr, upcast: bool = False):
+                if name in self.cse.invalidated_stores:
+                    # A load from an invalidated store requires us to
+                    # keep the actual buffer around
+                    V.kernel.must_keep_buffers.add(name)
                 if "tmp" in str(index):
                     return self.indirect_load(name, index, upcast)
                 store_cache = self.cse.store_cache

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -536,6 +536,8 @@ class Scheduler:
         # If all the uses of this buffer are also in self.pending_buffer_names,
         # it means the buffer becomes kernel-local after fusion
         for name in self.pending_buffer_names:
+            if name in V.kernel.must_keep_buffers:
+                continue
             node = self.name_to_node[name]
             is_live = any(
                 [


### PR DESCRIPTION
We were hitting a bug in some training benchmarks where you had:
```
for roffset in range(0, rnumel, RBLOCK):
   ...
   write to bufX
   ...
...
for roffset in range(0, rnumel, RBLOCK):
   ...
   read from bufX
   ...
```

Since these get fused into a single kernel, we would remove bufX, which would result in an error of trying to read from an undefined buffer.