### PR TITLE
Alias strings for AOT backends, and No-decomps for AOTAutograd accuracy test

### DIFF
--- a/torchdynamo/optimizations/__init__.py
+++ b/torchdynamo/optimizations/__init__.py
@@ -1,5 +1,8 @@
 from .backends import BACKENDS
 from .inference import offline_autotuner
 from .inference import online_autotuner
+from .training import create_aot_backends
+
+create_aot_backends()
 
 __all__ = ["online_autotuner", "offline_autotuner", "BACKENDS"]

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -537,22 +537,6 @@ def cudagraphs_inner(model, inputs, copy_outputs=True):
 
 @create_backend
 def aot_autograd(subgraph, **kwargs):
-    if not kwargs:
-        # from functorch._src.aot_autograd import static_argnums
-        from functorch.compile import default_decompositions
-        from functorch.compile import min_cut_rematerialization_partition
-        from functorch.compile import ts_compile
-
-        kwargs = {
-            # these are taken from memory_efficient_fusion()
-            "fw_compiler": ts_compile,
-            "bw_compiler": ts_compile,
-            "partition_fn": min_cut_rematerialization_partition,
-            "hasher_type": "StaticShapeHasher",
-            "decompositions": default_decompositions,
-            # "static_argnums": static_argnums,
-        }
-
     def _wrapped_bw_compiler(*args, **kwargs):
         # stop TorchDynamo from trying to compile our generated backwards pass
         return torchdynamo.disable(bw_compiler(*args, **kwargs))

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -14,7 +14,7 @@ from .normalize import normalize_ir
 log = logging.getLogger(__name__)
 
 
-class AOTAutogradStrategy(object):
+class AotAutogradStrategy(object):
     """Base class for backend strategies that use AOT Autograd"""
 
     @classmethod
@@ -26,7 +26,7 @@ class AOTAutogradStrategy(object):
     def __init__(self, gm: torch.fx.GraphModule, example_inputs):
         import functorch.compile
 
-        super(AOTAutogradStrategy, self).__init__()
+        super(AotAutogradStrategy, self).__init__()
         counters["aot_autograd"]["total"] += 1
         self.use_fallback = False
         self.original_example_inputs = example_inputs
@@ -89,7 +89,7 @@ class AOTAutogradStrategy(object):
         raise NotImplementedError()
 
 
-class AOTAutogradEagerStrategy(AOTAutogradStrategy):
+class AotNop(AotAutogradStrategy):
     """Useful for debugging purpose"""
 
     def candidate(self):
@@ -98,10 +98,14 @@ class AOTAutogradEagerStrategy(AOTAutogradStrategy):
         return BACKENDS["aot_autograd"](self.gm, self.example_inputs, fw_compiler=nop)
 
 
-aot_autograd_debug_strategy1 = AOTAutogradEagerStrategy.compile_fn
+aot_nop = AotNop.compile_fn
 
 
-class AOTAutogradNNCStrategy(AOTAutogradStrategy):
+class AotTorchscript(AotAutogradStrategy):
+    """
+    AOT Autograd with torchscript backend. Default partitioner.
+    """
+
     def candidate(self):
         from functorch.compile import ts_compile
 
@@ -110,13 +114,13 @@ class AOTAutogradNNCStrategy(AOTAutogradStrategy):
         )
 
 
-aot_autograd_nnc_strategy = AOTAutogradNNCStrategy.compile_fn
+aot_ts = AotTorchscript.compile_fn
 
 # Global counter to differentiate between different graphs.
 graph_idx = 0
 
 
-class AOTAutogradEagerSaveStrategy(AOTAutogradEagerStrategy):
+class AotPrint(AotNop):
     """Saves all the gm models so that we can run them separately"""
 
     def candidate(self):
@@ -126,39 +130,72 @@ class AOTAutogradEagerSaveStrategy(AOTAutogradEagerStrategy):
         for idx, x in enumerate(self.example_inputs):
             torch.save(x, module_idx + "_tensor" + str(idx) + ".pt")
         graph_idx += 1
-        return super(AOTAutogradEagerSaveStrategy, self).candidate()
+        return super(AotPrint, self).candidate()
 
 
-aot_autograd_debug_strategy2 = AOTAutogradEagerSaveStrategy.compile_fn
+aot_print = AotPrint.compile_fn
 
 
-class AOTAutogradMemoryEfficientFusion(AOTAutogradStrategy):
+def mem_efficient_fusion_kwargs(use_decomps):
+    from functorch.compile import default_decompositions
+    from functorch.compile import min_cut_rematerialization_partition
+    from functorch.compile import ts_compile
+
+    kwargs = {
+        # these are taken from memory_efficient_fusion()
+        "fw_compiler": ts_compile,
+        "bw_compiler": ts_compile,
+        "partition_fn": min_cut_rematerialization_partition,
+        "hasher_type": "StaticShapeHasher",
+    }
+
+    if use_decomps:
+        kwargs["decompositions"] = default_decompositions
+
+    return kwargs
+
+
+class AotMemEfficientFusion(AotAutogradStrategy):
     """Use Min cut rematerilization and NVFuser with AOT Autograd"""
 
     def candidate(self):
