### PR TITLE
Fall back to calling allclose when cosine_similarity returns invalid value

### DIFF
--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -501,6 +501,9 @@ def same(a, b, cos_similarity=False, tol=1e-4, equal_nan=False):
             a = a.flatten().to(torch.float32)
             b = b.flatten().to(torch.float32)
             res = torch.nn.functional.cosine_similarity(a, b, dim=0, eps=1e-6)
+            if res.isnan() or res == 0:
+                # Fallback to use torch.allcose
+                return torch.allclose(a, b, atol=tol, rtol=tol, equal_nan=equal_nan)
             if res < 0.99:
                 print(f"Similarity score={res.cpu().detach().item()}")
             return res >= 0.99


### PR DESCRIPTION
Summary: inductor enables --cosine as the default when running torchbench. Some training runs fail because of this issue.