### PR TITLE
Benchmark helper for command generation and pretty printing

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -377,7 +377,10 @@ def baselines(models, model_iter_fn, example_inputs, args):
     for rep in range(args.repeat):
         for idx, (name, model) in enumerate(models):
             if model is not None:
-                timings[rep, idx] = timed(model, model_iter_fn, example_inputs)
+                try:
+                    timings[rep, idx] = timed(model, model_iter_fn, example_inputs)
+                except Exception:
+                    pass
     pvalue = [
         ttest_ind(timings[:, 0], timings[:, i]).pvalue
         for i in range(1, timings.shape[1])
@@ -414,6 +417,17 @@ def speedup_experiment_ts(args, model_iter_fn, model, example_inputs):
 
     Writes to ./baseline_ts.csv
     """
+    if args.training:
+        return baselines(
+            [
+                ("eager", model),
+                ("ts", try_script(model, example_inputs)),
+            ],
+            model_iter_fn,
+            example_inputs,
+            args,
+        )
+
     return baselines(
         [
             ("eager", model),
@@ -816,6 +830,10 @@ def parse_args():
         action="store_true",
         help="Fail a benchmark if backend throws an exception",
     )
+    parser.add_argument(
+        "--output",
+        help="Overides the output filename",
+    )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--coverage", action="store_true", help="(default) " + help(coverage_experiment)
@@ -1209,6 +1227,9 @@ def main(runner, original_dir=None):
     experiment = functools.partial(experiment, args, model_iter_fn)
 
     cos_similarity = args.cosine
+
+    if args.output:
+        output_filename = args.output
 
     if output_filename:
         output_filename = os.path.join(torchdynamo.config.base_dir, output_filename)

--- a/benchmarks/helper.py
+++ b/benchmarks/helper.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+
+"""
+A wrapper over the benchmark infrastructure to generate commonly use commands,
+parse results and generate csv/graphs.
+
+The script works on manually written TABLE (see below). We can add more commands
+in the future.
+
+One example usage is
+-> python benchmarks/helper.py --e2e --modes=training --devices=cuda --suites=torchbench --dtypes=float32 --nightly
+
+where
+    e2e - generates the commands, runs the benchmarks, parse the results (other options - commands/parse)
+    nightly - Looks at the nightly field in the training/inferece field of TABLE to choose most relevant compilers.
+    models - either training or inference
+    suites - benchmark suite
+
+In case, you just need to get the commands, you can replace e2e with commands
+-> python benchmarks/helper.py --commands --modes=training --devices=cuda --suites=torchbench --dtypes=float32 --nightly
+
+The commands are written in file run.sh.
+
+In case, you just want to parse the logs once you have run the commands manually, you can use this command
+-> python benchmarks/helper.py --parse --modes=training --devices=cuda --suites=torchbench --dtypes=float32 --nightly
+
+"""
+
+import argparse
+import itertools
+import os
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from matplotlib import rcParams
+from tabulate import tabulate
+
+rcParams.update({"figure.autolayout": True})
+plt.rc("axes", axisbelow=True)
+
+DEFAULT_OUTPUT_DIR = "benchmark_logs"
+
+
+TABLE = {
+    "suites": ["torchbench", "huggingface"],
+    "dtypes": ["float32", "float16", "amp"],
+    "devices": ["cuda", "cpu"],
+    "modes": ["inference", "training"],
+    # Dict of name to base_command. nightly is a special field to tell which compilers are relevant.
+    "training": {
+        "ts_nnc": "--training --speedup-ts --use-eval-mode --isolate",
+        "ts_nvfuser": "--training --nvfuser --speedup-ts --use-eval-mode --isolate",
+        "aot_eager": "--training --accuracy-aot-nop --generate-aot-autograd-stats --use-eval-mode --isolate",
+        "aot_nnc": "--training --accuracy-aot-ts-mincut --use-eval-mode --isolate",
+        "aot_nvfuser": "--training --nvfuser --accuracy-aot-ts-mincut --use-eval-mode --isolate",
+        "nightly": ["ts_nvfuser", "aot_nvfuser"],
+    },
+    # Dict of name to base_command. nightly is a special field to tell which compilers are relevant.
+    "inference": {
+        "ts_nnc": "-dcuda --isolate --speedup-ts",
+        "ts_nvfuser": "-dcuda --isolate -n100 --speedup-ts --nvfuser",
+        "trt": "-dcuda --isolate -n100 --speedup-trt",
+        "eager_cudagraphs": "-dcuda --inductor-settings --float32 -n50 --backend=cudagraphs",
+        "nnc_cudagraphs": "-dcuda --inductor-settings --float32 -n50 --backend=cudagraphs_ts --nvfuser",
+        "nvfuser_cudagraphs": "-dcuda --inductor-settings --float32 -n50 --backend=cudagraphs_ts",
+        "inductor_cudagraphs": "-dcuda --inductor-settings --float32 -n50 --inductor",
+        "nightly": ["nvfuser_cudagraphs", "inductor_cudagraphs"],
+    },
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--filter", "-k", action="append", help="filter benchmarks with regexp"
+    )
+    parser.add_argument("--devices", action="append", help="cpu or cuda")
+    parser.add_argument("--modes", action="append", help="inference or training")
+    parser.add_argument("--dtypes", action="append", help="float16/float32/amp")
+    parser.add_argument("--suites", action="append", help="huggingface/torchbench")
+    parser.add_argument("--quick", action="store_true", help="Just runs one model")
+    parser.add_argument(
+        "--nightly",
+        action="store_true",
+        help="Use only compilers mentioned in nightly field",
+    )
+    parser.add_argument(
+        "--output-dir", help="Choose the output directory to save the logs"
+    )
+
+    # Choose either generation of commands, pretty parsing or e2e runs
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--commands", action="store_true", help="Generate commands")
+    group.add_argument("--parse", action="store_true", help="Parse the files")
+    group.add_argument(
+        "--e2e", action="store_true", help="Generate commands, run and parse the files"
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def generate_commands(args, dtypes, suites, modes, devices, output_dir):
+    with open("run.sh", "w") as runfile:
+        lines = []
+
+        lines.append("# Setup the output directory")
+        lines.append(f"rm -rf {output_dir}")
+        lines.append(f"mkdir {output_dir}")
+        lines.append("")
+
+        for iter in itertools.product(modes, suites, devices, dtypes):
+            mode, suite, device, dtype = iter
+            lines.append(
+                f"# Commands for {suite} for device={device}, dtype={dtype} for {mode}"
+            )
+
+            info = TABLE[mode]
+            compilers = list(info.keys())
+            compilers.remove("nightly")
+            if args.nightly:
+                compilers = info["nightly"]
+            for compiler in compilers:
+                base_cmd = info[compiler]
+                output_filename = (
+                    f"{output_dir}/{compiler}_{suite}_{dtype}_{mode}_{device}.csv"
+                )
+                cmd = f"python benchmarks/{suite}.py --{dtype} -d{device} --output={output_filename} {base_cmd}"
+                if args.quick:
+                    if suite == "torchbench":
+                        cmd = f"{cmd} --only=resnet18"
+                    elif suite == "huggingface":
+                        cmd = f"{cmd} --only=BertForPreTraining_P1_bert"
+                    else:
+                        raise NotImplementedError(
+                            f"Quick not implemented for {suite}.py"
+                        )
+                lines.append(cmd)
+            lines.append("")
+        runfile.writelines([line + "\n" for line in lines])
+
+
+def pp_dataframe(df, title, output_dir):
+    # Pretty print
+    print(tabulate(df, headers="keys", tablefmt="pretty", showindex="never"))
+
+    # Save to csv, can be copy pasted in google sheets
+    df.to_csv(f"{output_dir}/{title}.csv", index=False)
+
+    # Graph
+    labels = df.columns.values.tolist()
+    labels = labels[2:]
+    df.plot(
+        x="name",
+        y=labels,
+        kind="bar",
+        title=title,
+        ylabel="Speedeup over eager",
+        xlabel="",
+        grid=True,
+        figsize=(max(len(df.index) / 3, 10), 10),
+    )
+    plt.tight_layout()
+    plt.savefig(f"{output_dir}/{title}.png")
+
+
+def parse_logs(args, dtypes, suites, modes, devices, output_dir):
+    for iter in itertools.product(modes, suites, devices, dtypes):
+        mode, suite, device, dtype = iter
+        info = TABLE[mode]
+        compilers = list(info.keys())
+        compilers.remove("nightly")
+        if args.nightly:
+            compilers = info["nightly"]
+        frames = []
+        best_compiler = compilers[-1]
+        # Collect results from all the files
+        for compiler in compilers:
+            output_filename = (
+                f"{output_dir}/{compiler}_{suite}_{dtype}_{mode}_{device}.csv"
+            )
+            df = pd.read_csv(output_filename)
+            df.rename(
+                columns={"speedup": compiler, "ts": compiler, "ofi": f"ofi_{compiler}"},
+                inplace=True,
+            )
+            frames.append(df)
+
+        # Merge the results
+        df = pd.merge(*frames, on=["dev", "name"])
+
+        # Pretty print and also write to a bargraph
+        title = f"{suite}_{dtype}_{mode}_{device}"
+        pp_dataframe(df, title, output_dir)
+
+        # Sort the dataframe and pretty print
+        sorted_df = df.sort_values(by=best_compiler, ascending=False)
+        pp_dataframe(sorted_df, f"sorted_{title}", output_dir)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    def extract(key):
+        value = getattr(args, key, None)
+        return value if value is not None else TABLE[key]
+
+    dtypes = extract("dtypes")
+    suites = extract("suites")
+    modes = extract("modes")
+    devices = extract("devices")
+
+    output_dir = args.output_dir if args.output_dir is not None else DEFAULT_OUTPUT_DIR
+
+    if args.commands:
+        generate_commands(args, dtypes, suites, modes, devices, output_dir)
+    elif args.parse:
+        parse_logs(args, dtypes, suites, modes, devices, output_dir)
+    elif args.e2e:
+        generate_commands(args, dtypes, suites, modes, devices, output_dir)
+        os.system("bash run.sh")
+        parse_logs(args, dtypes, suites, modes, devices, output_dir)

--- a/benchmarks/huggingface.py
+++ b/benchmarks/huggingface.py
@@ -104,7 +104,7 @@ def bert_input_func(device, dtype, vocab_size, batch_size, seq_len, tgt_seq_len=
     return res
 
 
-def albert_input_func(device, dtype, vocab_size, batch_size, seq_len, tgt_seq_len=None):
+def albert_input_func(device, dtype, vocab_size):
     batch_size = 8
     seq_len = 512
     res = hf_general_inputs(dtype, device, vocab_size, batch_size, seq_len)

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -1,25 +1,25 @@
 #!/usr/bin/env python
 
 """
-A wrapper over the benchmark infrastructure to generate commonly use commands,
+A wrapper over the benchmark infrastructure to generate commonly used commands,
 parse results and generate csv/graphs.
 
 The script works on manually written TABLE (see below). We can add more commands
 in the future.
 
 One example usage is
--> python benchmarks/helper.py --suites=torchbench --inference
+-> python benchmarks/runner.py --suites=torchbench --inference
 This command will generate the commands for the default compilers (see DEFAULTS
 below) for inference, run them and visualize the logs.
 
-If you want to just run the commands, you could use the following command
--> python benchmarks/helper.py --print_run_commands --suites=torchbench --inference
+If you want to just print the commands, you could use the following command
+-> python benchmarks/runner.py --print_run_commands --suites=torchbench --inference
 
-Similarly, if you want to just visualize the already run logs
--> python benchmarks/helper.py --visualize_logs --suites=torchbench --inference
+Similarly, if you want to just visualize the already finished logs
+-> python benchmarks/runner.py --visualize_logs --suites=torchbench --inference
 
 If you want to test float16
--> python benchmarks/helper.py --suites=torchbench --inference --dtypes=float16
+-> python benchmarks/runner.py --suites=torchbench --inference --dtypes=float16
 
 """
 
@@ -174,7 +174,7 @@ def pp_dataframe(df, title, output_dir):
         y=labels,
         kind="bar",
         title=title,
-        ylabel="Speedeup over eager",
+        ylabel="Speedup over eager",
         xlabel="",
         grid=True,
         figsize=(max(len(df.index) / 4, 5), 10),
@@ -237,5 +237,12 @@ if __name__ == "__main__":
         parse_logs(args, dtypes, suites, devices, compilers, output_dir)
     elif args.run:
         generate_commands(args, dtypes, suites, devices, compilers, output_dir)
-        os.system("bash run.sh")
+        # TODO - Do we need to worry about segfaults
+        try:
+            os.system("bash run.sh")
+        except Exception as e:
+            print(
+                "Running commands failed. Please run manually (bash run.sh) and inspect the errors."
+            )
+            raise e
         parse_logs(args, dtypes, suites, devices, compilers, output_dir)


### PR DESCRIPTION
A wrapper over the benchmark infrastructure to generate commands, parse the results, and automatically generate graphs.

For this command,

`python benchmarks/helper.py --e2e --modes=training --devices=cuda --suites=torchbench --dtypes=float32 --nightly`

The results look like as follows
~~~
+------+-----------------------------------+------------+-------------+
| dev  |               name                | ts_nvfuser | aot_nvfuser |
+------+-----------------------------------+------------+-------------+
| cuda |    mobilenet_v2_quantized_qat     |    0.0     |   1.7448    |
| cuda |           BERT_pytorch            |    0.0     |   1.4675    |
| cuda |             hf_Albert             |    0.0     |   1.4386    |
| cuda |        mobilenet_v3_large         |   1.079    |    1.427    |
| cuda |         timm_efficientnet         |   1.0983   |   1.4207    |
| cuda |            densenet121            |   1.1109   |   1.4051    |
| cuda |             resnet18              |   1.1008   |   1.3889    |
| cuda |           mobilenet_v2            |   0.9965   |   1.3889    |
| cuda |            mnasnet1_0             |   1.0489   |    1.367    |
| cuda |        shufflenet_v2_x1_0         |   1.0187   |   1.3618    |
| cuda |      timm_vision_transformer      |   0.9522   |    1.353    |
| cuda |          resnext50_32x4d          |   1.115    |   1.3385    |
| cuda |             resnet50              |   0.9943   |   1.2905    |
| cuda |           timm_resnest            |   0.9954   |   1.2903    |
| cuda |              yolov3               |    0.0     |   1.2883    |
| cuda |              hf_GPT2              |    0.0     |   1.2801    |
| cuda |   pytorch_CycleGAN_and_pix2pix    |   1.1076   |   1.2598    |
| cuda |          LearningToPaint          |   1.1291   |   1.2542    |
| cuda |            timm_regnet            |   1.0334   |   1.2356    |
| cuda |            timm_nfnet             |   1.071    |   1.2185    |
| cuda |           pytorch_unet            |   0.9976   |   1.2057    |
| cuda |            timm_vovnet            |   0.994    |   1.1902    |
| cuda |              hf_Bart              |    0.0     |   1.1636    |
| cuda |        Background_Matting         |   1.009    |   1.1551    |
| cuda |           squeezenet1_1           |   1.0532   |   1.1275    |
| cuda |               dcgan               |   1.0746   |   1.1182    |
| cuda |                drq                |    0.0     |   1.1067    |
| cuda |          pytorch_stargan          |   0.9892   |   1.1039    |
| cuda |              hf_Bert              |    0.0     |   1.1019    |
| cuda |           maml_omniglot           |    0.0     |   1.0831    |
| cuda |         timm_efficientdet         |    0.0     |   1.0585    |
| cuda |           hf_Longformer           |    0.0     |   1.0299    |
| cuda |        speech_transformer         |    0.0     |   1.0236    |
| cuda |            hf_BigBird             |    0.0     |    1.02     |
| cuda | attention_is_all_you_need_pytorch |    0.0     |   1.0181    |
| cuda |              demucs               |    0.0     |   0.9995    |
| cuda |              alexnet              |   0.9923   |   0.9981    |
| cuda |               vgg16               |   0.9992   |   0.9969    |
| cuda |          pytorch_struct           |    0.0     |   0.9959    |
| cuda |         soft_actor_critic         |    0.0     |   0.9919    |
| cuda |            Super_SloMo            |   1.004    |   0.9858    |
| cuda |             tacotron2             |    0.0     |    0.985    |
| cuda |            tts_angular            |    0.0     |   0.9798    |
| cuda |          vision_maskrcnn          |    0.0     |   0.9764    |
| cuda |      nvidia_deeprecommender       |    0.0     |   0.9764    |
| cuda |               hf_T5               |    0.0     |    0.887    |
| cuda |           fastNLP_Bert            |    0.0     |   0.8409    |
| cuda |      resnet50_quantized_qat       |    0.0     |     0.0     |
| cuda |           hf_DistilBert           |    0.0     |     0.0     |
| cuda |    detectron2_maskrcnn_r_50_c4    |    0.0     |     0.0     |
| cuda |   detectron2_maskrcnn_r_50_fpn    |    0.0     |     0.0     |
| cuda |               dlrm                |    0.0     |     0.0     |
| cuda |           fambench_dlrm           |    0.0     |     0.0     |
| cuda |  detectron2_fasterrcnn_r_50_fpn   |    0.0     |     0.0     |
| cuda |            hf_Reformer            |    0.0     |     0.0     |
| cuda |  detectron2_fasterrcnn_r_101_c4   |    0.0     |     0.0     |
| cuda |  detectron2_fasterrcnn_r_50_dc5   |    0.0     |     0.0     |
| cuda |   detectron2_fasterrcnn_r_50_c4   |    0.0     |     0.0     |
| cuda |  detectron2_fasterrcnn_r_101_fpn  |    0.0     |     0.0     |
| cuda |  detectron2_fasterrcnn_r_101_dc5  |    0.0     |     0.0     |
| cuda |               moco                |    0.0     |     0.0     |
| cuda |   detectron2_maskrcnn_r_101_fpn   |    0.0     |     0.0     |
| cuda |   detectron2_maskrcnn_r_101_c4    |    0.0     |     0.0     |
+------+-----------------------------------+------------+-------------+
~~~

![image](https://user-images.githubusercontent.com/13822661/179143299-761b9f3c-8954-4f80-8b3f-5ff5952c78c9.png)
