### PR TITLE
simplify ModularIndexing even if base is an expr

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -295,6 +295,14 @@ class TestIndexingSimplification(unittest.TestCase):
             IndexingDiv(i1 + 2 * i2, 32),
         )
 
+        expr = (
+            ModularIndexing(2 * i2 + r3, 1, 64)
+        )
+        # modular indexing is removed if base is smaller than modulo
+        self.assertEqual(
+            sizevars.simplify_with_ranges(expr, var_ranges), 2 * i2 + r3
+        )
+
         # check the same thing but with symbolic divisor
         self.assertEqual(IndexingDiv(r3 * i0, r3), i0)
         self.assertEqual(ModularIndexing(r3 * i0, r3, 10), ModularIndexing(i0, 1, 10))

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -295,13 +295,9 @@ class TestIndexingSimplification(unittest.TestCase):
             IndexingDiv(i1 + 2 * i2, 32),
         )
 
-        expr = (
-            ModularIndexing(2 * i2 + r3, 1, 64)
-        )
+        expr = ModularIndexing(2 * i2 + r3, 1, 64)
         # modular indexing is removed if base is smaller than modulo
-        self.assertEqual(
-            sizevars.simplify_with_ranges(expr, var_ranges), 2 * i2 + r3
-        )
+        self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), 2 * i2 + r3)
 
         # check the same thing but with symbolic divisor
         self.assertEqual(IndexingDiv(r3 * i0, r3), i0)

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -88,12 +88,11 @@ class SizeVarAllocator(object):
 
         def visit_modular_indexing(base, divisor, modulus):
             base = remove_zero_terms(base, divisor)
-            if isinstance(base, (sympy.Expr, sympy.Symbol)):
-                # actual iteration range is to size-1
-                iter_ranges = {k: v - 1 for k, v in var_ranges.items()}
-                base_s = base.subs(iter_ranges)
-                if self.maybe_guard_lt(base_s, modulus * divisor):
-                    return IndexingDiv(base, divisor)
+            # actual iteration range is to size-1
+            iter_ranges = {k: v - 1 for k, v in var_ranges.items()}
+            base_s = base.subs(iter_ranges)
+            if self.maybe_guard_lt(base_s, modulus * divisor):
+                return IndexingDiv(base, divisor)
             return ModularIndexing(base, divisor, modulus)
 
         expr = expr.replace(


### PR DESCRIPTION
Per title, Modular indexing is simplified as 
            `ModularIndexing(2 * i2 + r3, 1, 64) => 2 * i2 + r3` with `i2=32` and `r3=2`
        