### PR TITLE
Additional indexing simplifications

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -340,21 +340,41 @@ class TestIndexingSimplification(unittest.TestCase):
             2 * ModularIndexing(i0, 1, 128),
         )
 
+        # it should work when divisor is not 1
+        expr2 = ModularIndexing(i0, 3, 32) + 32 * ModularIndexing(i0, 32 * 3, 4)
+        simplified = sizevars.simplify_with_ranges(expr2, {})
+        self.assertEqual(simplified, ModularIndexing(i0, 3, 128))
+        self.assertEqual(expr2.subs({i0: 39485}), simplified.subs({i0: 39485}))
+
         # it should not happen in this case as the modulus is wrong
-        expr2 = ModularIndexing(i0, 1, 30) + 32 * ModularIndexing(i0, 32, 4)
-        self.assertEqual(sizevars.simplify_with_ranges(expr2, {}), expr2)
+        expr3 = ModularIndexing(i0, 1, 30) + 32 * ModularIndexing(i0, 32, 4)
+        self.assertEqual(sizevars.simplify_with_ranges(expr3, {}), expr3)
 
         # check that it also works with a modulus>1
-        expr3 = ModularIndexing(i0, 10, i1) + i1 * ModularIndexing(i0, i1, i2)
-        self.assertEqual(
-            sizevars.simplify_with_ranges(expr3, {}), ModularIndexing(i0, 10, i1 * i2)
-        )
+        expr4 = ModularIndexing(i0, 10, i1) + i1 * ModularIndexing(i0, i1 * 10, i2)
+        res0 = expr4.subs({i0: 24056, i1: 13, i2: 19})
+        simplified = sizevars.simplify_with_ranges(expr4, {})
+        res1 = simplified.subs({i0: 24056, i1: 13, i2: 19})
+        self.assertEqual(res0, res1)
+        self.assertEqual(simplified, ModularIndexing(i0, 10, i1 * i2))
 
         # and also works with an offset
         self.assertEqual(
-            sizevars.simplify_with_ranges(expr3 + 10, {}),
+            sizevars.simplify_with_ranges(expr4 + 10, {}),
             ModularIndexing(i0, 10, i1 * i2) + 10,
         )
+
+        # works for ModularIndexing + IndexingDiv
+        expr5 = 197 * IndexingDiv(i0, 197) + ModularIndexing(i0, 1, 197)
+        simplified = sizevars.simplify_with_ranges(expr5, {})
+        self.assertEqual(simplified, i0)
+        self.assertEqual(expr5.subs({i0: 39485}), simplified.subs({i0: 39485}))
+
+        # divisor != 1
+        expr6 = 197 * IndexingDiv(i0, 197 * 3) + ModularIndexing(i0, 3, 197)
+        simplified = sizevars.simplify_with_ranges(expr6, {})
+        self.assertEqual(simplified, IndexingDiv(i0, 3))
+        self.assertEqual(expr6.subs({i0: 39485}), simplified.subs({i0: 39485}))
 
 
 class CommonTemplate:

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -370,6 +370,12 @@ class TestIndexingSimplification(unittest.TestCase):
         self.assertEqual(simplified, i0)
         self.assertEqual(expr5.subs({i0: 39485}), simplified.subs({i0: 39485}))
 
+        # works with a scale
+        self.assertEqual(
+            sizevars.simplify_with_ranges(2 * expr5, {}),
+            2 * i0,
+        )
+
         # divisor != 1
         expr6 = 197 * IndexingDiv(i0, 197 * 3) + ModularIndexing(i0, 3, 197)
         simplified = sizevars.simplify_with_ranges(expr6, {})

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -344,7 +344,7 @@ class Reduction(Loops):
         if is_triton(device):
             reduction_numel_hint = V.graph.sizevars.size_hint(reduction_numel)
             numel_hint = V.graph.sizevars.size_hint(sympy_product(ranges))
-            if reduction_numel_hint >= 8192 and numel_hint <= 768:
+            if reduction_numel_hint > 8192 and numel_hint == 1:
                 # triton doesn't support reduce to single element well, so break it up
                 split = 128
                 return cls.create_multilayer(

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -349,6 +349,7 @@ def join_dimensions(expr: sympy.Expr) -> sympy.Expr:
     This type of pattern can come from view operations
     """
     from .ir import ModularIndexing
+    from .ir import IndexingDiv
 
     if not isinstance(expr, sympy.Add):
         return expr
@@ -363,7 +364,9 @@ def join_dimensions(expr: sympy.Expr) -> sympy.Expr:
         if m1:
             for term2 in expr.args:
                 m2 = term2.match(
-                    m1[scale] * m1[mod1] * ModularIndexing(m1[base], m1[mod1], mod2)
+                    m1[scale]
+                    * m1[mod1]
+                    * ModularIndexing(m1[base], m1[divisor] * m1[mod1], mod2)
                 )
                 if m2 and term1 != term2:
                     expr = join_dimensions(
@@ -374,6 +377,19 @@ def join_dimensions(expr: sympy.Expr) -> sympy.Expr:
                         * ModularIndexing(m1[base], m1[divisor], m1[mod1] * m2[mod2])
                     )
                     return expr
+    for term1 in expr.args:
+        m1 = term1.match(scale * ModularIndexing(base, divisor, mod1))
+        if m1:
+            for term2 in expr.args:
+                m2 = term2.match(
+                    m1[scale] * m1[mod1] * IndexingDiv(m1[base], m1[divisor] * m1[mod1])
+                )
+                if m2 is not None:  # in case of success we get an empty dict here
+                    expr = join_dimensions(
+                        expr - term1 - term2 + IndexingDiv(m1[base], m1[divisor])
+                    )
+                    return expr
+
     return expr
 
 

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -345,6 +345,9 @@ def join_dimensions(expr: sympy.Expr) -> sympy.Expr:
     ModularIndexing(i0, 1, 32) + 32 * ModularIndexing(i0, 32, 4)
     becomes
     ModularIndexing(i0, 1, 128)
+    ModularIndexing(i0, 1, 32) + 32 * IndexingDiv(i0, 32)
+    becomes i0
+
 
     This type of pattern can come from view operations
     """
@@ -386,7 +389,10 @@ def join_dimensions(expr: sympy.Expr) -> sympy.Expr:
                 )
                 if m2 is not None:  # in case of success we get an empty dict here
                     expr = join_dimensions(
-                        expr - term1 - term2 + IndexingDiv(m1[base], m1[divisor])
+                        expr
+                        - term1
+                        - term2
+                        + m1[scale] * IndexingDiv(m1[base], m1[divisor])
                     )
                     return expr
 

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -348,8 +348,8 @@ def join_dimensions(expr: sympy.Expr) -> sympy.Expr:
 
     This type of pattern can come from view operations
     """
-    from .ir import ModularIndexing
     from .ir import IndexingDiv
+    from .ir import ModularIndexing
 
     if not isinstance(expr, sympy.Add):
         return expr


### PR DESCRIPTION
Additional indexing simplification to get rid of more ModularIndexing instances and let dimension reordering work. 
Also, a fix for ModularIndexing dimension joining when the original divisor was not 1 - I had to change the test for expr4 (previously expr3), because before dumb substitution into original and simplified expressions produces wrong results which is clearly wrong. Now tests also check plain substitution results, in addition to checking that expected expression is produced. 
See tests for new handled cases