### PR TITLE
Support _get_abs_string_index of nn Module

### DIFF
--- a/torchdynamo/exc.py
+++ b/torchdynamo/exc.py
@@ -2,6 +2,7 @@ import dataclasses
 import os
 import traceback
 
+import torchdynamo.config as config
 from torchdynamo.utils import counters
 
 
@@ -66,6 +67,8 @@ class Unsupported(RuntimeError):
 
 
 def unimplemented(msg: str):
+    if config.debug:
+        print("Unimplemented - causing graph break:", msg)
     assert msg != os.environ.get("BREAK", False)
     raise Unsupported(msg)
 

--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -350,24 +350,13 @@ class NNModuleVariable(VariableTracker):
                 **options,
             )
         elif name == "_get_abs_string_index":
-            assert (
-                not kwargs
-                and len(args) == 1
-                and isinstance(args[0], variables.ConstantVariable)
+            # Inline the function
+            fn = getattr(module, name).__func__
+            return tx.inline_user_function_return(
+                variables.UserFunctionVariable(fn, **options),
+                [self] + args,
+                kwargs,
             )
-            assert type(module) in (
-                torch.nn.ModuleList,
-                torch.nn.ParameterList,
-            ), typestr(module)
-            assert self.source
-
-            len_modules = len(module)
-            idx = args[0].as_python_constant()
-            assert -len_modules <= idx < len_modules
-
-            if idx < 0:
-                idx += len_modules
-            return ConstantVariable(str(idx))
         else:
             return super().call_method(tx, name, args, kwargs)
 

--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -349,6 +349,25 @@ class NNModuleVariable(VariableTracker):
                 source=NNModuleSource(GetItemSource(self.source, key)),
                 **options,
             )
+        elif name == "_get_abs_string_index":
+            assert (
+                not kwargs
+                and len(args) == 1
+                and isinstance(args[0], variables.ConstantVariable)
+            )
+            assert type(module) in (
+                torch.nn.ModuleList,
+                torch.nn.ParameterList,
+            ), typestr(module)
+            assert self.source
+
+            len_modules = len(module)
+            idx = args[0].as_python_constant()
+            assert -len_modules <= idx < len_modules
+
+            if idx < 0:
+                idx += len_modules
+            return ConstantVariable(str(idx))
         else:
             return super().call_method(tx, name, args, kwargs)
 


### PR DESCRIPTION
This resolves the recompilation error for T5 models (https://github.com/pytorch/torchdynamo/issues/473). Difficult to repro it standalone.

However, I think the root of the re-compilation in T5 is different. Still debugging that part.