### PR TITLE
[inductor] Explicitly emit None output as None

### DIFF
--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1341,6 +1341,11 @@ class ConstantBuffer(InputBuffer):
         return ConstantBuffer(V.graph.constant_name(self.name, device), self.layout)
 
 
+class NoneAsConstantBuffer(IRNode):
+    def codegen_reference(self):
+        return "None"
+
+
 @dataclasses.dataclass
 class ComputedBuffer(Buffer):
     data: Loops
@@ -1751,7 +1756,7 @@ class ExternKernel(InputsKernel):
     @classmethod
     def realize_input(cls, x):
         if x is None:
-            return V.graph.add_tensor_constant(torch.tensor(()))
+            return NoneAsConstantBuffer()
         if isinstance(x, Constant):
             return V.graph.add_tensor_constant(
                 torch.tensor(x.value, dtype=x.get_dtype(), device=x.get_device())

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -510,8 +510,9 @@ class Scheduler:
 
         # make sure outputs aren't dead-code-eliminated
         for node in V.graph.graph_outputs:
-            name = node.get_name()
-            add_user(node.get_name(), OutputNode(StarDep(name)))
+            if not isinstance(node, ir.NoneAsConstantBuffer):
+                name = node.get_name()
+                add_user(node.get_name(), OutputNode(StarDep(name)))
 
         # make sure input mutation isn't dead-code-eliminated
         for name in self.mutation_renames:


### PR DESCRIPTION
Summary:
Before:
```
constant0 = None  # 3855eccb97cd9b8c1773347b7d77322fdbdb736f784af24868acc7a6a6c64413

def kernel2(...):
  ...
  return (buf417, buf412, constant0, ...)

```

After:
```
def kernel2(...):
  ...
  return (buf417, buf412, None, ...)
```

The Before code is okay by itself, however, a problem exists when
autograd is evolved and we may see errors like,
```
RuntimeError: Function CompiledFunctionBackward returned an invalid gradient at index 2 - got [0] but expected shape compatible with [64]
```