### PR TITLE
Add GPU test runner in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+version: 2.1
+
+jobs:
+  gpu_linux:
+    machine:
+      # https://circleci.com/docs/2.0/configuration-reference/#available-linux-gpu-images
+      image: ubuntu-2004-cuda-11.4:202110-01
+    resource_class: gpu.nvidia.large
+    steps:
+      - checkout
+      - run:
+          name: Setup
+          command: |
+            source .circleci/setup_env.sh
+      - run:
+          name: Tests
+          command: |
+            source .circleci/setup_env.sh
+            mkdir test-results
+            pytest -v --junitxml=test-results/junit.xml
+      - store_test_results:
+          path: test-results
+      # This fails with a git-lfs error
+      # - run:
+      #     name: TorchBench install
+      #     command: |
+      #       source .circleci/setup_env.sh
+      #       export GIT_LFS_SKIP_SMUDGE=1
+      #       conda install -y -c conda-forge git-lfs
+      #       git clone --recursive --depth=1 --shallow-submodules git@github.com:jansel/benchmark.git torchbenchmark
+      #       cd torchbenchmark
+      #       git lfs install
+      #       env GIT_TRACE=1 git lfs fetch
+      #       git lfs checkout .
+      #       python install.py
+      #       cd ..
+      # - run:
+      #     name: TorchBench run
+      #     command: |
+      #       source .circleci/setup_env.sh
+      #       python benchmarks/torchbench.py --coverage -d cuda --raise-on-backend-error
+      # - store_artifacts:
+      #     path: coverage.csv
+
+workflows:
+  gpu:
+    jobs:
+      - gpu_linux

--- a/.circleci/setup_env.sh
+++ b/.circleci/setup_env.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# based on https://github.com/pytorch/functorch/blob/main/.circleci/unittest/linux/scripts/setup_env.sh
+set -ex
+root_dir="$(git rev-parse --show-toplevel)"
+conda_dir="${root_dir}/conda"
+env_dir="${root_dir}/env"
+torchbench_dir="${root_dir}/torchbenchmark"
+
+cd "${root_dir}"
+
+if [ ! -d "${conda_dir}" ]; then
+    printf "* Installing conda at ${conda_dir}\n"
+    case "$(uname -s)" in
+        Darwin*) os=MacOSX;;
+        *) os=Linux
+    esac
+    wget -O miniconda.sh http://repo.continuum.io/miniconda/Miniconda3-latest-${os}-x86_64.sh
+    bash ./miniconda.sh -b -f -p "${conda_dir}"
+fi
+eval "$(${conda_dir}/bin/conda shell.bash hook)"
+
+if [ ! -d "${env_dir}" ]; then
+    printf "* Creating a test environment at ${env_dir}\n"
+    conda create --prefix "${env_dir}" -y python=3.8 pip
+    conda activate "${env_dir}"
+    make setup_nightly_gpu
+else
+    conda activate "${env_dir}"
+fi

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ C_FILES := $(wildcard torchdynamo/*.c torchdynamo/*.cpp)
 CLANG_TIDY ?= clang-tidy-10
 CLANG_FORMAT ?= clang-format-10
 
+# versions used in CI
+PYTORCH_VERSION ?= 1.13.0.dev20220710
+FUNCTORCH_VERSION ?= 9b96f14e65ffdf64a28416054fe536ed14297fe9
+TRITON_VERSION ?= 90fcb586f2433e04a1424e1f9b19100b0f809170
+
 default: develop
 
 develop:
@@ -44,9 +49,18 @@ setup:
 
 setup_nightly:
 	pip install ninja
-	pip install --pre torch==1.13.0.dev20220701+cpu --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-	pip install -v git+https://github.com/pytorch/functorch.git@6dfa19e61e27012be87c49a249633a58f0cdd024
+	pip install --pre torch==$(PYTORCH_VERSION) --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+	pip install -v git+https://github.com/pytorch/functorch.git@$(FUNCTORCH_VERSION)
 	pip install -r requirements.txt
+	python setup.py develop
+
+setup_nightly_gpu:
+	conda install -y -c pytorch magma-cuda113
+	conda install -y pytorch==$(PYTORCH_VERSION) torchvision torchaudio torchtext cudatoolkit=11.3 -c pytorch-nightly
+	pip install ninja
+	pip install -v git+https://github.com/pytorch/functorch.git@$(FUNCTORCH_VERSION)
+	pip install -r requirements.txt
+	pip install -U "git+https://github.com/jansel/triton@$(TRITON_VERSION)#subdirectory=python"
 	python setup.py develop
 
 clean:

--- a/benchmarks/torchbench.py
+++ b/benchmarks/torchbench.py
@@ -22,6 +22,7 @@ torch.backends.cuda.matmul.allow_tf32 = True
 
 os.environ["KALDI_ROOT"] = "/tmp"  # avoids some spam
 for torchbench_dir in (
+    "./torchbenchmark",
     "../torchbenchmark",
     "../torchbench",
     "../benchmark",


### PR DESCRIPTION
This adds a V100 GPU runner with CircleCI.  Currently, it runs GPU tests.

I tried (and failed) to get TorchBench working.  For some reason `git lfs fetch` keeps failing with:
```
04:12:05.390494 trace git-lfs: HTTP: POST https://lfs.github.com/pytorch/benchmark/objects/batch
04:12:05.456107 trace git-lfs: http: decompressed gzipped response
04:12:05.456126 trace git-lfs: HTTP: 403
04:12:05.456177 trace git-lfs: HTTP: {"message":"Bad credentials","documentation_url":"https://support.github.com/contact"}
```
More details on the git-lfs error [here](https://app.circleci.com/pipelines/github/pytorch/torchdynamo/38/workflows/c9d37b21-a195-49a1-b93a-026b4e5f8afc/jobs/38) if someone wants to take a crack at it.