### PR TITLE
Fix ModelOutput tests

### DIFF
--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -215,7 +215,7 @@ def convert_frame_assert(compiler_fn: Callable, guard_export_fn=None, one_graph=
         ):
             return None
         if code.co_name == "<genexpr>" and code.co_filename.endswith(
-            "transformers/file_utils.py"
+            ("transformers/file_utils.py", "transformers/utils/generic.py")
         ):
             # not needed, but cleans up torchbench error stats
             return None


### PR DESCRIPTION
Transformers have changed the location of __post_init__ function, which is causing `tests/test_model_output.py::TestModelOutput::test_mo_assign` to fail.