### PR TITLE
Fix unspec random bug if no explicit fx graph output in a frame

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1677,7 +1677,9 @@ class MiscTests(torchdynamo.testing.TestCase):
         def fn(x):
             r1 = random.random()
             y = x + random.uniform(10, 20)
-            r2 = random.randint(2, 18)
+            y.sum().item()
+            r2 = random.randint(2, 18)  # no graph output in this frame
+            y.sum().item()
             return y + r1, r2
 
         x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])

--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -36,13 +36,6 @@ class GraphOutputEntry:
         self.variable = self.variable.add_options(other)
 
 
-def _get_gen_rand_values_fn(random_calls):
-    def _gen_rand_values():
-        return [fn(*args, **kwargs) for fn, args, kwargs in random_calls]
-
-    return _gen_rand_values
-
-
 class PyCodegen(object):
     """
     Helper class uses for constructing Python bytecode
@@ -328,20 +321,6 @@ class PyCodegen(object):
         self.extend_output(self.load_function_name(fn_name))
 
         graphargs = self.tx.output.graphargs
-
-        # to handle random calls
-        if len(self.tx.random_calls) > 0:
-            rand_fn_name = unique_id("__gen_rand_values")
-            rand_fn = torchdynamo.disable(_get_gen_rand_values_fn(self.tx.random_calls))
-            self.tx.output.install_global(rand_fn_name, rand_fn)
-            self.extend_output(self.load_function_name(rand_fn_name))
-            self.extend_output(
-                [
-                    create_instruction("CALL_FUNCTION", 0),
-                    self.create_store(self.tx.output.random_values_var),
-                ]
-            )
-
         for arg in graphargs:
             if arg.is_unspecialized:
                 self.extend_output(

--- a/torchdynamo/codegen.py
+++ b/torchdynamo/codegen.py
@@ -11,7 +11,6 @@ import torchdynamo
 
 from .bytecode_transformation import Instruction
 from .bytecode_transformation import create_instruction
-from .bytecode_transformation import unique_id
 from .exc import unimplemented
 from .source import AttrSource
 from .source import Source


### PR DESCRIPTION
Fix #545 
 
The root cause is unspec random values are not generated if there is no explicit fx graph output in a eval frame. So we should move it from ```compile_and_call_fx_graph``` to ```compile_subgraph```.