### PR TITLE
[inductor] Fix a bmm related bug

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -779,7 +779,7 @@ class CommonTemplate:
         )
         self.common(mod, (torch.randn(2, 8),))
 
-    def test_bmm(self):
+    def test_bmm1(self):
         def fn(a, b):
             return (
                 torch.bmm(a, b),
@@ -799,6 +799,19 @@ class CommonTemplate:
             (
                 torch.randn(1, 16, 8),
                 torch.randn(1, 8, 10),
+            ),
+            check_lowp=False,
+        )
+
+    def test_bmm2(self):
+        def fn(a, b):
+            return torch.bmm(a.permute(0, 2, 1), b)
+
+        self.common(
+            fn,
+            (
+                torch.randn(1, 8, 8),
+                torch.randn(1, 8, 8),
             ),
             check_lowp=False,
         )

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1893,7 +1893,11 @@ class BatchMatrixMultiply(ExternKernelOut):
             size=[b3, m, n],
         ).as_fixed()
 
-        if b3 == 1:
+        if (
+            b3 == 1
+            and is_contiguous_storage_and_layout(a)
+            and is_contiguous_storage_and_layout(b)
+        ):
             # convert to normal mm
             data = MatrixMultiply(
                 layout=output_layout.as_fixed(),


### PR DESCRIPTION
Summary: The bug is exposed with pytorch_struct training run. We need to
be conservative on the optimization for bs=1 bmm, when any operand is not consecutive.