### PR TITLE
[DRAFT] add dump graph utils

### DIFF
--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -83,6 +83,12 @@ def _wrap_compiler_fn(compiler_fn):
         from torchinductor.compile_fx import compile_fx
 
         return compile_fx
+
+    elif compiler_fn == "inductor_dump":
+        from torchinductor.compile_fx import compile_fx_aot_dump
+
+        return compile_fx_aot_dump
+
     elif isinstance(compiler_fn, str):
         from .optimizations import BACKENDS
 

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -429,13 +429,29 @@ def compile_fx_aot(model_: torch.fx.GraphModule, example_inputs_: List[torch.Ten
     model_ = normalize_ir(model_, example_inputs_)
     num_example_inputs = len(example_inputs_)
 
-    # def fw_compiler(model: torch.fx.GraphModule, example_inputs):
-    #     fixed = len(example_inputs) - num_example_inputs
-    #     return compile_fx_inner(model, example_inputs, num_fixed=fixed)
+    def fw_compiler(model: torch.fx.GraphModule, example_inputs):
+        fixed = len(example_inputs) - num_example_inputs
+        return compile_fx_inner(model, example_inputs, num_fixed=fixed)
 
-    # def bw_compiler(model: torch.fx.GraphModule, example_inputs):
-    #     fixed = count_tangents(model)
-    #     return compile_fx_inner(model, example_inputs, num_fixed=fixed)
+    def bw_compiler(model: torch.fx.GraphModule, example_inputs):
+        fixed = count_tangents(model)
+        return compile_fx_inner(model, example_inputs, num_fixed=fixed)
+
+
+    return aot_autograd(
+        model_,
+        example_inputs_,
+        fw_compiler=fw_compiler,
+        bw_compiler=bw_compiler,
+        decompositions=decompositions,
+        partition_fn=min_cut_rematerialization_partition,
+    )
+
+
+def compile_fx_aot_dump(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]):
+    """Main entrypoint to a compile given FX graph"""
+    model_ = normalize_ir(model_, example_inputs_)
+
 
     def fw_compiler(model: torch.fx.GraphModule, example_inputs):
         # import pickle

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -359,18 +359,6 @@ def count_tangents(fx_g: torch.fx.GraphModule):
     assert static_arg_idxs == list(range(len(static_arg_idxs)))
     return len(static_arg_idxs)
 
-# def get_input_meta(args):
-#     input_meta = []
-#     if len(args) > 0 and isinstance(args[0], tuple):  # joint input
-#         input_meta += get_input_meta(args[0])
-#         input_meta += get_input_meta(args[1])
-#         return input_meta
-#     for arg in args:
-#         if(type(arg) == int or type(arg) == float):
-#             input_meta.append((type(arg),))
-#         else:
-#             input_meta.append((type(arg), arg.shape, arg.stride(), arg.dtype, arg.device))
-#     return input_meta
 
 model_name = "hf_Bert"
 
@@ -404,20 +392,14 @@ def compile_fx_aot_dump(model_: torch.fx.GraphModule, example_inputs_: List[torc
 
 
     def fw_compiler(model: torch.fx.GraphModule, example_inputs):
-        # import pickle
-        # model.graph.set_codegen(torch.fx.graph.CodeGen())  # remove codegen
-        # model.to_folder("hf_Bert_forward_0")
-        # input_meta = get_input_meta(example_inputs)
-        # pickle.dump(input_meta, open("hf_Bert_forward_0/hf_Bert_forward_0.input", "wb"))  # noqa: E501
         global model_name
-        draw_compute_box(model, example_inputs, f"{model_name}_fw", print_graph=True)
+        draw_compute_box(model, example_inputs, f"{model_name}_fw", print_graph=False)
         return model
         
 
     def bw_compiler(model: torch.fx.GraphModule, example_inputs):
-        # print(model)
         global model_name
-        draw_compute_box(model, example_inputs, f"{model_name}_bw", print_graph=True)
+        draw_compute_box(model, example_inputs, f"{model_name}_bw", print_graph=False)
         return model
 
     return aot_autograd(

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -310,7 +310,7 @@ def create_fx_graph(nodes, fname, backend = "triton", print_graph = False):
     #     print(graph)
     print("starting creating module")
     gm = GraphModule({}, graph)
-    print(gm)
+    # print(gm)
     print("starting drawing")
     draw_graph(gm, fname, clear_meta=False)
 
@@ -422,7 +422,7 @@ def count_tangents(fx_g: torch.fx.GraphModule):
 #             input_meta.append((type(arg), arg.shape, arg.stride(), arg.dtype, arg.device))
 #     return input_meta
 
-model_name = "alexnet"
+model_name = "hf_Bert"
 
 def compile_fx_aot(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]):
     """Main entrypoint to a compile given FX graph"""

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -67,6 +67,7 @@ decompositions = get_decompositions(
         aten.threshold_backward,
         aten.transpose.int,
         aten.upsample_nearest2d_backward,
+        aten.lift_fresh_copy,
     ]
 )
 decompositions.update(aot_autograd_decompositions)

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -67,7 +67,6 @@ decompositions = get_decompositions(
         aten.threshold_backward,
         aten.transpose.int,
         aten.upsample_nearest2d_backward,
-        aten.lift_fresh_copy,
     ]
 )
 decompositions.update(aot_autograd_decompositions)


### PR DESCRIPTION
creates a fx graph of the buffers generated by lowering

with this patch you can run e.g.

`python benchmarks/torchbench.py --training --devices=cuda --inductor-dump --isolate -k hf_Bert`

to dump the forward and backward graphs of compute-buffers of hf_Bert. The resulting svg file will be in torchbenchmark/.

If you want to run it for other graphs, change the model_name in compile_fx so the dumped file matches the model name. 

Also the dumping is quite slow, so for large models like hf_Bert, you would want to change the number of layers to a small number.