### PR TITLE
Revert "Add heuristic to decide when to specialize and when not to (#…

### DIFF
--- a/tests/test_repros.py
+++ b/tests/test_repros.py
@@ -779,7 +779,7 @@ class ReproTests(torchdynamo.testing.TestCase):
                 640,
                 False,
             )
-        self.assertGreaterEqual(torchdynamo.utils.counters["frames"]["ok"], 2)
+        self.assertGreaterEqual(torchdynamo.utils.counters["frames"]["ok"], 3)
         self.assertEqual(
             torchdynamo.utils.counters["frames"]["total"],
             torchdynamo.utils.counters["frames"]["ok"],
@@ -914,9 +914,9 @@ class ReproTests(torchdynamo.testing.TestCase):
             for _ in range(10):
                 self.assertTrue(same(model(a, b, c, d), correct))
 
-        self.assertEqual(cnt.frame_count, ifdyn(4, 3))
+        self.assertEqual(cnt.frame_count, ifdyn(5, 4))
         # TODO(jansel): figure out why op count depends on imports
-        self.assertIn(cnt.op_count, (33, 32, 26, 25))
+        self.assertIn(cnt.op_count, (36, 35, 29, 28))
 
     def test_hf_model_output(self):
         ex = ModelOutput(a=torch.randn(10), b=torch.randn(10), c=torch.randn(10))

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -71,7 +71,6 @@ from .variables.misc import UnknownVariable
 from .variables.misc import WithExitFunctionVariable
 from .variables.nn_module import NNModuleVariable
 from .variables.tensor import TensorVariable
-from .variables.tensor import UnspecializedPythonVariable
 from .variables.torch import TorchVariable
 from .variables.user_defined import UserDefinedVariable
 
@@ -544,10 +543,6 @@ class InstructionTranslatorBase(object):
 
     def COMPARE_OP(self, inst):
         left, right = self.popn(2)
-        if isinstance(left, UnspecializedPythonVariable):
-            left = left.convert_to_constant(self)
-        if isinstance(right, UnspecializedPythonVariable):
-            right = right.convert_to_constant(self)
         options = VariableTracker.propagate([left, right])
         op = inst.argval
         supported_is_const = {

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -414,56 +414,6 @@ def check_constant_args(args, kwargs):
     return all(x.is_python_constant() for x in itertools.chain(args, kwargs.values()))
 
 
-def check_unspec_python_args(args, kwargs):
-    from .variables.constant import ConstantVariable
-    from .variables.tensor import UnspecializedPythonVariable
-
-    return all(
-        isinstance(
-            i,
-            (
-                UnspecializedPythonVariable,
-                ConstantVariable,
-            ),
-        )
-        for i in itertools.chain(args, kwargs.values())
-    ) and any(
-        isinstance(x, UnspecializedPythonVariable)
-        for x in itertools.chain(args, kwargs.values())
-    )
-
-
-def specialize_args_kwargs(tx, args, kwargs):
-    from .variables.tensor import UnspecializedNumpyVariable
-    from .variables.tensor import UnspecializedPythonVariable
-
-    specialized_args = []
-    specialized_kwargs = {}
-    for x in args:
-        if isinstance(
-            x,
-            (
-                UnspecializedNumpyVariable,
-                UnspecializedPythonVariable,
-            ),
-        ):
-            specialized_args.append(x.convert_to_constant(tx))
-        else:
-            specialized_args.append(x)
-    for k, v in kwargs:
-        if isinstance(
-            x,
-            (
-                UnspecializedNumpyVariable,
-                UnspecializedPythonVariable,
-            ),
-        ):
-            specialized_kwargs.update({k: x.convert_to_constant(tx)})
-        else:
-            specialized_kwargs.update({k: v})
-    return specialized_args, specialized_kwargs
-
-
 dict_values = type(dict().values())
 odict_values = type(collections.OrderedDict().values())
 tuple_iterator = type(iter(tuple()))

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -21,10 +21,8 @@ from ..exc import unimplemented
 from ..source import AttrSource
 from ..source import TypeSource
 from ..utils import check_constant_args
-from ..utils import check_unspec_python_args
 from ..utils import istype
 from ..utils import proxy_args_kwargs
-from ..utils import specialize_args_kwargs
 from .base import MutableLocal
 from .base import VariableTracker
 
@@ -183,7 +181,19 @@ class BuiltinVariable(VariableTracker):
         )
 
     def unspec_python_args(self, *args, **kwargs):
-        return check_unspec_python_args(args, kwargs)
+        return all(
+            isinstance(
+                i,
+                (
+                    variables.UnspecializedPythonVariable,
+                    variables.ConstantVariable,
+                ),
+            )
+            for i in itertools.chain(args, kwargs.values())
+        ) and any(
+            isinstance(x, variables.UnspecializedPythonVariable)
+            for x in itertools.chain(args, kwargs.values())
+        )
 
     @staticmethod
     def unwrap_unspec_args_kwargs(args, kwargs):
@@ -218,11 +228,8 @@ class BuiltinVariable(VariableTracker):
     ) -> "VariableTracker":
         constant_args = check_constant_args(args, kwargs)
         tensor_args = self.tensor_args(*args, **kwargs)
