### PR TITLE
Improve mutation analysis

### DIFF
--- a/torchdynamo/optimizations/analysis.py
+++ b/torchdynamo/optimizations/analysis.py
@@ -8,6 +8,7 @@ from torch.fx.node import map_aggregate
 from torch.fx.passes.shape_prop import ShapeProp
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
 from torch.utils._pytree import tree_map
+from torch.multiprocessing.reductions import StorageWeakRef
 
 from .. import config
 from ..utils import fake_tensors_available
@@ -23,18 +24,16 @@ class ShapeAliasingAndMutationProp(ShapeProp):
     def __init__(self, *args, **kwargs):
         super(ShapeAliasingAndMutationProp, self).__init__(*args, **kwargs)
         self.input_alias_groups = set()
-        self.data_ptr_to_alias_group = dict()
-        self.storage_keepalive = []
+        self.storage_to_alias_group = dict()
         self.make_alias_group = itertools.count(1)
 
     def tensor_alias_group(self, value: torch.Tensor):
         """Assign a unique identifier to the storage of a given tensor"""
-        storage_data_ptr = value.storage().data_ptr()
-        alias_group = self.data_ptr_to_alias_group.get(storage_data_ptr)
+        storage = StorageWeakRef(value.storage())
+        alias_group = self.storage_to_alias_group.get(storage)
         if alias_group is None:
             alias_group = next(self.make_alias_group)
-            self.data_ptr_to_alias_group[storage_data_ptr] = alias_group
-            self.storage_keepalive.append(value.storage())
+            self.storage_to_alias_group[storage] = alias_group
         return alias_group
 
     def placeholder(self, target, args, kwargs):
@@ -108,12 +107,12 @@ class ShapeAliasingAndMutationProp(ShapeProp):
             super().run(*args)
         finally:
             # cleanup
-            self.storage_keepalive.clear()
             self.env.clear()
 
 
-def has_mutation(gm, example_inputs):
-    """Check if the graph module has any form of mutation"""
+def has_mutation(gm, example_inputs, inputs_only=False):
+    """Check if the graph module has any form of mutation.  If inputs_only is
+    true, we only check for mutation of inputs"""
     # TODO - moco gives bad accuracy with Aliasing. gm is getting mutated in a bad way.
 
     if fake_tensors_available and config.fake_tensor_propagation:
@@ -130,5 +129,9 @@ def has_mutation(gm, example_inputs):
 
     for node in new_gm.graph.nodes:
         if node.meta["is_mutation"] or node.meta["is_input_mutation"]:
-            return True
+            if inputs_only:
+                if node.meta["is_input_alias"]:
+                    return True
+            else:
+                return True
     return False

--- a/torchdynamo/optimizations/analysis.py
+++ b/torchdynamo/optimizations/analysis.py
@@ -7,8 +7,8 @@ import torch
 from torch.fx.node import map_aggregate
 from torch.fx.passes.shape_prop import ShapeProp
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
-from torch.utils._pytree import tree_map
 from torch.multiprocessing.reductions import StorageWeakRef
+from torch.utils._pytree import tree_map
 
 from .. import config
 from ..utils import fake_tensors_available

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -75,11 +75,7 @@ class AOTAutogradStrategy(object):
         else:
             mutated = has_mutation(self.gm, self.example_inputs)
 
-        if (
-            mutated
-            or len(gm_inputs) == 0
-            or has_set_grad_enabled
-        ):
+        if mutated or len(gm_inputs) == 0 or has_set_grad_enabled:
             self.use_fallback = True
 
     @property


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #568
* __->__ #564

- Add inputs_only option to test if inputs are mutated only.
  This is helpful stopgap for as long as functionalization
  can't handle mutated inputs correctly.

- Don't use data pointer on storage to test for aliasing; instead
  use the storage.  While this is technically less precise (since you can
  have two distinct storages with the same pointer), it has the strong merit of
  actually working correctly when you run the analysis with fake tensors.
  And if you had two storages with the same data pointer anyway, you aren't
  going to get the mutation analysis right anyway as the version counter
  won't get updated.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>