### PR TITLE
Ignore flake8 extensions that are used for linting PyTorch core

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E203,W503,C101
+ignore = E203,W503,C101,C4,EXE,B,Y
 max-line-length = 120


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Partially helps with https://github.com/pytorch/torchdynamo/issues/482

Signed-off-by: Edward Z. Yang <ezyang@fb.com>