### PR TITLE
[inductor] Force indirect-indexing to use dense_mask

### DIFF
--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -502,21 +502,22 @@ class TritonKernel(Kernel):
         itervars = list(itertools.chain(*self.set_ranges(*new_ranges)))
         return [[fn(itervars) for fn in fns] for fns in return_getters_groups]
 
+    def is_indirect_indexing(self, index: sympy.Expr):
+        index_vars = set(index.free_symbols)
+        return any(
+            # tmpX  means indirect indexing
+            str(v).startswith("tmp")
+            for v in index_vars
+        )
+
     def indexing(self, index: sympy.Expr, copy_shape=None):
         """
         Compute the index and mask to pass to tl.load() or tl.store()
         """
         index_vars = set(index.free_symbols)
         index_str = texpr(self.rename_indexing(self.simplify_indexing(index)))
-
-        need_dense = (
-            config.triton.dense_indexing
-            or any(
-                # tmpX  means indirect indexing
-                str(v).startswith("tmp")
-                for v in index_vars
-            )
-        ) and index != 0
+        indirect_indexing = self.is_indirect_indexing(index)
+        need_dense = (config.triton.dense_indexing or indirect_indexing) and index != 0
         have_dense = True
         have_loop_vars = False
         mask = []
@@ -537,6 +538,8 @@ class TritonKernel(Kernel):
         elif not have_loop_vars and copy_shape:
             mask = dense_mask
             index_str = f"{index_str} + tl.zeros({copy_shape}.shape, tl.int32)"
+        elif indirect_indexing:
+            mask = dense_mask
 
         if self._load_mask:
             mask.append(self._load_mask)
@@ -586,16 +589,15 @@ class TritonKernel(Kernel):
 
     def load(self, name: str, index: sympy.Expr, upcast: bool = False):
         var = self.args.input(name)
+        indirect_indexing = self.is_indirect_indexing(index)
         index, mask = self.indexing(index)
         line = f"tl.load({var} + {index}, {mask})"
         if upcast:
             line += ".to(tl.float32)"
 
-        if self.inside_reduction and "rmask" not in mask and self.loads != self.compute:
+        if self.inside_reduction and "rmask" not in mask and not indirect_indexing:
             # can lift a common load outside of reduction loop
-            # One exception is when this is invoked inside of an indirect_load,
-            # because there may be dependency, Kernel.indirect_load sets self.loads
-            # to self.compute which we can use as a checking here.
+            # One exception is when this is an indirect_load.
             tmp = self.cse.generate(self.body, line)
         else:
             tmp = self.cse.generate(self.loads, line)


### PR DESCRIPTION
Summary: The triton backend's range-tree based index comparison can not
handle indirect-indexing, which causes mask to incorrectly become None
in some cases. Force mask to be the same as dense_mask in this case.