### PR TITLE
Fix bug with dataclass codegen

### DIFF
--- a/torchdynamo/variables/dicts.py
+++ b/torchdynamo/variables/dicts.py
@@ -298,7 +298,7 @@ class DataClassVariable(ConstDictVariable):
             codegen(self.items[key])
         return [
             codegen.create_load_const(keys),
-            create_instruction("CALL_FUNCTION_KW", len(keys))
+            create_instruction("CALL_FUNCTION_KW", len(keys)),
         ]
 
     def call_method(

--- a/torchdynamo/variables/dicts.py
+++ b/torchdynamo/variables/dicts.py
@@ -293,10 +293,13 @@ class DataClassVariable(ConstDictVariable):
 
     def reconstruct(self, codegen):
         codegen.extend_output([codegen._create_load_const(self.user_cls)])
-        result = list(super().reconstruct(codegen))
-        assert result[-1].opname == "BUILD_CONST_KEY_MAP"
-        result.append(create_instruction("CALL_FUNCTION_KW", result.pop().argval))
-        return result
+        keys = tuple(self.items.keys())
+        for key in keys:
+            codegen(self.items[key])
+        return [
+            codegen.create_load_const(keys),
+            create_instruction("CALL_FUNCTION_KW", len(keys))
+        ]
 
     def call_method(
         self,


### PR DESCRIPTION
DataclassVariable expects the previous behavior (pre #579) to setup some kw args, overrode the new behavior.