### PR TITLE
Append stack trace to fx node

### DIFF
--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -433,3 +433,12 @@ class OutputGraph(fx.Tracer):
         for node in self.graph.nodes:
             if "example_value" in node.meta:
                 del node.meta["example_value"]
+
+    def create_proxy(self, kind, target, args, kwargs, name=None, type_expr=None, proxy_factory_fn=None):
+        rv = super().create_proxy(kind, target, args, kwargs, name, type_expr, proxy_factory_fn)
+
+        # append stack trace to fx node
+        frame_summary = self.root_tx.frame_summary()
+        rv.node.stack_trace = f"{frame_summary}\n  {frame_summary.line}"
+
+        return rv

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -451,7 +451,12 @@ class OutputGraph(fx.Tracer):
 
         # append stack trace to fx node
         tx = current_tx if current_tx else self.root_tx
-        frame_summary = tx.frame_summary()
-        rv.node.stack_trace = f"{frame_summary}\n  {frame_summary.line}"
+        frame_summaries: List[traceback.FrameSummary] = []
+        while tx:
+            frame_summaries.append(tx.frame_summary())
+            tx = getattr(tx, "parent", None)
+
+        msgs = reversed(traceback.StackSummary.from_list(frame_summaries).format())
+        rv.node.stack_trace = "".join(msgs)
 
         return rv

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -434,11 +434,24 @@ class OutputGraph(fx.Tracer):
             if "example_value" in node.meta:
                 del node.meta["example_value"]
 
-    def create_proxy(self, kind, target, args, kwargs, name=None, type_expr=None, proxy_factory_fn=None):
-        rv = super().create_proxy(kind, target, args, kwargs, name, type_expr, proxy_factory_fn)
+    def create_proxy(
+        self,
+        kind,
+        target,
+        args,
+        kwargs,
+        name=None,
+        type_expr=None,
+        proxy_factory_fn=None,
+        current_tx=None,
+    ):
+        rv = super().create_proxy(
+            kind, target, args, kwargs, name, type_expr, proxy_factory_fn
+        )
 
         # append stack trace to fx node
-        frame_summary = self.root_tx.frame_summary()
+        tx = current_tx if current_tx else self.root_tx
+        frame_summary = tx.frame_summary()
         rv.node.stack_trace = f"{frame_summary}\n  {frame_summary.line}"
 
         return rv

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -267,7 +267,7 @@ class BuiltinVariable(VariableTracker):
                     fn, args = operator.add, [args[1], args[0]]
 
                 proxy = tx.output.create_proxy(
-                    "call_function", fn, *proxy_args_kwargs(args, kwargs)
+                    "call_function", fn, *proxy_args_kwargs(args, kwargs), current_tx=tx
                 )
                 if self.unspec_numpy_args(*args, **kwargs):
                     _args, _kwargs = self.unwrap_unspec_args_kwargs(args, kwargs)

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -291,7 +291,11 @@ class ProfileRecordFunctionVariable(ContextWrappingVariable):
     def _call_func(self, tx, value):
         if self.enter:
             self.proxy_value = tx.output.create_proxy(
-                "call_function", torch.ops.profiler._record_function_enter, (value,), {}
+                "call_function",
+                torch.ops.profiler._record_function_enter,
+                (value,),
+                {},
+                current_tx=tx,
             )
         else:
             tx.output.create_proxy(
@@ -299,6 +303,7 @@ class ProfileRecordFunctionVariable(ContextWrappingVariable):
                 torch.ops.profiler._record_function_exit,
                 (self.proxy_value,),
                 {},
+                current_tx=tx,
             )
 
     def _func_name(self):
@@ -482,6 +487,7 @@ class GetAttrVariable(VariableTracker):
                             "call_function",
                             original_torch_or_getattr_variable.value,
                             *proxy_args_kwargs(new_args, new_kwargs),
+                            current_tx=tx,
                         ),
                         **options,
                     )
@@ -492,6 +498,7 @@ class GetAttrVariable(VariableTracker):
                             "call_method",
                             original_torch_or_getattr_variable.name,
                             *proxy_args_kwargs(new_args, new_kwargs),
