### PR TITLE
Testfix - Disable cache size limit for dynamic shape test

### DIFF
--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -7,6 +7,7 @@ import torch
 import torchdynamo.testing
 from torchdynamo import config
 from torchdynamo.testing import unsupported
+from torchdynamo.utils import disable_cache_limit
 
 globalmod = torch.nn.ReLU()
 
@@ -343,6 +344,7 @@ class SubGraphTests(torchdynamo.testing.TestCase):
 
         self._common(fn, 2, 6)
 
+    @disable_cache_limit()
     def test_dynamic_shapes(self):
         def fn(a, b):
             return a - b * 10


### PR DESCRIPTION
Makes the tests agnostic to cache_size_limit. For smaller cache_size_limit like 8, the test_dynamic_shapes fails. Resolves one of the failures observed in https://github.com/pytorch/pytorch/pull/80106