### PR TITLE
add check for rematerialization

### DIFF
--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -245,7 +245,7 @@ class GraphLowering(torch.fx.Interpreter):
         num_users = len(set(n.users))
         if num_users > 1 and isinstance(result, TensorBox):
             for user in n.users:
-                if user.target in needs_realized_inputs:
+                if user.target in needs_realized_inputs or user.op == 'output':
                     result.realize()
 
             # TODO(jansel): introduce a store vs inline choice

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -245,7 +245,7 @@ class GraphLowering(torch.fx.Interpreter):
         num_users = len(set(n.users))
         if num_users > 1 and isinstance(result, TensorBox):
             for user in n.users:
-                if user.target in needs_realized_inputs or user.op == 'output':
+                if user.target in needs_realized_inputs or user.op == "output":
                     result.realize()
 
             # TODO(jansel): introduce a store vs inline choice


### PR DESCRIPTION
realize a node if it's user is output.

If a node's user is output, it must be materialized. Without the change, a node with an output-user might be re-computed by some compute-buffers, but read by other compute-buffers. The recomputation can be saved by forcing the node to be materialized early.

This might make some benchmark slower because of the current fusing strategy sometimes block vertical fusion by doing horizontal fusion too early. This should be solved when we have a more optimal fusing strategy.