### PR TITLE
Moving string to compiler_fn logic to eval_frame

### DIFF
--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -77,31 +77,15 @@ def fx_forward_from_src_skip_result(*args, **kwargs):
     return result
 
 
-def _wrap_compiler_fn(compiler_fn):
-    """Expand backend strings to functions"""
-    if compiler_fn == "inductor":
-        from torchinductor.compile_fx import compile_fx
-
-        return compile_fx
-    elif isinstance(compiler_fn, str):
-        from .optimizations import BACKENDS
-
-        return wrap_compiler_fn(BACKENDS[compiler_fn])
-    else:
-        return compiler_fn
-
-
 def wrap_compiler_fn(compiler_fn):
     """WrapperBackend if config.verify_correctness is True"""
-    wrapped_compiler_fn = _wrap_compiler_fn(compiler_fn)
-
     if config.verify_correctness:
         # wrap backend if verify_correctness is True
-        wrapper_backend_compiler_fn = WrapperBackend(wrapped_compiler_fn)
+        wrapper_backend_compiler_fn = WrapperBackend(compiler_fn)
 
         return wrapper_backend_compiler_fn
 
-    return wrapped_compiler_fn
+    return compiler_fn
 
 
 def wrap_convert_context(fn):

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -363,6 +363,7 @@ def optimize_assert(backend, backend_ctx_ctor=null_context, guard_export_fn=None
     """
     The same as `torchdynamo.optimize(backend, nopython=True)`
     """
+    backend = get_compiler_fn(backend)
     return _optimize_catch_errors(
         convert_frame.convert_frame_assert(backend, guard_export_fn), backend_ctx_ctor
     )

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -364,6 +364,11 @@ def optimize_assert(backend, backend_ctx_ctor=null_context, guard_export_fn=None
     The same as `torchdynamo.optimize(backend, nopython=True)`
     """
     backend = get_compiler_fn(backend)
+
+    # Find if backend has any extra context manager
+    if hasattr(backend, "backend_ctx_ctor"):
+        backend_ctx_ctor = getattr(backend, "backend_ctx_ctor")
+
     return _optimize_catch_errors(
         convert_frame.convert_frame_assert(backend, guard_export_fn), backend_ctx_ctor
     )

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -200,6 +200,20 @@ class WrapperBackend:
             self.restore()
 
 
+def get_compiler_fn(compiler_fn):
+    """Expand backend strings to functions"""
+    if compiler_fn == "inductor":
+        from torchinductor.compile_fx import compile_fx
+
+        return compile_fx
+    elif isinstance(compiler_fn, str):
+        from .optimizations import BACKENDS
+
+        return BACKENDS[compiler_fn]
+    else:
+        return compiler_fn
+
+
 def optimize(backend, nopython=False):
     """
     The main entrypoint of TorchDynamo.  Do graph capture and call
@@ -228,6 +242,9 @@ def optimize(backend, nopython=False):
         with torchdynamo.optimize(my_compiler):
            ...
     """
+    backend = get_compiler_fn(backend)
+
+    # Find if backend has any extra context manager
     backend_ctx_ctor = null_context
     if hasattr(backend, "backend_ctx_ctor"):
         backend_ctx_ctor = getattr(backend, "backend_ctx_ctor")


### PR DESCRIPTION
Helps with checking if a backend has any special context manager, like `aot_nvfuser` sets up torch.jit.fuser("fuser2") ctx mananger.

@jansel @pyjhzwh @ngimel 