### PR TITLE
make triton generate kernels with the same src code each time

### DIFF
--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -598,7 +598,5 @@ class Kernel(CodeGen):
         index = sympy.expand(index)
         index = sympy.simplify(index.subs(V.graph.sizevars.replacements))
         sorted_symbols = sorted(index.free_symbols, key=lambda s: s.name)
-        subs = {
-            x: self.args.size(x) for x in sorted_symbols if str(x).startswith("s")
-        }
+        subs = {x: self.args.size(x) for x in sorted_symbols if str(x).startswith("s")}
         return index.subs(subs)

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -597,7 +597,8 @@ class Kernel(CodeGen):
             return [self.rename_indexing(x) for x in index]
         index = sympy.expand(index)
         index = sympy.simplify(index.subs(V.graph.sizevars.replacements))
+        sorted_symbols = sorted(index.free_symbols, key=lambda s: s.name)
         subs = {
-            x: self.args.size(x) for x in index.free_symbols if str(x).startswith("s")
+            x: self.args.size(x) for x in sorted_symbols if str(x).startswith("s")
         }
         return index.subs(subs)

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -533,16 +533,18 @@ class TritonKernel(Kernel):
 
     def simplify_indexing(self, expr: sympy.Expr):
         expr = V.graph.sizevars.simplify_with_ranges(expr, self.var_ranges())
+        sorted_expr_symbols = sorted(expr.free_symbols, key=lambda s: s.name)
         nodes = [
             self.range_tree_nodes[sym]
-            for sym in expr.free_symbols
+            for sym in sorted_expr_symbols
             if sym in self.range_tree_nodes
         ]
         if nodes:
             nodes.sort(key=lambda x: x.depth)
             expr = nodes[-1].simplify(expr)
+            sorted_expr_symbols = sorted(expr.free_symbols, key=lambda s: s.name)
 
-        for sym in expr.free_symbols:
+        for sym in sorted_expr_symbols:
             if sym in self.range_tree_nodes:
                 self.range_tree_nodes[sym].codegen()
 
@@ -574,7 +576,6 @@ class TritonKernel(Kernel):
 
         if not self.inside_reduction or "rmask" not in mask:
             self.outside_loop_vars.add(tmp)
-
         return tmp
 
     def store(self, name, index, value, mode=None):


### PR DESCRIPTION
Currently, for some of the args we iterate over python set, which is non-deterministic, and results in a slightly different (but correct) kernel each time. Thus we don't hit in triton precompiled cache next time we run the same benchmark. This diff changes iterating over set to iterating over sorted elements of the set. 
Unfortunately, I don't know how to test this, but in my local runs I'm now always hitting in triton cache for the same kernel.  