### PR TITLE
[inductor] Add type conversion for div when both operands are integers

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -735,7 +735,37 @@ class CommonTemplate:
                 aten.div(a, b, rounding_mode="trunc"),
             )
 
+        # divide a scalar
         self.common(fn, (torch.randint(-100, 0, [8, 8]), 16))
+
+    def test_div6(self):
+        def fn(a, b):
+            return (
+                aten.div(a, b, rounding_mode=None),
+                aten.div(a, b, rounding_mode="floor"),
+                aten.div(a, b, rounding_mode="trunc"),
+            )
+
+        # treat boolean as integer
+        self.common(
+            fn, (torch.ones([8, 8], dtype=torch.bool), torch.randint(-100, -1, [8, 8]))
+        )
+
+    def test_div7(self):
+        def fn(a, b):
+            return (
+                aten.div(a, b, rounding_mode=None),
+                aten.div(a, b, rounding_mode="floor"),
+                aten.div(a, b, rounding_mode="trunc"),
+            )
+
+        self.common(
+            fn,
+            (
+                torch.randint(2**32, 2**40, [100, 100]),
+                torch.randint(-10, -1, [100, 100]),
+            ),
+        )
 
     def test_sum_keepdims(self):
         def fn(a, b):

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -686,7 +686,7 @@ class CommonTemplate:
             check_lowp=False,  # a much more elaborate test is required to match finfo max's for float and half
         )
 
-    def test_div(self):
+    def test_div1(self):
         def fn(a, b):
             return (
                 aten.div(a, b, rounding_mode=None),
@@ -695,6 +695,47 @@ class CommonTemplate:
             )
 
         self.common(fn, (torch.randn(8, 8) * 100, torch.randn(8, 8) * 100))
+
+    def test_div2(self):
+        def fn(a, b):
+            return (
+                aten.div(a, b, rounding_mode=None),
+                aten.div(a, b, rounding_mode="floor"),
+                aten.div(a, b, rounding_mode="trunc"),
+            )
+
+        self.common(fn, (torch.randint(-100, 100, [8, 8]), 100 * torch.randn(8, 8)))
+
+    def test_div3(self):
+        def fn(a, b):
+            return (
+                aten.div(a, b, rounding_mode=None),
+                aten.div(a, b, rounding_mode="floor"),
+                aten.div(a, b, rounding_mode="trunc"),
+            )
+
+        a = torch.randint(1, 100, [8, 8])
+        self.common(fn, (a * 2, a))
+
+    def test_div4(self):
+        def fn(a, b):
+            return (
+                aten.div(a, b, rounding_mode=None),
+                aten.div(a, b, rounding_mode="floor"),
+                aten.div(a, b, rounding_mode="trunc"),
+            )
+
+        self.common(fn, (torch.randint(-100, 0, [8, 8]), torch.randint(1, 10, [8, 8])))
+
+    def test_div5(self):
+        def fn(a, b):
+            return (
+                aten.div(a, b, rounding_mode=None),
+                aten.div(a, b, rounding_mode="floor"),
+                aten.div(a, b, rounding_mode="trunc"),
+            )
+
+        self.common(fn, (torch.randint(-100, 0, [8, 8]), 16))
 
     def test_sum_keepdims(self):
         def fn(a, b):

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -201,11 +201,23 @@ class TritonOverrides(OpOverrides):
             return f"tl.where({tmp}>{x}, {tmp}-1, {tmp})"
 
     @staticmethod
+    def floordiv(a, b):
+        # See the comment in lowering.div_mode
+        div = f"tl.fdiv({a}.to(tl.float32), {b}.to(tl.float32), True)"
+        return f"{ops.floor(div)}"
+
+    @staticmethod
     def trunc(x):
         if has_triton_libdevice():
             return f"tl.libdevice.trunc({x})"
         else:
             return f"{x}.to(tl.int32).to(tl.float32)"
+
+    @staticmethod
+    def truncdiv(a, b):
+        # See the comment in lowering.div_mode
+        div = f"tl.fdiv({a}.to(tl.float32), {b}.to(tl.float32), True)"
+        return f"{ops.trunc(div)}"
 
     @staticmethod
     def ceil(x):

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -202,9 +202,12 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def floordiv(a, b):
-        # See the comment in lowering.div_mode
-        div = f"tl.fdiv({a}.to(tl.float32), {b}.to(tl.float32), True)"
-        return f"{ops.floor(div)}"
+        # See the comment in lowering.div_mode. a and b are integer type.
+        # Similar to div_floor_kernel_cuda in pytorch core.
+        # Notice that // in triton behaves as truncdiv instead of floordiv
+        quot = f"{a} // {b}"
+        rem = f"{a} % {b}"
+        return f"tl.where(({a} < 0) != ({b} < 0), tl.where({rem} != 0, {quot} - 1, {quot}), {quot})"
 
     @staticmethod
     def trunc(x):
@@ -215,9 +218,9 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def truncdiv(a, b):
-        # See the comment in lowering.div_mode
-        div = f"tl.fdiv({a}.to(tl.float32), {b}.to(tl.float32), True)"
-        return f"{ops.trunc(div)}"
+        # See the comment in lowering.div_mode. a and b are integer type.
+        # Notice that // in triton behaves as truncdiv instead of floordiv
+        return f"{a} // {b}"
 
     @staticmethod
     def ceil(x):

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -155,16 +155,6 @@ def round_dec(x, decimals=0):
     return aten.round(x * ten_pow_decimals) * (1.0 / ten_pow_decimals)
 
 
-@register_decomposition([aten.div.Tensor_mode])
-def div_mode(a, b, rounding_mode=None):
-    result = aten.div(a, b)
-    if rounding_mode == "floor":
-        return torch.floor(result)
-    if rounding_mode == "trunc":
-        return torch.trunc(result)
-    return result
-
-
 @register_decomposition([aten.gelu])
 def gelu(x, approximate="none"):
     if config.approximations or approximate != "none":

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -197,9 +197,13 @@ class CleanDiv(IndexingDiv):
     pass
 
 
-def is_triton(device):
+def is_triton(x):
     # TODO(jansel): a config check once we have multi-backend
-    return device.type == "cuda"
+    if getattr(x, "get_device", None):
+        return is_triton(x.get_device())
+    if isinstance(x, torch.device):
+        return x.type == "cuda"
+    return False
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Summary: The problem is exposed in https://github.com/pytorch/torchdynamo/issues/603,
`RuntimeError: gather(): Expected dtype int64 for index`.

There are two problems here,
1) The return types of floordiv and truediv are different when both
operands are integer type.
2) Decomposing floordiv into div+floor gives a different result on
triton from eager because of CUDA fdiv mode choice differences, see
the discussion at https://github.com/openai/triton/issues/605.