### PR TITLE
Misc fixes - torchbench.py, huggingface.py and runner.py

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -883,6 +883,11 @@ def parse_args():
     group.add_argument(
         "--speedup-trt", action="store_true", help=help(speedup_experiment_trt)
     )
+    group.add_argument(
+        "--speedup-dynamo-ts",
+        action="store_true",
+        help="TorchDynamo frontend with torchscript backend",
+    )
     group.add_argument("--python-key", action="store_true")
     group.add_argument(
         "--speedup-fx2trt", action="store_true", help=help(speedup_experiment_fx2trt)
@@ -1147,6 +1152,10 @@ def main(runner, original_dir=None):
     elif args.speedup_trt:
         experiment = speedup_experiment_trt
         output_filename = "baseline_trt.csv"
+    elif args.speedup_dynamo_ts:
+        optimize_ctx = torchdynamo.optimize(backends.ts, nopython=args.nopython)
+        experiment = speedup_experiment
+        output_filename = "speedup_dynamo_ts.csv"
     elif args.speedup_fx2trt:
         optimize_ctx = torchdynamo.optimize(
             backends.fx2trt_compiler, nopython=args.nopython

--- a/benchmarks/torchbench.py
+++ b/benchmarks/torchbench.py
@@ -49,6 +49,20 @@ USE_SMALL_BATCH_SIZE = {
 }
 
 
+DETECTRON2_MODELS = {
+    "detectron2_fasterrcnn_r_101_c4",
+    "detectron2_fasterrcnn_r_101_dc5",
+    "detectron2_fasterrcnn_r_101_fpn",
+    "detectron2_fasterrcnn_r_50_c4",
+    "detectron2_fasterrcnn_r_50_dc5",
+    "detectron2_fasterrcnn_r_50_fpn",
+    "detectron2_maskrcnn_r_101_c4",
+    "detectron2_maskrcnn_r_101_fpn",
+    "detectron2_maskrcnn_r_50_c4",
+    "detectron2_maskrcnn_r_50_fpn",
+}
+
+
 # Additional models that are skipped in training
 SKIP_TRAIN = {
     # not designed for training
@@ -59,6 +73,8 @@ SKIP_TRAIN = {
     "opacus_cifar10",
     "maml",
 }
+SKIP_TRAIN.update(DETECTRON2_MODELS)
+
 
 # Some models have bad train dataset. We read eval dataset.
 # yolov3 - seems to have different number of inputs between eval and train
@@ -69,7 +85,7 @@ ONLY_EVAL_DATASET = {"yolov3", "timm_efficientdet"}
 # These models support only train mode. So accuracy checking can't be done in
 # eval mode.
 ONLY_TRAINING_MODE = {"tts_angular", "tacotron2", "demucs"}
-
+ONLY_TRAINING_MODE.update(DETECTRON2_MODELS)
 
 # Need lower tolerance on GPU. GPU kernels have non deterministic kernels for these models.
 REQUIRE_HIGHER_TOLERANCE = {

--- a/torchdynamo/testing.py
+++ b/torchdynamo/testing.py
@@ -68,7 +68,7 @@ def reduce_to_scalar_loss(out):
         return sum([reduce_to_scalar_loss(value) for value in out.values()]) / len(
             out.keys()
         )
-    raise NotImplementedError("Don't know how to reduce")
+    raise NotImplementedError("Don't know how to reduce", type(out))
 
 
 def debug_dir():


### PR DESCRIPTION
Tried running torchbench and huggingface models for training, and using the recently submitted runner.py.

Command - `python benchmarks/runner.py --suites=torchbench --suites=huggingface --training`

![image](https://user-images.githubusercontent.com/13822661/179345567-a2cc960f-61e8-4bf0-8f1a-814f37676639.png)

![image](https://user-images.githubusercontent.com/13822661/179345583-4ba62053-8f9b-491f-b587-393868a46a46.png)

Fixes in the PR
* Skip detectron models for training 
* Temporarily lower batch size for few models in huggingface.py
* Some fixes in runner.py parsing

Will open issues to track the workarounds in this PR. From the graphs, we can see that `aot_nvfuser` needs more work for HF models.

cc @Chillee @wconstab @ngimel for graphs and speedup numbers