-        unspec_python_args = self.unspec_python_args(*args, **kwargs)
         options = VariableTracker.propagate(self, args, kwargs.values())
-        has_constant_handler = self.can_constant_fold_through() and (
-            constant_args or unspec_python_args
-        )
+        has_constant_handler = self.can_constant_fold_through() and constant_args
         assert isinstance(args, list)
         assert isinstance(kwargs, dict)
 
@@ -304,7 +311,6 @@ class BuiltinVariable(VariableTracker):
                 exc.remove_from_stats()
 
         if has_constant_handler:
-            args, kwargs = specialize_args_kwargs(tx, args, kwargs)
             # constant fold
             return variables.ConstantVariable(
                 self.as_python_constant()(
@@ -376,10 +382,7 @@ class BuiltinVariable(VariableTracker):
     call_max = _call_min_max
 
     def call_range(self, tx, *args, **kwargs):
-        if self.unspec_python_args(*args, **kwargs) or self.constant_args(
-            *args, **kwargs
-        ):
-            args, kwargs = specialize_args_kwargs(tx, args, kwargs)
+        if self.constant_args(*args, **kwargs):
             return variables.RangeVariable(
                 value=range(
                     *[x.value for x in args],

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -37,7 +37,6 @@ from ..utils import proxy_args_kwargs
 from .base import MutableLocal
 from .base import VariableTracker
 from .base import typestr
-from .constant import ConstantVariable
 from .lists import ShapeVariable
 from .lists import SizeVariable
 
@@ -645,14 +644,3 @@ class UnspecializedPythonVariable(TensorVariable):
             raw_value=raw_value,
             need_unwrap=need_unwrap,
         )
-
-    def convert_to_constant(self, tx):
-        for graph_arg in tx.output.graphargs:
-            if graph_arg.source is self.source:
-                graph_arg.erase()
-
-        for g in self.guards:
-            if g.name == self.source.name():
-                g.create_fn = GuardBuilder.CONSTANT_MATCH
-
-        return ConstantVariable(value=self.raw_value, guards=self.guards)

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -14,11 +14,9 @@ from .. import variables
 from ..allowed_functions import torch_get_name
 from ..exc import unimplemented
 from ..utils import check_constant_args
-from ..utils import check_unspec_python_args
 from ..utils import istype
 from ..utils import product
 from ..utils import proxy_args_kwargs
-from ..utils import specialize_args_kwargs
 from .base import VariableTracker
 from .tensor import TensorWithTFOverrideVariable
 
@@ -95,14 +93,12 @@ class TorchVariable(VariableTracker):
         from . import TensorVariable
 
         constant_args = check_constant_args(args, kwargs)
-        unspec_python_args = check_unspec_python_args(args, kwargs)
         options = VariableTracker.propagate(self, args, kwargs.values())
 
         if self.value in config.constant_functions:
             assert not args and not kwargs
             return ConstantVariable(config.constant_functions[self.value], **options)
-        elif self.can_constant_fold_through() and (constant_args or unspec_python_args):
-            args, kwargs = specialize_args_kwargs(tx, args, kwargs)
+        elif self.can_constant_fold_through() and constant_args:
             # constant fold
             return ConstantVariable(
                 self.as_python_constant()(


### PR DESCRIPTION
…520)"

This reverts commit 1faba0741a0f92cd90eb732e88bb1e810b9823fa.

This causes errors in TorchBench, see https://github.com/pytorch/torchdynamo/issues/538 and https://github.com/pytorch/torchdynamo/issues/545

Let's fix the TorchBench errors then re-merge this.