### PR TITLE
[inductor] Add `aten.detach` to decomposition list.

### DIFF
--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -25,6 +25,7 @@ decompositions = get_decompositions(
         aten.clamp_min,
         aten.cudnn_batch_norm,
         aten.cudnn_batch_norm_backward,
+        aten.detach,
         aten.elu_backward,
         aten._embedding_bag,
         aten.embedding_dense_backward,


### PR DESCRIPTION
Should probably just always enable it.

Also prohibits some rematerialization from occurring sometimes.