-        return BACKENDS["aot_autograd"](self.gm, self.example_inputs)
+        kwargs = mem_efficient_fusion_kwargs(use_decomps=True)
+        return BACKENDS["aot_autograd"](self.gm, self.example_inputs, **kwargs)
 
 
-class AOTAutogradMemoryEfficientFusionWithContext:
+class AotMemEfficientFusionNoDecomps(AotAutogradStrategy):
+    """Use Min cut rematerilization and NVFuser with AOT Autograd"""
+
+    def candidate(self):
+        kwargs = mem_efficient_fusion_kwargs(use_decomps=False)
+        return BACKENDS["aot_autograd"](self.gm, self.example_inputs, **kwargs)
+
+
+class AOTMemEfficientFusionWithContext:
     """Pass nvfuser context to TorchDynamo"""
 
-    def __init__(self):
+    def __init__(self, use_decomps=True):
         self.backend_ctx_ctor = lambda: torch.jit.fuser("fuser2")
+        self.use_decomps = use_decomps
 
     def __call__(self, gm: torch.fx.GraphModule, example_inputs):
-        return AOTAutogradMemoryEfficientFusion.compile_fn(gm, example_inputs)
+        if self.use_decomps:
+            return AotMemEfficientFusion.compile_fn(gm, example_inputs)
+        else:
+            return AotMemEfficientFusionNoDecomps.compile_fn(gm, example_inputs)
 
 
-aot_autograd_speedup_strategy = AOTAutogradMemoryEfficientFusionWithContext()
+aot_mem_efficient_fusion = AOTMemEfficientFusionWithContext(True)
+aot_mem_efficient_fusion_no_decomp = AOTMemEfficientFusionWithContext(False)
 
 
-class AOTAutogradPrimsNvFuser(AOTAutogradStrategy):
+class AotPrimsNvfuser(AotAutogradStrategy):
     """
     Use FX graph partitioner + Aten2Prims ref + trace executor + nvFuser
     """
 
     def __init__(self, gm: torch.fx.GraphModule, example_inputs):
-        super(AOTAutogradPrimsNvFuser, self).__init__(gm, example_inputs)
+        super(AotPrimsNvfuser, self).__init__(gm, example_inputs)
 
         from functorch.compile import min_cut_rematerialization_partition
         from torch.fx.passes.backends.nvfuser import NvFuserBackend
@@ -209,4 +246,37 @@ class AOTAutogradPrimsNvFuser(AOTAutogradStrategy):
         )
 
 
-aot_autograd_prims_nvfuser_strategy = AOTAutogradPrimsNvFuser.compile_fn
+aot_prims_nvfuser = AotPrimsNvfuser.compile_fn
+
+
+def create_aot_backends():
+    """
+    Register aliases for the AOT backends
+    """
+    # aot_nop uses AOT Autograd backend with nop compiler. It is helpful in debugging.
+    BACKENDS["aot_nop"] = aot_nop
+
+    # aot_nop uses AOT Autograd backend with print compiler. It prints the
+    # graphs and also saves the graph modules that are sent to AOT Autograd.
+    # This is helpful for debugging.
+    BACKENDS["aot_print"] = aot_print
+
+    # aot_ts uses torchscript backend. We can use this with both nnc and nvfuser
+    # by using the relevant fuser with torch.jit.fuser(...)
+    BACKENDS["aot_ts"] = aot_ts
+
+    # prims_nvfuser uses the prims and AOT-Autograd to get FX-aten IR. And then
+    # directly lowers to NVFuser without relying no Torchscript.
+    BACKENDS["prims_nvfuser"] = aot_prims_nvfuser
+
+    # aot_nvfuser uses the memory efficient fusion algorithm from AOT Autograd.
+    # It uses min cut rematerialization algorithm, and uses nvfuser as the
+    # compiler backend. This is the most optimized setting with nvfuser for
+    # training.
+    BACKENDS["aot_nvfuser"] = aot_mem_efficient_fusion
+
+    # Similar to aot_nvfuser, but disables the decompositions. Decompositions
+    # can cause accuracy deviations. This setting allows us to compare accuracy
+    # without worrying about the impact of decomposisitons. More details at
+    # https://github.com/pytorch/torchdynamo/issues/611
+    BACKENDS["aot_nvfuser_nodecomps"] = aot_mem_efficient_fusion_no_decomp


### PR DESCRIPTION
@Chillee suggested a better UX for using AOT Autograd memory efficient fusion. Suggestion is for `BACKENDS['nvfuser]` to point to `aot_autograd_efficient_strategy`. This way, the user does not have to add this extra import from torchdynamo.

Asking for comments @jansel @ngimel if `nvfuser` is a fine replacement. One other possibility is to use `aot_nvfuser` instead, which is little more explicit about using aot.