### PR TITLE
Move random values generation before any graph output codegen

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1706,8 +1706,6 @@ class MiscTests(torchdynamo.testing.TestCase):
             random.seed(1)
             res2 = fn(shape)
 
-        print(res1)
-        print(res2)
         self.assertTrue(same(res1, res2))
 
     def test_side_effects_codegen_update_mutated(self):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1691,6 +1691,25 @@ class MiscTests(torchdynamo.testing.TestCase):
             res2 = fn(x)
         self.assertTrue(same(res1, res2))
 
+    def test_unspecialized_primitive_variable5(self):
+        # test inserting random output into graph only
+        def fn(shape):
+            torch.manual_seed(123)
+            x = torch.randn(shape, device="cpu") * random.randint(30, 100)
+            return x
+
+        shape = [2, 3]
+        random.seed(1)
+        res1 = fn(shape)
+        cnts = torchdynamo.testing.CompileCounter()
+        with torchdynamo.optimize(cnts):
+            random.seed(1)
+            res2 = fn(shape)
+
+        print(res1)
+        print(res2)
+        self.assertTrue(same(res1, res2))
+
     def test_side_effects_codegen_update_mutated(self):
         # codegen to update mutated variables with side effect
         # should after stack value's codegen

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -249,8 +249,22 @@ class OutputGraph(fx.Tracer):
             restore_vars.extend(val_to_names[v])
             stack_values.extend([v] * len(val_to_names[v]))
 
+        # to handle random calls
         if len(tx.random_calls) > 0:
+            random_calls_instructions = []
             self.random_values_var = self.new_var("random_values")
+            rand_fn_name = unique_id("__gen_rand_values")
+            rand_fn = torchdynamo.disable(_get_gen_rand_values_fn(tx.random_calls))
+            self.install_global(rand_fn_name, rand_fn)
+            codegen = PyCodegen(tx, root)
+            random_calls_instructions.extend(codegen.load_function_name(rand_fn_name))
+            random_calls_instructions.extend(
+                [
+                    create_instruction("CALL_FUNCTION", 0),
+                    codegen.create_store(tx.output.random_values_var),
+                ]
+            )
+            self.add_output_instructions(random_calls_instructions)
 
         if (
             stack_values
@@ -288,18 +302,6 @@ class OutputGraph(fx.Tracer):
             self.side_effects.codegen_update_mutated(pass2)
 
             output = []
-            # to handle random calls
-            if len(tx.random_calls) > 0:
-                rand_fn_name = unique_id("__gen_rand_values")
-                rand_fn = torchdynamo.disable(_get_gen_rand_values_fn(tx.random_calls))
-                self.install_global(rand_fn_name, rand_fn)
-                output.extend(pass2.load_function_name(rand_fn_name))
-                output.extend(
-                    [
-                        create_instruction("CALL_FUNCTION", 0),
-                        pass2.create_store(tx.output.random_values_var),
-                    ]
-                )
             if count_calls(self.graph) != 0 or len(pass2.graph_outputs) != 0:
                 output.extend(
                     self.compile_and_call_fx_graph(tx, pass2.graph_output_vars(), root)


### PR DESCRIPTION
Fix this [bug](https://github.com/pytorch/pytorch/pull/81299) found by Pytorch-Dynamo CI.

We should move random values generation out of the [```if... else..```](https://github.com/pytorch/torchdynamo/blob/main/torchdynamo/output_graph.py#L255), as either condition can use random value. The ```if``` condition is where only graph output, ```else``` condition is where graph output + python variable reconstruction + side effects. 