### PR TITLE
Use fake mode when doing mutation analysis

### DIFF
--- a/tests/test_verify_correctness.py
+++ b/tests/test_verify_correctness.py
@@ -136,10 +136,10 @@ class TestVerifyCorrectness(torchdynamo.testing.TestCase):
         def incorrect_compile_fn(gm, example_inputs):
             return transform(gm).forward
 
-        r1 = toy_example(i1, i2)
+        toy_example(i1, i2)
         try:
             with torchdynamo.optimize(incorrect_compile_fn):
-                r2 = toy_example(i1, i2)
+                toy_example(i1, i2)
         except RuntimeError:
             pass
         else:

--- a/torchdynamo/optimizations/analysis.py
+++ b/torchdynamo/optimizations/analysis.py
@@ -120,12 +120,14 @@ def has_mutation(gm, example_inputs):
         fake_mode = FakeTensorMode()
         fake_wrapper = functools.partial(wrap_to_fake_tensor, fake_mode=fake_mode)
         example_inputs = tree_map(fake_wrapper, example_inputs)
-        new_gm = deepcopy_to_fake_tensor(gm, fake_mode)
+        new_gm = gm
+        with fake_mode:
+            ShapeAliasingAndMutationProp(gm).run(*example_inputs)
     else:
         new_gm = copy.deepcopy(gm)
         example_inputs = copy.deepcopy(example_inputs)
+        ShapeAliasingAndMutationProp(new_gm).run(*example_inputs)
 
-    ShapeAliasingAndMutationProp(new_gm).run(*example_inputs)
     for node in new_gm.graph.nodes:
         if node.meta["is_mutation"] or node.meta["is_input_mutation"]:
             return True

--- a/torchdynamo/optimizations/analysis.py
+++ b/torchdynamo/optimizations/analysis.py
@@ -15,7 +15,6 @@ from ..utils import fake_tensors_available
 if fake_tensors_available:
     from torch._subclasses import FakeTensorMode  # noqa: F401
 
-    from ..utils import deepcopy_to_fake_tensor
     from ..utils import wrap_to_fake_tensor
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #561
* __->__ #560

Currently, the mutation analysis is done without enabling fake
tensor mode.  This means if there is compute on a constant it
won't convert into fake tensor, and will subsequently fail
in fake tensor mode (which doesn't support mixed fake and non fake
inputs.)  The most likely situation this occurs is when accessing
tensor constants on the GraphModule.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>