### PR TITLE
Revert "Enable guard_nn_modules - Observe module changes to drive inv…

### DIFF
--- a/torchdynamo/__init__.py
+++ b/torchdynamo/__init__.py
@@ -24,8 +24,6 @@ __all__ = [
 
 
 def reset():
-    from torchdynamo.guards import NNModuleChangeTrackerUtil
-
     """Clear all compile caches and restore initial state"""
     for weak_code in convert_frame.input_codes.seen + convert_frame.output_codes.seen:
         code = weak_code()
@@ -35,7 +33,6 @@ def reset():
     convert_frame.output_codes.clear()
     orig_code_map.clear()
     guard_failures.clear()
-    NNModuleChangeTrackerUtil.de_register_patches_on_torch_nn_module()
     resume_execution.ContinueExecutionCache.cache.clear()
 
 

--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -47,7 +47,7 @@ base_dir = dirname(dirname(abspath(__file__)))
 dynamic_shapes = os.environ.get("TORCHDYNAMO_DYNAMIC_SHAPES") == "1"
 
 # Set this to False to assume nn.Modules() contents are immutable (similar assumption as freezing)
-guard_nn_modules = True
+guard_nn_modules = False
 
 # Run the FX graph as it is created to get better type information
 dynamic_propagation = True

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -72,10 +72,6 @@ class _TorchDynamoContext:
         self.prior = unset
         self.backend_ctx.__exit__(exc_type, exc_val, exc_tb)
 
-        from torchdynamo.guards import NNModuleChangeTrackerUtil
-
-        NNModuleChangeTrackerUtil.de_register_patches_on_torch_nn_module()
-
     def __call__(self, fn):
         assert callable(fn)
         callback = self.callback

--- a/torchdynamo/guards.py
+++ b/torchdynamo/guards.py
@@ -1,7 +1,6 @@
 import collections
 import dataclasses
 import enum
-import functools
 import logging
 import math
 import os
@@ -29,7 +28,6 @@ from ._guards import check_type_id
 from .eval_frame import set_guard_error_hook
 from .eval_frame import set_guard_fail_hook
 from .exc import unimplemented
-from .utils import ExactWeakKeyDictionary
 from .utils import guard_failures
 from .utils import istype
 from .utils import orig_code_map
@@ -39,12 +37,6 @@ from .utils import tuple_iterator_len
 
 log = logging.getLogger(__name__)
 
-# This is a map from modules, to code. Module code map is keyed on a weakref of a module
-# itself, and is a critical component of observing module changes.
-# torch.nn.Modules are not guarded in the traditional way, but instead are patched with
-# observers to invalidate on change. This is done as an optimization allowing us to guard on modules.
-# see config.guard_nn_modules and guard_is_module_associated
-module_code_map = ExactWeakKeyDictionary()  # {nn.Module: Set[GuardedCode]}
 
 CLOSURE_VARS = collections.OrderedDict(
     [
@@ -58,88 +50,6 @@ CLOSURE_VARS = collections.OrderedDict(
         ("inf", float("inf")),
     ]
 )
-
-
-class NNModuleChangeTrackerUtil:
-    original_register_parameter = None
-    original_add_module = None
-    original_load_state_dict = None
-    original_setattr = None
-
-    @classmethod
-    def register_patches_on_torch_nn_module(cls):
-        torch_nn_module_cls = torch.nn.Module
-        if getattr(torch_nn_module_cls, "__dynamo_module_patch", True):
-            # register_parameter
-            torch_nn_module_cls.__dynamo_module_patch = False
-
-            original_register_parameter = torch_nn_module_cls.register_parameter
-
-            @functools.wraps(original_register_parameter)
-            def custom_register_parameter(self, key, value):
-                NNModuleChangeTrackerUtil.invalidate_module(self)
-                return original_register_parameter(self, key, value)
-
-            torch_nn_module_cls.register_parameter = custom_register_parameter
-
-            # add_module
-            original_add_module = torch_nn_module_cls.add_module
-
-            @functools.wraps(original_add_module)
-            def custom_add_module(self, name, module):
-                NNModuleChangeTrackerUtil.invalidate_module(self)
-                return original_add_module(self, name, module)
-
-            torch_nn_module_cls.add_module = custom_add_module
-
-            # load_state_dict
-            original_load_state_dict = torch_nn_module_cls.load_state_dict
-
-            @functools.wraps(original_load_state_dict)
-            def custom_load_state_dict(self, state_dict, strict):
-                NNModuleChangeTrackerUtil.invalidate_module(self)
-                return original_load_state_dict(self, state_dict, strict)
-
-            torch_nn_module_cls.load_state_dict = custom_load_state_dict
-
-            # __setattr__
-            original_setattr = torch_nn_module_cls.__setattr__
-
-            @functools.wraps(original_setattr)
-            def custom_setattr(self, key, value):
-                NNModuleChangeTrackerUtil.invalidate_module(self)
-                return original_setattr(self, key, value)
-
-            torch_nn_module_cls.__setattr__ = custom_setattr
-            cls.original_register_parameter = original_register_parameter
-            cls.original_add_module = original_add_module
-            cls.original_load_state_dict = original_load_state_dict
-            cls.original_setattr = original_setattr
-
-    @classmethod
-    def de_register_patches_on_torch_nn_module(cls):
-        torch_nn_module_cls = torch.nn.Module
-        if hasattr(
-            torch_nn_module_cls, "_NNModuleChangeTrackerUtil__dynamo_module_patch"
-        ):
-            torch_nn_module_cls.__setattr__ = cls.original_setattr
-            torch_nn_module_cls.load_state_dict = cls.original_load_state_dict
-            torch_nn_module_cls.add_module = cls.original_add_module
-            torch_nn_module_cls.register_parameter = cls.original_register_parameter
-            delattr(
-                torch_nn_module_cls, "_NNModuleChangeTrackerUtil__dynamo_module_patch"
-            )
-
-    @staticmethod
-    def invalidate_module(module):
-        if module not in module_code_map:
-            # Module is out of scope / deleted (weak ref key ref dict)
-            return
-
-        for code in module_code_map[module]:
-            code.valid = False
-
-        del module_code_map[module]
 
 
 class GuardSource(enum.Enum):
@@ -268,10 +178,6 @@ class GuardBuilder:
         self.tensor_check_names = []
         self.tensor_check_examples = []
         self.guarded_code = guarded_code
-        # A set of the ids of all objects tracked for invalidation
-        self.module_associated_guarded_ids = set()
-        # map from module ids to the ids of objects tracked for invalidation
-        self.module_to_guard_ids = ExactWeakKeyDictionary()  # {nn.Module: Set[id]}
 
     def get(self, name: str):
         return eval(name, self.scope, CLOSURE_VARS)
@@ -288,9 +194,6 @@ class GuardBuilder:
         return name
 
     def TYPE_MATCH(self, guard: Guard):
-        if self.guard_is_module_associated(guard):
-            return
-
         # ___check_type_id is same as `id(type(x)) == y`
         t = type(self.get(guard.name))
         obj_id = self.id_ref(t)
@@ -298,9 +201,6 @@ class GuardBuilder:
         self._produce_guard_code(guard, [code])
 
     def ID_MATCH(self, guard: Guard):
-        if self.guard_is_module_associated(guard):
-            return
-
         # ___check_obj_id is same as `id(x) == y`
         m = re.match(r"^type\((.+)\)$", guard.name)
         if m:
@@ -325,10 +225,6 @@ class GuardBuilder:
         self._produce_guard_code(guard, [code], provided_guarded_object=self.get(base))
 
     def EQUALS_MATCH(self, guard: Guard):
-        val = self.get(guard.name)
-        if self.guard_is_module_associated(guard):
-            return
-
         ref = self.arg_ref(guard)
         val = self.get(guard.name)
         t = type(val)
@@ -394,9 +290,6 @@ class GuardBuilder:
         self._produce_guard_code(guard, code)
 
     def CONSTANT_MATCH(self, guard: Guard):
-        if self.guard_is_module_associated(guard):
-            return
-
         val = self.get(guard.name)
         if istype(val, (bool, type(None))):
             self.ID_MATCH(guard)
@@ -405,18 +298,21 @@ class GuardBuilder:
 
     def NN_MODULE(self, guard: Guard):
         self.ID_MATCH(guard)
-
+        ref = self.arg_ref(guard)
         val = self.get(guard.name)
+
+        def setup_guard():
+            assert istype(val.training, bool)
+            self.code.append(f"{ref}.training == {val.training}")
+
         if hasattr(val, "training"):
-            self.register_module_for_invalidation(val, self.guarded_code)
+            # There are cases where a monkeypatched object has a guard made between __new__ and __init__
+            setup_guard()
         else:
             unimplemented(f"Guard setup for uninitialized class {type(val)}")
 
     def FUNCTION_MATCH(self, guard: Guard):
         """things like torch.add and user defined functions"""
-        if self.guard_is_module_associated(guard):
-            return
-
         if guard.is_local():
             return self.ID_MATCH(guard)
 
@@ -424,9 +320,6 @@ class GuardBuilder:
         return self.FUNCTION_MATCH(guard)
 
     def PYMODULE_MATCH(self, guard: Guard):
-        if self.guard_is_module_associated(guard):
-            return
-
         return self.FUNCTION_MATCH(guard)
 
     def LIST_LENGTH(self, guard):
@@ -462,6 +355,18 @@ class GuardBuilder:
 
         self._produce_guard_code(guard, code)
 
+    def NN_MODULE_PARAM_NAMES(self, guard):
+        ref = self.arg_ref(guard)
+        value = self.get(guard.name)
+        t = type(value)
+        keys = {k for k, v in value.named_parameters()}
+
+        code = list()
+        code.append(f"___check_type_id({ref}, {self.id_ref(t)})")
+        code.append(f"{{k for k, v in {ref}.named_parameters()}} == {keys!r}")
+
+        self._produce_guard_code(guard, code)
+
     def ODICT_KEYS(self, guard):
         """OrderedDict keys match"""
         ref = self.arg_ref(guard)
@@ -489,9 +394,6 @@ class GuardBuilder:
         self._produce_guard_code(guard, [code])
 
     def TENSOR_MATCH(self, guard: Guard):
-        if self.guard_is_module_associated(guard):
-            return
-
         if guard.is_nn_module():
             self.ID_MATCH(guard)
         else:
@@ -544,38 +446,6 @@ class GuardBuilder:
             obj_ref,
         )
 
-    def register_module_for_invalidation(self, module, guarded_code):
-        NNModuleChangeTrackerUtil.register_patches_on_torch_nn_module()
-        module_id = id(module)
-        if module_id not in self.module_to_guard_ids:
-            self.module_to_guard_ids[module] = set()
-
-        for buffer in module.buffers():
-            buffer_id = id(buffer)
-            self.module_associated_guarded_ids.add(buffer_id)
-            self.module_to_guard_ids[module].add(buffer_id)
-
-        for mod in module.modules():
-            mod_id = id(mod)
-            self.module_associated_guarded_ids.add(mod_id)
-            self.module_to_guard_ids[module].add(mod_id)
-
-        for parameter in module.parameters():
-            parameter_id = id(parameter)
-            self.module_associated_guarded_ids.add(parameter_id)
-            self.module_to_guard_ids[module].add(parameter_id)
-
-        if module not in module_code_map:
-            module_code_map[module] = set()
-        module_code_map[module].add(guarded_code)
-
-    def guard_is_module_associated(self, guard):
-        if config.guard_nn_modules and guard.is_nn_module():
-            val = self.get(guard.name)
-            if id(val) in self.module_associated_guarded_ids:
-                return True
-        return False
-
 
 @dataclasses.dataclass
 class GuardedCode:
@@ -610,7 +480,6 @@ class CheckFunctionManager:
             if not config.guard_nn_modules and guard.is_nn_module():
                 continue
             guard.create(local_builder, global_builder)
-
         self.check_fn = self.compile_check_fn(local_builder, global_builder)
         self._seen_ids.clear()
 

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1218,7 +1218,6 @@ class InstructionTranslator(InstructionTranslatorBase):
         self.one_graph: bool = one_graph
         vars = list(code_options["co_varnames"])
         vars.extend(x for x in self.cell_and_freevars() if x not in vars)
-
         self.symbolic_locals = collections.OrderedDict(
             (k, VariableBuilder(self, LocalSource(k))(f_locals[k]))
             for k in vars

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -118,9 +118,6 @@ class ExactWeakKeyDictionary:
         self.refs.clear()
         self.values.clear()
 
-    def __delitem__(self, idx):
-        self._remove_id(id(idx))
-
 
 def istype(obj, allowed_types):
     """isinstance() without subclasses"""

--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -435,6 +435,9 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
 
             if method is torch.nn.Module.parameters:
                 assert not args or kwargs
+                options["guards"].add(
+                    self.source.create_guard(GuardBuilder.NN_MODULE_PARAM_NAMES)
+                )
                 items = []
                 for name, value in self.value.named_parameters():
                     items.append(


### PR DESCRIPTION
…alidation instead of id_match + training guards (#326)"

This reverts commit c74758022b438e3e9bd31c8b0775d47b022fef4b.

This PR is causing infinite loops in inductor training. To repro checkout the repro326 branch https://github.com/pytorch/torchdynamo/tree/repro326 and run:
```
./benchmarks/torchbench.py -dcuda --inductor --training --float16 -k attention_is_all_you_need_pytorch
```
(This should also repro on main once all my pending PRs are merged)

Output:
```
Traceback (most recent call last):
  File "./benchmarks/torchbench.py", line 340, in <module>
    main(TorchBenchmarkRunner(), original_dir)
  File "/home/jansel/torchdynamo/benchmarks/common.py", line 1169, in main
    runner.run_one_model(
  File "/home/jansel/torchdynamo/benchmarks/common.py", line 649, in run_one_model
    model_iter_fn(model, example_inputs)
  File "./benchmarks/torchbench.py", line 328, in forward_and_backward_pass
    pred = mod(*cloned_inputs)
  File "/home/jansel/pytorch/torch/nn/modules/module.py", line 1186, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/jansel/torchbenchmark/torchbenchmark/models/attention_is_all_you_need_pytorch/transformer/Models.py", line 172, in forward
    dec_output, *_ = self.decoder(trg_seq, trg_mask, enc_output, src_mask)
  File "/home/jansel/pytorch/torch/nn/modules/module.py", line 1186, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/jansel/torchbenchmark/torchbenchmark/models/attention_is_all_you_need_pytorch/transformer/Models.py", line 101, in forward
    def forward(self, trg_seq, trg_mask, enc_output, src_mask, return_attns=False):
  File "/home/jansel/torchdynamo/torchdynamo/eval_frame.py", line 97, in _fn
    return fn(*args, **kwargs)
  File "/home/jansel/pytorch/torch/nn/modules/module.py", line 1186, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/jansel/functorch/functorch/_src/aot_autograd.py", line 642, in forward
    return compiled_f(
  File "/home/jansel/torchdynamo/torchdynamo/eval_frame.py", line 97, in _fn
    return fn(*args, **kwargs)
  File "/home/jansel/functorch/functorch/_src/aot_autograd.py", line 187, in forward
    fx_g = make_fx(joint_forward_backward, aot_decompositions)(
  File "/home/jansel/pytorch/torch/fx/experimental/proxy_tensor.py", line 281, in wrapped
    t = dispatch_trace(wrap_key(f, args), tracer=fx_tracer, concrete_args=tuple(phs))
  File "/home/jansel/torchdynamo/torchdynamo/eval_frame.py", line 97, in _fn
    return fn(*args, **kwargs)
  File "/home/jansel/pytorch/torch/fx/experimental/proxy_tensor.py", line 179, in dispatch_trace
    return GraphModule(tracer.root, graph, name)
  File "/home/jansel/pytorch/torch/fx/graph_module.py", line 366, in __init__
    self.graph = graph
  File "/home/jansel/torchdynamo/torchdynamo/guards.py", line 111, in custom_setattr
    return original_setattr(self, key, value)
  File "/home/jansel/torchdynamo/torchdynamo/guards.py", line 111, in custom_setattr
    return original_setattr(self, key, value)
  File "/home/jansel/torchdynamo/torchdynamo/guards.py", line 111, in custom_setattr
    return original_setattr(self, key, value)
  [Previous line repeated 490 more times]
  File "/home/jansel/pytorch/torch/nn/modules/module.py", line 1309, in __setattr__
    super().__setattr__(name, value)
  File "/home/jansel/pytorch/torch/fx/graph_module.py", line 402, in graph
    self._graph = g
  File "/home/jansel/torchdynamo/torchdynamo/guards.py", line 111, in custom_setattr
    return original_setattr(self, key, value)
  File "/home/jansel/torchdynamo/torchdynamo/guards.py", line 111, in custom_setattr
    return original_setattr(self, key, value)
  File "/home/jansel/torchdynamo/torchdynamo/guards.py", line 111, in custom_setattr
    return original_setattr(self, key, value)
  [Previous line repeated 476 more times]
  File "/home/jansel/torchdynamo/torchdynamo/guards.py", line 110, in custom_setattr
    NNModuleChangeTrackerUtil.invalidate_module(self)
  File "/home/jansel/torchdynamo/torchdynamo/guards.py", line 135, in invalidate_module
    if module not in module_code_map:
  File "/home/jansel/torchdynamo/torchdynamo/utils.py", line 103, in __contains__
    return id(key) in self.values
RecursionError: maximum recursion depth exceeded while calling a Python object
```
