### PR TITLE
RFC - pass result back to avoid making proxies for torch.* methods

### DIFF
--- a/torchdynamo/optimizations/python_key.py
+++ b/torchdynamo/optimizations/python_key.py
@@ -6,6 +6,7 @@ from itertools import chain
 import torch
 from torch.fx import GraphModule
 from torch.fx import Node
+from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode
 from torch.nn.utils import _stateless
 
 from ..allowed_functions import torch_get_name
@@ -96,6 +97,8 @@ def python_key_normalize(
     params_len = len(params_flat)
     nargs = params_len + len(example_inputs)
 
+    tracer = None
+
     class PatchingInterpreter(torch.fx.Interpreter):
         def run_node(self, n: torch.fx.Node):
             try:
@@ -108,9 +111,12 @@ def python_key_normalize(
                         # Tensor creation ops won't be captured because none
                         # of their inputs are PythonTensor proxies.
                         # Explicitly add them to the output graph.
-                        
-                        # FX should do the right thing here if the op target func came from torch
-                        if n.target.__module__ == 'torch':
+
+                        if n.target.__module__ == "torch":
+                            assert tracer, "Tracer must not be None here."
+                            proxy_mode = ProxyTorchDispatchMode(tracer)
+                            with proxy_mode:
+                                result = super().run_node(n)
                             return result
 
                         result = python_tensor_cls(

--- a/torchdynamo/optimizations/python_key.py
+++ b/torchdynamo/optimizations/python_key.py
@@ -108,6 +108,11 @@ def python_key_normalize(
                         # Tensor creation ops won't be captured because none
                         # of their inputs are PythonTensor proxies.
                         # Explicitly add them to the output graph.
+                        
+                        # FX should do the right thing here if the op target func came from torch
+                        if n.target.__module__ == 'torch':
+                            return result
+
                         result = python_tensor_cls(
                             result,
                             tracer.create_proxy(n.op, n.target, n.args, n.kwargs),


### PR DESCRIPTION
Given:

```
def foo(x):
    y = torch.empty(3)
    return x * y

torchdynamo.reset()
graph = None
def capturing_compiler(c, i):
    global graph
    graph = c
    print(c.graph.print_tabular())
    return graph.forward

with torchdynamo.optimize(capturing_compiler, nopython=True):
    z = foo(torch.randn([1, 1]))
```

and

```
outgm, wrap = python_key_normalize(
    graph,
    torch.randn([1, 1])
)
```

Before this change, we would return:

<img width="973" alt="image" src="https://user-images.githubusercontent.com/4755252/180909050-65d42113-161c-4d4f-972a-c0c0d68973ea.png">

After this change, we return:

<img width="834" alt="image" src="https://user-images.githubusercontent.com/4755252/180908989-9e1c7e11-73f6-4cff-8b83-d3d5dd6cefe4.png">

Longer term, we should probably switch back to only a single impl of this, using the one in fx ProxyTensor (cc: @Chillee)
