### PR TITLE
[inductor] Layernorm fusion and other fixes

### DIFF
--- a/.pytest
+++ b/.pytest
@@ -1,3 +1,0 @@
-[pytest]
-log_cli = True
-log_cli_level = DEBUG

--- a/benchmarks/torchbench.py
+++ b/benchmarks/torchbench.py
@@ -155,6 +155,7 @@ AOT_AUTOGRAD_NOT_YET_WORKING = {
     "tacotron2",  # also has an issue with normalize_ir
     # https://github.com/pytorch/torchdynamo/issues/590
     "pyhpc_isoneutral_mixing",
+    "vision_maskrcnn",
     # https://github.com/pytorch/torchdynamo/issues/80
     "hf_BigBird",
     # https://github.com/pytorch/pytorch/issues/81526
@@ -166,12 +167,9 @@ AOT_AUTOGRAD_NOT_YET_WORKING = {
 # https://github.com/pytorch/torchdynamo/issues/332
 INDUCTOR_INFERENCE_NOT_YET_WORKING = {
     *AOT_AUTOGRAD_NOT_YET_WORKING,
-    # ValueError: tmpX is not defined
-    "fastNLP_Bert",
-    "vision_maskrcnn",
-    "maml",
-    # missing ops: argmax, scatter
+    # missing ops: scatter / argmax
     "hf_Reformer",
+    "maml",
     # as_strided issue
     "hf_Longformer",
     # RuntimeError: CUDA out of memory.
@@ -188,6 +186,8 @@ INDUCTOR_TRAINING_NOT_YET_WORKING = {
     "mobilenet_v2_quantized_qat",
     # TypeError: expected Tensor as element 0 in argument 1, but got NoneType
     "dlrm",
+    # RuntimeError: The tensor has a non-zero number of elements,
+    "fastNLP_Bert",
     # RuntimeError: CUDA out of memory.
     "Background_Matting",
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths =
     tests
+log_cli = False
+log_cli_level = INFO

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -1348,6 +1348,17 @@ class CommonTemplate:
             check_lowp=False,  # too painful to match types of bn model
         )
 
+    @patch.object(config, "aot_autograd", False)
+    def test_layer_norm(self):
+        m = torch.nn.Sequential(
+            torch.nn.LayerNorm(32),
+            torch.nn.ReLU(),
+        )
+        m.eval()
+        self.common(m, (torch.randn([16, 32]),), check_lowp=False)
+        if self.device != "cpu":
+            self.assertEqual(torchinductor.metrics.generated_kernel_count, 1)
+
     def test_leaky_relu(self):
         def fn(x):
             return aten.leaky_relu(x, 0.2) + 2, aten.leaky_relu(x + 1)

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -61,6 +61,7 @@ LOGGING_CONFIG = {
             "propagate": False,
         },
     },
+    "disable_existing_loggers": False,
 }
 
 

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -843,6 +843,7 @@ class TritonScheduling:
         return group
 
     def codegen(self, *groups):
+        log.info(f"codegen {groups}")
         wrapper = V.graph.wrapper_code
         scheduler = self.scheduler
 
@@ -865,8 +866,11 @@ class TritonScheduling:
                     group, reduction_group = groups
 
                     # Add pointwise with compatible dimensions
-                    for node in scheduler.pop_group(
-                        (group * reduction_group, sympy.Integer(1)),
+                    for node in scheduler.pop_groups(
+                        [
+                            (group * reduction_group, sympy.Integer(1)),
+                            (group, reduction_group, sympy.Integer(1)),
+                        ]
                     ):
                         try:
                             node.run(*kernel.split_and_set_ranges(node.get_ranges()))

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -43,10 +43,12 @@ decompositions = get_decompositions(
         aten.l1_loss,
         aten.leaky_relu,
         aten.leaky_relu_backward,
+        aten._log_softmax,
         aten._log_softmax_backward_data,
         aten.logsumexp.default,
         aten.max_pool2d_with_indices_backward,
         aten.mse_loss,
+        aten.mse_loss_backward,
         aten.narrow,
         aten.native_batch_norm,
         aten.native_batch_norm_backward,
@@ -54,6 +56,7 @@ decompositions = get_decompositions(
         aten.native_group_norm,
         aten.native_layer_norm,
         aten.native_layer_norm_backward,
+        aten.nll_loss_backward,
         aten.norm,
         aten.reflection_pad2d_backward,
         aten.select_backward,
@@ -61,6 +64,7 @@ decompositions = get_decompositions(
         aten.sigmoid_backward,
         aten.silu_backward,
         aten.slice_backward,
+        aten._softmax,
         aten._softmax_backward_data,
         aten.stack,
         aten.tanh_backward,
@@ -96,26 +100,6 @@ def clamp(x, min=None, max=None):
     if max is not None:
         x = torch.minimum(x, torch.tensor(max, dtype=x.dtype, device=x.device))
     return x
-
-
-@register_decomposition([aten._softmax])
-def _softmax(x, dim, half_to_float):
-    # TODO(jansel): check numerical stability (see SoftMaxKernel.cpp)
-    if half_to_float and x.dtype in (torch.bfloat16, torch.float16):
-        x = x.to(torch.float32)
-    x = torch.exp(x)
-    x_sum = torch.sum(x, dim, keepdim=True)
-    scale = torch.reciprocal(x_sum)
-    return x * scale
-
-
-@register_decomposition([aten._log_softmax])
-def _log_softmax(x, dim, half_to_float):
-    # TODO(jansel): check numerical stability (see SoftMaxKernel.cpp)
-    if half_to_float and x.dtype in (torch.bfloat16, torch.float16):
-        x = x.to(torch.float32)
-    x_sum = torch.log(torch.sum(torch.exp(x), dim, keepdim=True))
-    return x - x_sum
 
 
 @register_decomposition([aten.t])

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -108,6 +108,7 @@ class RecordLoadStore(V.MockHandler):
 
     def canonicalize(self, index):
         sizes = list(self._var_ranges.values())
+        sizes = [V.graph.sizevars.simplify(x) for x in sizes]
         if not self._normalize:
             return index, tuple([x for x in sizes if x != 1])
 

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -351,10 +351,10 @@ def broadcast_tensors(*inputs):
     return outputs
 
 
-@register_lowering(aten.alias)
-@register_lowering(aten.detach)
+@register_lowering(
+    [aten.alias, aten.detach, aten.lift_fresh_copy, aten.lift_fresh, aten.lift]
+)
 def detach(x):
-    assert isinstance(x, TensorBox)
     return x  # AOT autograd handles this for us
 
 
@@ -692,7 +692,6 @@ make_fallback(aten.sort)
 make_fallback(aten.topk)
 make_fallback(aten.upsample_bilinear2d_backward)
 make_fallback(aten.upsample_nearest2d_backward)
-make_fallback(aten.mse_loss_backward)
 
 
 @register_lowering(aten.convolution)

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -351,16 +351,13 @@ def broadcast_tensors(*inputs):
     return outputs
 
 
-@register_lowering([aten.alias, aten.detach, aten.lift_fresh, aten.lift])
-def detach(x):
+@register_lowering([aten.alias, aten.detach, aten.lift])
+def nop(x):
     return x  # AOT autograd handles this for us
 
 
-if hasattr(aten, "lift_fresh_copy"):
-
-    @register_lowering(aten.lift_fresh_copy)
-    def lift_fresh_copy(x):
-        return x
+if hasattr(aten, "lift_fresh"):
+    register_lowering(aten.lift_fresh)(nop)
 
 
 @register_lowering(aten.squeeze)
@@ -741,6 +738,10 @@ def clone(x, *, memory_format=0):
         inner_fn=x.make_loader(),
         ranges=list(x.get_size()),
     )
+
+
+if hasattr(aten, "lift_fresh_copy"):
+    register_lowering(aten.lift_fresh_copy)(clone)
 
 
 @register_lowering([torch.arange, aten.arange])

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -351,11 +351,16 @@ def broadcast_tensors(*inputs):
     return outputs
 
 
-@register_lowering(
-    [aten.alias, aten.detach, aten.lift_fresh_copy, aten.lift_fresh, aten.lift]
-)
+@register_lowering([aten.alias, aten.detach, aten.lift_fresh, aten.lift])
 def detach(x):
     return x  # AOT autograd handles this for us
+
+
+if hasattr(aten, "lift_fresh_copy"):
+
+    @register_lowering(aten.lift_fresh_copy)
+    def lift_fresh_copy(x):
+        return x
 
 
 @register_lowering(aten.squeeze)

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -339,7 +339,9 @@ class SchedulerNode(BaseSchedulerNode):
                 itertools.chain.from_iterable(sizes),
             )
         )
-        with V.set_ops_handler(SimplifyIndexing(V.get_ops_handler(), var_ranges)):
+        with V.set_ops_handler(
+            SimplifyIndexing(V.get_ops_handler(), var_ranges)
+        ), V.kernel.set_current_node(self):
             self._body(*index_vars)
         self.scheduler.pending_buffer_names.add(self.get_name())
 


### PR DESCRIPTION
Old:
```
@reduction_heuristics(size_hints=[16, 32])
@triton.jit
def kernel0(in_ptr0, out_ptr1, out_ptr2, xnumel, rnumel, XBLOCK : tl.constexpr, RBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK, 1])
    xmask = xindex < xnumel
    rbase = tl.reshape(tl.arange(0, RBLOCK), [1, RBLOCK])
    x0 = xindex % 16
    _tmp1 = tl.zeros([XBLOCK, RBLOCK], tl.float32) + 0
    for roffset in range(0, rnumel, RBLOCK):
        rindex = roffset + rbase
        rmask = rindex < rnumel
        r1 = rindex % 32
        tmp0 = tl.load(in_ptr0 + r1 + (32*x0), xmask & rmask)
        _tmp1 = tl.where(xmask & rmask, _tmp1 + tmp0, _tmp1)
    tmp1 = tl.reshape(tl.sum(_tmp1, 1), [XBLOCK, 1])
    tmp2 = tmp1
    tl.store(out_ptr1 + x0, tmp2, xmask)
    _tmp8 = tl.zeros([XBLOCK, RBLOCK], tl.float32) + 0
    for roffset in range(0, rnumel, RBLOCK):
        rindex = roffset + rbase
        rmask = rindex < rnumel
        r1 = rindex % 32
        tmp3 = tl.load(in_ptr0 + r1 + (32*x0), xmask & rmask)
        tmp4 = 32
        tmp5 = tmp1 / tmp4
        tmp6 = tmp3 - tmp5
        tmp7 = tmp6 * tmp6
        _tmp8 = tl.where(xmask & rmask, _tmp8 + tmp7, _tmp8)
    tmp8 = tl.reshape(tl.sum(_tmp8, 1), [XBLOCK, 1])
    tl.store(out_ptr2 + x0, tmp8, xmask)

@pointwise_heuristics(size_hints=[16, 32])
@triton.jit
def kernel1(in_ptr0, in_ptr1, in_ptr2, in_ptr3, in_ptr4, out_ptr0, xnumel, ynumel, XBLOCK : tl.constexpr, YBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK, 1])
    xmask = xindex < xnumel
    yoffset = tl.program_id(1) * YBLOCK
    yindex = yoffset + tl.reshape(tl.arange(0, YBLOCK), [1, YBLOCK])
    ymask = yindex < ynumel
    x0 = xindex % 16
    y1 = yindex % 32
    tmp0 = tl.load(in_ptr0 + y1 + (32*x0), xmask & ymask)
    tmp1 = tl.load(in_ptr1 + x0, xmask)
    tmp5 = tl.load(in_ptr2 + x0, xmask)
    tmp13 = tl.load(in_ptr3 + y1, ymask)
    tmp15 = tl.load(in_ptr4 + y1, ymask)
    tmp2 = 32.0
    tmp3 = tmp1 / tmp2
    tmp4 = tmp0 - tmp3
    tmp6 = 32
    tmp7 = tmp5 / tmp6
    tmp8 = 1e-05
    tmp9 = tmp7 + tmp8
    tmp10 = tl.sqrt(tmp9)
    tmp11 = 1 / tmp10
    tmp12 = tmp4 * tmp11
    tmp14 = tmp12 * tmp13
    tmp16 = tmp14 + tmp15
    tmp17 = tl.maximum(0, tmp16)
    tl.store(out_ptr0 + y1 + (32*x0), tmp17, xmask & ymask)
```

New:
```
@reduction_heuristics(size_hints=[16, 32])
@triton.jit
def kernel0(in_ptr0, in_ptr1, in_ptr2, out_ptr3, xnumel, rnumel, XBLOCK : tl.constexpr, RBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK, 1])
    xmask = xindex < xnumel
    rbase = tl.reshape(tl.arange(0, RBLOCK), [1, RBLOCK])
    x0 = xindex % 16
    _tmp1 = tl.zeros([XBLOCK, RBLOCK], tl.float32) + 0
    for roffset in range(0, rnumel, RBLOCK):
        rindex = roffset + rbase
        rmask = rindex < rnumel
        r1 = rindex % 32
        tmp0 = tl.load(in_ptr0 + r1 + (32*x0), xmask & rmask)
        _tmp1 = tl.where(xmask & rmask, _tmp1 + tmp0, _tmp1)
    tmp1 = tl.reshape(tl.sum(_tmp1, 1), [XBLOCK, 1])
    tmp2 = tmp1
    _tmp8 = tl.zeros([XBLOCK, RBLOCK], tl.float32) + 0
    for roffset in range(0, rnumel, RBLOCK):
        rindex = roffset + rbase
        rmask = rindex < rnumel
        r1 = rindex % 32
        tmp3 = tl.load(in_ptr0 + r1 + (32*x0), xmask & rmask)
        tmp4 = 32
        tmp5 = tmp1 / tmp4
        tmp6 = tmp3 - tmp5
        tmp7 = tmp6 * tmp6
        _tmp8 = tl.where(xmask & rmask, _tmp8 + tmp7, _tmp8)
    tmp8 = tl.reshape(tl.sum(_tmp8, 1), [XBLOCK, 1])
    x2 = xindex
    for roffset in range(0, rnumel, RBLOCK):
        rindex = roffset + rbase
        rmask = rindex < rnumel
        r3 = rindex
        tmp9 = tl.load(in_ptr0 + r3 + (32*x2), xmask & rmask)
        tmp20 = tl.load(in_ptr1 + r3, rmask)
        tmp22 = tl.load(in_ptr2 + r3, rmask)
        tmp10 = 32.0
        tmp11 = tmp2 / tmp10
        tmp12 = tmp9 - tmp11
        tmp13 = 32
        tmp14 = tmp8 / tmp13
        tmp15 = 1e-05
        tmp16 = tmp14 + tmp15
        tmp17 = tl.sqrt(tmp16)
        tmp18 = 1 / tmp17
        tmp19 = tmp12 * tmp18
        tmp21 = tmp19 * tmp20
        tmp23 = tmp21 + tmp22
        tmp24 = tl.maximum(0, tmp23)
        tl.store(out_ptr3 + r3 + (32*x2), tmp24, xmask & rmask)
```