### PR TITLE
Special support for HFPretrainedConfig class objects

### DIFF
--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -41,6 +41,7 @@ from .constant import ConstantVariable
 from .constant import EnumVariable
 from .dicts import ConstDictVariable
 from .dicts import DataClassVariable
+from .dicts import HFPretrainedConfigVariable
 from .functions import UserFunctionVariable
 from .lists import ListIteratorVariable
 from .lists import ListVariable
@@ -290,6 +291,10 @@ class VariableBuilder:
         elif DataClassVariable.is_matching_object(value):
             return DataClassVariable.wrap(self, value).add_guards(
                 make_guards(GuardBuilder.TYPE_MATCH)
+            )
+        elif HFPretrainedConfigVariable.is_matching_object(value):
+            return HFPretrainedConfigVariable(
+                value, guards=make_guards(GuardBuilder.TYPE_MATCH)
             )
         elif isinstance(value, slice):
             start = ConstantVariable(value.start)

--- a/torchdynamo/variables/dicts.py
+++ b/torchdynamo/variables/dicts.py
@@ -279,3 +279,32 @@ class DataClassVariable(ConstDictVariable):
                 assert variables.ConstantVariable.is_literal(defaults[name])
                 return variables.ConstantVariable(defaults[name]).add_options(self)
         super(DataClassVariable, self).var_getattr(tx, name)
+
+
+class HFPretrainedConfigVariable(VariableTracker):
+    """
+    Hack for HuggingFace PretrainedConfig
+    """
+
+    @staticmethod
+    def is_matching_cls(cls):
+        try:
+            from transformers.configuration_utils import PretrainedConfig
+
+            return issubclass(cls, PretrainedConfig)
+        except ImportError:
+            return False
+
+    @classmethod
+    def is_matching_object(cls, obj):
+        return cls.is_matching_cls(type(obj))
+
+    def __init__(self, obj, **kwargs):
+        super(HFPretrainedConfigVariable, self).__init__(**kwargs)
+        self.obj = obj
+        assert self.is_matching_cls(type(obj))
+
+    def var_getattr(self, tx, name: str) -> "VariableTracker":
+        from . import ConstantVariable
+
+        return ConstantVariable(getattr(self.obj, name))


### PR DESCRIPTION
~~@jansel This is for the HF models __get_attribute__ method~~

<img width="636" alt="image" src="https://user-images.githubusercontent.com/13822661/178064154-c368b400-1028-4194-973c-125d2890ee8a.png">

~~I am trying to inline the function, but then it calls object.__get_attribute__. And I am not sure, how to handle it.~~


Update - I also added special handling for HFPretrainedConfig. I am fine with whatever way is better. 

Further update - After offline discussion, decided to go with HFPretrainedConfig.