### PR TITLE
cache triton kernels

### DIFF
--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -844,11 +844,19 @@ class TritonScheduling:
                         except CantSplit:
                             reschedule.append(node)
 
-        kernel_name = wrapper.next_kernel_name()
         if config.triton.many_files:
+            kernel_name = wrapper.next_kernel_name()
             wrapper.define_kernel(kernel_name, kernel.codegen_kernel())
         else:
-            wrapper.header.splice(kernel.codegen_kernel(kernel_name))
+            src_code = kernel.codegen_kernel("{kernel_name}")
+            if src_code in wrapper.kernels:
+                kernel_name = wrapper.kernels[src_code]
+            else:
+                kernel_name = wrapper.next_kernel_name()
+                wrapper.kernels[src_code] = kernel_name
+                code = src_code.format(kernel_name=kernel_name)
+                wrapper.header.splice(code)
+
         kernel.call_kernel(wrapper, kernel_name)
 
         scheduler.enqueue(reschedule)

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -57,6 +57,7 @@ class WrapperCodeGen(CodeGen):
         self._names_iter = count()
         self.header = IndentedBuffer()
         self.prefix = IndentedBuffer()
+        self.kernels = {}
         self.lines = []
         self.header.splice(
             f"""


### PR DESCRIPTION
Cache triton kernels based on the exact match of the generated python code in a single file mode. Multiple-file mode behavior is unchanged. 
According to @chillee this reduces timm vision transformer compile time from 14 minutes to 3. 