+                            current_tx=tx,
                         ),
                         **options,
                     )

--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -184,6 +184,7 @@ class NNModuleVariable(VariableTracker):
                     "call_module",
                     self.module_key,
                     *proxy_args_kwargs(args, kwargs),
+                    current_tx=tx,
                 ),
                 nnmodule=mod,
                 **options,

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -447,7 +447,7 @@ class TensorVariable(VariableTracker):
                 return self.__class__.create(
                     tx,
                     tx.output.create_proxy(
-                        "call_method", "item", (self.as_proxy(),), {}
+                        "call_method", "item", (self.as_proxy(),), {}, current_tx=tx
                     ),
                     **options,
                 )
@@ -461,7 +461,7 @@ class TensorVariable(VariableTracker):
                 return self.__class__.create(
                     tx,
                     tx.output.create_proxy(
-                        "call_function", len, (self.as_proxy(),), {}
+                        "call_function", len, (self.as_proxy(),), {}, current_tx=tx
                     ),
                     **options,
                 )
@@ -471,6 +471,7 @@ class TensorVariable(VariableTracker):
                 "call_function",
                 operator.setitem,
                 *proxy_args_kwargs([self] + args, kwargs),
+                current_tx=tx,
             )
             return ConstantVariable(None, **options)
         else:
@@ -487,7 +488,10 @@ class TensorVariable(VariableTracker):
             return self.__class__.create(
                 tx,
                 tx.output.create_proxy(
-                    "call_method", name, *proxy_args_kwargs([self] + args, kwargs)
+                    "call_method",
+                    name,
+                    *proxy_args_kwargs([self] + args, kwargs),
+                    current_tx=tx,
                 ),
                 **options,
             )

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -195,7 +195,10 @@ class TorchVariable(VariableTracker):
             tensor_variable = TensorVariable.create(
                 tx=tx,
                 proxy=tx.output.create_proxy(
-                    "call_function", self.value, *proxy_args_kwargs(args, kwargs)
+                    "call_function",
+                    self.value,
+                    *proxy_args_kwargs(args, kwargs),
+                    current_tx=tx,
                 ),
                 **options,
             )
@@ -265,6 +268,7 @@ class TorchVariable(VariableTracker):
                     "call_function",
                     torch.nn.functional.softmax,
                     *proxy_args_kwargs([input, dim], {}),
+                    current_tx=tx,
                 ),
                 **VariableTracker.propagate([self, dim, input]),
             )
@@ -328,6 +332,7 @@ class TorchVariable(VariableTracker):
                         ],
                         {},
                     ),
+                    current_tx=tx,
                 ),
                 **VariableTracker.propagate(
                     [


### PR DESCRIPTION
For debugging purpose, user commonly wish to trace back from an fx.Node to the user code. 


<img width="428" alt="image" src="https://user-images.githubusercontent.com/9906745/181680317-2514e893-600a-4d7c-a182-e9376f20b6f8.png">
Sample output: 

```
placeholder x
  File "/fsx/users/bahuang/repos/torchdynamo/test.py", line 21, in forward
    def forward(self, x):


call_function <built-in method sqrt of type object at 0x7f4c3f8d8360>
  File "/fsx/users/bahuang/repos/torchdynamo/test.py", line 22, in forward
    x = self.n(x)
  File "/fsx/users/bahuang/repos/torchdynamo/test.py", line 12, in forward
    a = torch.sqrt(q)


call_method relu
  File "/fsx/users/bahuang/repos/torchdynamo/test.py", line 22, in forward
    x = self.n(x)
  File "/fsx/users/bahuang/repos/torchdynamo/test.py", line 13, in forward
    return f(a)
  File "/fsx/users/bahuang/repos/torchdynamo/test.py", line 8, in f
    return x.relu()


call_module self_sigmoid
  File "/fsx/users/bahuang/repos/torchdynamo/test.py", line 23, in forward
    x = self.sigmoid(x)


output output
None
```