### PR TITLE
[inductor] Avoid extra copies on matmul inputs

### DIFF
--- a/benchmarks/torchbench.py
+++ b/benchmarks/torchbench.py
@@ -168,6 +168,8 @@ AOT_AUTOGRAD_NOT_YET_WORKING = {
 # https://github.com/pytorch/torchdynamo/issues/332
 INDUCTOR_INFERENCE_NOT_YET_WORKING = {
     *AOT_AUTOGRAD_NOT_YET_WORKING,
+    # RuntimeError: The tensor has a non-zero number of elements,
+    "fastNLP_Bert",
     # missing ops: scatter / argmax
     "hf_Reformer",
     "maml",
@@ -187,8 +189,6 @@ INDUCTOR_TRAINING_NOT_YET_WORKING = {
     "mobilenet_v2_quantized_qat",
     # TypeError: expected Tensor as element 0 in argument 1, but got NoneType
     "dlrm",
-    # RuntimeError: The tensor has a non-zero number of elements,
-    "fastNLP_Bert",
     # RuntimeError: CUDA out of memory.
     "Background_Matting",
 }

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -2351,6 +2351,21 @@ class CommonTemplate:
             ],
         )
 
+    @patch.object(config, "aot_autograd", False)
+    def test_mm_views(self):
+        def fn(a, b):
+            return torch.mm(a.view(32, 32), b.view(32, 32))
+
+        self.common(
+            fn,
+            (
+                torch.randn([32, 32]).transpose(0, 1),
+                torch.randn([1, 32, 32]).transpose(0, 1),
+            ),
+            check_lowp=False,
+        )
+        self.assertEqual(torchinductor.metrics.generated_kernel_count, 0)
+
 
 if HAS_CPU:
 

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -1,6 +1,7 @@
 import collections
 import dataclasses
 import itertools
+import logging
 import typing
 from typing import List
 from typing import Set
@@ -9,6 +10,8 @@ import sympy
 
 from .codegen.common import _simplify_loops
 from .virtualized import V
+
+log = logging.getLogger(__name__)
 
 
 class MemoryDep(typing.NamedTuple):
@@ -80,12 +83,14 @@ class ReadWrites:
     reads: Set[MemoryDep]
     writes: Set[MemoryDep]
     index_exprs: Set[IndexExprDep]
+    range_vars: List[sympy.Expr]
 
     def rename(self, renames: typing.Dict[str, str]):
         return ReadWrites(
             {dep.rename(renames) for dep in self.reads},
             {dep.rename(renames) for dep in self.writes},
             self.index_exprs,
+            self.range_vars,
         )
 
     def with_read(self, name: str):
@@ -94,6 +99,7 @@ class ReadWrites:
             set.union(self.reads, {StarDep(name)}),
             self.writes,
             self.index_exprs,
+            self.range_vars,
         )
 
 
@@ -183,7 +189,13 @@ def extract_read_writes(fn, *argsizes, normalize=False, prefix="d"):
     rw = RecordLoadStore(var_ranges, normalize=normalize)
     with V.set_ops_handler(rw):
         fn(*args)
-    return ReadWrites(rw._reads, rw._writes, rw._index_exprs)
+
+    if normalize:
+        range_vars = None  # Number of vars could differ due to normalization
+    else:
+        range_vars = [*itertools.chain(*args)]
+
+    return ReadWrites(rw._reads, rw._writes, rw._index_exprs, range_vars)
 
 
 def canonicalization_prefix():

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -146,8 +146,19 @@ class SizeVarAllocator(object):
             return left
 
     def maybe_guard_equals(self, left: sympy.Expr, right: sympy.Expr):
+        """if left==right, guard on that fact and return true"""
         if self.size_hint(left - right) == 0:
             self.guard_equals(left, right)
+            return True
+        return False
+
+    def maybe_guard_list_equals(self, left: List[sympy.Expr], right: List[sympy.Expr]):
+        """if left==right, guard on that fact and return true"""
+        if len(left) != len(right):
+            return False
+        if all(self.size_hint(a - b) == 0 for a, b in zip(left, right)):
+            for a, b in zip(left, right):
+                self.guard_equals(a, b)
             return True
         return False
 
@@ -247,6 +258,11 @@ class SizeVarAllocator(object):
                     - index_dim.subs({v: sympy.Integer(0)})
                 )
         return strides
+
+    def offset_var(self, index: sympy.Expr, vars: List[sympy.Symbol]):
+        """Extract offset part of an indexing expression"""
+        index = index.subs(self.replacements)
+        return index.subs({v: sympy.Integer(0) for v in vars if v != 0})
 
     def stride_hints(self, index: sympy.Expr, vars: List[sympy.Symbol]):
         for v in index.free_symbols:


### PR DESCRIPTION
@ngimel this should fix one of the issues you found

Before:
```
def call(arg0, arg1):
    arg0_size = arg0.size()
    s0 = arg0_size[0]
    buf0 = empty_strided((32, 32), (1, 32), device='cuda', dtype=torch.float32)
    kernel0[grid(1024)](arg0, buf0, 1024)
    buf1 = empty_strided((32, 32), (32, 1), device='cuda', dtype=torch.float32)
    aten.mm.out(buf0, as_strided(arg1, (32, 32), (32, 1)), out=buf1)
    return (buf1, )
```

After:
```
def call(arg0, arg1):
    arg0_size = arg0.size()
    s0 = arg0_size[0]
    buf0 = empty_strided((32, 32), (32, 1), device='cuda', dtype=torch.float32)
    aten.mm.out(arg0, as_strided(arg1, (32, 32), (32, 1)), out=buf0)
    return (buf0, )
```