### PR TITLE
[inductor] layout of ExternKernelAlloc

### DIFF
--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1705,7 +1705,10 @@ class ConcatKernel(NopKernel):
             return cls.realize_into(src.data, dst)
         if isinstance(src, StorageBox):
             src.realize()
-            if isinstance(src.data.layout, FlexibleLayout):
+            # ExternKernelAlloc has specific requirements for output layout, should create a copy
+            if isinstance(src.data.layout, FlexibleLayout) and not isinstance(
+                src.data, ExternKernelAlloc
+            ):
                 src.data.layout = AliasedLayout(dst)
                 return src.data
         # introduce a copy

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2057,13 +2057,13 @@ class AdaptiveAvgPool2d(ExternKernelAlloc):
         )
 
     def apply_constraint(self):
-        x = self.intput[0]
+        x = self.inputs[0]
         if isinstance(x, FixedLayout):
             # fix self's layout to be the same order as x
             self.freeze_layout_with_same_order(x.stride)
         else:
             x = self.require_stride_order(x, self.layout.preferred_stride_order)
-            self.input[0] = x
+            self.inputs[0] = x
             self.freeze_layout_with_stride_order(self.layout.preferred_stride_order)
 
 
@@ -2427,8 +2427,8 @@ class Convolution(ExternKernelAlloc):
         CONV1X1_NHWC = (
             "True"
             if self.inputs[0].get_stride()[1] == 1
-            and self.inputs[1].shape[2] == 1
-            and self.inputs[1].shape[3] == 1
+            and self.inputs[1].get_size()[2] == 1
+            and self.inputs[1].get_size()[3] == 1
             else "False"
         )
         # dict for tl.constexpr


### PR DESCRIPTION
For ExternKernelAlloc kernels, output layout should not be fixed to FixedLayout when inputs layout are not fixed (still FlexbileLayout). Instead, when `decide_layout()`, call `apply_constraint()` that will fix both output layout and input layout to avoid layout mismatch if input layout changed in pick_loop_order.