### PR TITLE
[inductor] Workaround triton bug with XBLOCK=1

### DIFF
--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -149,7 +149,8 @@ def reduction_heuristics(size_hints):
         return autotune(
             [
                 triton_config_reduction(size_hints, 32, 128, num_stages=2),
-                triton_config_reduction(size_hints, 1, 2048, num_stages=1),
+                # Note, we can't do xblock=1 due to https://github.com/openai/triton/issues/574
+                triton_config_reduction(size_hints, 2, 1024, num_stages=1),
             ],
             key=["xnumel", "rnumel"],
         )


### PR DESCRIPTION
Workaround for https://github.com/openai/triton/issues/574

This slows things down a bit, but fixes 14 segfaults