### PR TITLE
Disabling TF32 for accuracy comparison

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import collections
+import contextlib
 import copy
 import csv
 import functools
@@ -46,6 +47,21 @@ log = logging.getLogger(__name__)
 current_name = ""
 current_device = ""
 output_filename = None
+
+
+@contextlib.contextmanager
+def no_tf32():
+    prior_cuda_tf32 = torch.backends.cuda.matmul.allow_tf32
+    prior_cudnn_tf32 = torch.backends.cudnn.allow_tf32
+
+    try:
+        torch.backends.cuda.matmul.allow_tf32 = False
+        torch.backends.cudnn.allow_tf32 = False
+        yield
+    finally:
+        pass
+        torch.backends.cuda.matmul.allow_tf32 = prior_cuda_tf32
+        torch.backends.cudnn.allow_tf32 = prior_cudnn_tf32
 
 
 def output_csv(filename, headers, row):
@@ -668,57 +684,63 @@ class BenchmarkRunner:
         tolerance, cos_similarity = self.get_tolerance_and_cosine_flag(
             is_training, current_device, name
         )
-        with self.pick_grad(name, is_training):
-            mode = "train" if is_training else "eval"
-            sys.stdout.write(f"{current_device:4} {mode:5} {current_name:34} ")
-            sys.stdout.flush()
-            for submod in itertools.chain([model], model.modules()):
-                assert not torchdynamo.utils.is_jit_model(submod)
-            torch.manual_seed(1337)
-            correct_result = model_iter_fn(
-                copy.deepcopy(model), torchdynamo.utils.clone_inputs(example_inputs)
-            )
-
-            torch.manual_seed(1337)
-            if current_name not in self.non_deterministic_models:
-                correct_rerun_result = model_iter_fn(
+        # TF32 can amplify minor noises. So, disable TF32 for accuracy comparison
+        with no_tf32():
+            with self.pick_grad(name, is_training):
+                mode = "train" if is_training else "eval"
+                sys.stdout.write(f"{current_device:4} {mode:5} {current_name:34} ")
+                sys.stdout.flush()
+                for submod in itertools.chain([model], model.modules()):
+                    assert not torchdynamo.utils.is_jit_model(submod)
+                torch.manual_seed(1337)
+                correct_result = model_iter_fn(
                     copy.deepcopy(model), torchdynamo.utils.clone_inputs(example_inputs)
                 )
-                if not same(correct_result, correct_rerun_result):
-                    print("INCORRECT - Variation in Eager runs itself")
+
+                torch.manual_seed(1337)
+                if current_name not in self.non_deterministic_models:
+                    correct_rerun_result = model_iter_fn(
+                        copy.deepcopy(model),
+                        torchdynamo.utils.clone_inputs(example_inputs),
+                    )
+                    if not same(correct_result, correct_rerun_result):
+                        print("INCORRECT - Variation in Eager runs itself")
+                        if not skip_accuracy_check:
+                            return sys.exit(-1)
+
+                torch.manual_seed(1337)
+                torchdynamo.reset()
+
+                try:
+                    with optimize_ctx:
+                        new_result = model_iter_fn(model, example_inputs)
+                except Exception:
+                    logging.exception("unhandled error")
+                    print("ERROR")
+                    return sys.exit(-1)
+                if current_name in self.non_deterministic_models:
+                    # This model has non-deterministic output so we cant
+                    # check correctness.
+                    # TODO(jansel): submit upstream fix for this
+                    pass
+                elif not same(correct_result, new_result, cos_similarity, tolerance):
+                    print("INCORRECT")
                     if not skip_accuracy_check:
                         return sys.exit(-1)
+            ok, total = Stats.reset_counters()
+            results = []
 
-            torch.manual_seed(1337)
-            torchdynamo.reset()
             if experiment.func is cold_start_experiment:
                 results = []
                 results.append(experiment(model, example_inputs, optimize_ctx))
                 print(" ".join(map(str, results)))
                 return 0
 
-            try:
+            # run Dynamo few times to see if we reached a fixed point
+            torchdynamo.reset()
+            for _ in range(3):
                 with optimize_ctx:
-                    new_result = model_iter_fn(model, example_inputs)
-            except Exception:
-                logging.exception("unhandled error")
-                print("ERROR")
-                return sys.exit(-1)
-            if current_name in self.non_deterministic_models:
-                # This model has non-deterministic output so we cant
-                # check correctness.
-                # TODO(jansel): submit upstream fix for this
-                pass
-            elif not same(correct_result, new_result, cos_similarity, tolerance):
-                print("INCORRECT")
-                if not skip_accuracy_check:
-                    return sys.exit(-1)
-            ok, total = Stats.reset_counters()
-            results = []
-
-            # run one more time to see if we reached a fixed point
-            with optimize_ctx:
-                model_iter_fn(model, example_inputs)
+                    model_iter_fn(model, example_inputs)
             _, frames_second_pass = Stats.reset_counters()  # should be 0
 
             if frames_second_pass > 0:
@@ -960,6 +982,10 @@ def parse_args():
 
 
 def main(runner, original_dir=None):
+    # We are primarily interested in tf32 datatype
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+
     args = parse_args()
 
     # Pass the parsed args object to benchmark runner object

--- a/benchmarks/huggingface.py
+++ b/benchmarks/huggingface.py
@@ -51,9 +51,6 @@ finally:
     from transformers import XLNetLMHeadModel
 
 
-# We are primarily interested in tf32 datatype
-torch.backends.cuda.matmul.allow_tf32 = True
-
 SKIP = {
     # Difficult to run and compare
     "Reformer"

--- a/benchmarks/torchbench.py
+++ b/benchmarks/torchbench.py
@@ -17,9 +17,6 @@ from torchdynamo.testing import collect_results
 from torchdynamo.testing import reduce_to_scalar_loss
 from torchdynamo.utils import clone_inputs
 
-# We are primarily interested in tf32 datatype
-torch.backends.cuda.matmul.allow_tf32 = True
-
 os.environ["KALDI_ROOT"] = "/tmp"  # avoids some spam
 for torchbench_dir in (
     "./torchbenchmark",


### PR DESCRIPTION
Some context here - https://github.com/pytorch/torchdynamo/issues/611

Even though this is not enough, it can help reduce the number of spurious models that fail because of TF32 issues.

@jansel @Chillee @ngimel Does this make sense?