### PR TITLE
[inductor] Split indexing; store_cache[(name, index)]

### DIFF
--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -290,7 +290,7 @@ class CppKernel(Kernel):
         if name not in V.graph.removed_buffers:
             var = self.args.output(name)
             self.reduction_suffix.writeline(name, f"{var}[{cexpr(index)}] = {tmpvar};")
-        self.cse.store_cache[name] = tmpvar
+        self.cse.store_cache[(name, index)] = tmpvar
 
     def set_ranges(self, lengths, reduction_lengths):
         if self.call_ranges:

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -802,7 +802,7 @@ class TritonKernel(Kernel):
             var_name = self.cse.reduction_cache[(dtype, reduction_type, value)]
             self.suffix.writeline(f"{result_var} = {var_name}")
         self.inside_reduction = False
-        sympy_index = self.rename_indexing(self.simplify_indexing(index))
+        sympy_index = V.graph.sizevars.simplify_with_ranges(index, self.var_ranges())
         index, mask = self.indexing(index, result_var)
         assert "rmask" not in index
         self.inside_reduction = True

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -313,7 +313,6 @@ class RangeTree:
                 V.kernel.range_tree_nodes[node.symbol()] = node
                 self.var_list.append(node.symbol())
                 self.var_ranges[node.symbol()] = length
-                new_node = node
             else:
                 new_node = RangeTreeEntryAlias(
                     f"{self.prefix}{next(V.kernel.iter_vars_count)}",
@@ -322,16 +321,16 @@ class RangeTree:
                     aliased_entries,
                     expr,
                 )
+                # inheriet children from existing node
+                new_node.children = node.children
                 self.children[length] = new_node
                 V.kernel.range_tree_nodes[new_node.symbol()] = new_node
                 self.var_list.append(new_node.symbol())
                 self.var_ranges[new_node.symbol()] = length
-                # Note: return the node in original RangeTree
-                # since new_node only codegen aliased expression
+                node = new_node
         else:
             node = self.children[length]
-            new_node = node
-        return node, new_node
+        return node
 
 
 class RangeTreeRoot(RangeTree):

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -803,7 +803,7 @@ class TritonKernel(Kernel):
             var_name = self.cse.reduction_cache[(dtype, reduction_type, value)]
             self.suffix.writeline(f"{result_var} = {var_name}")
         self.inside_reduction = False
-        sympy_index = index
+        sympy_index = self.rename_indexing(self.simplify_indexing(index))
         index, mask = self.indexing(index, result_var)
         assert "rmask" not in index
         self.inside_reduction = True

--- a/torchinductor/codegen/triton_template.py
+++ b/torchinductor/codegen/triton_template.py
@@ -31,7 +31,7 @@ class TritonTemplateKernel(TritonKernel):
         for k, v in self.inout_dict.items():
             self.args.output_buffers[v] = k
         if isinstance(self.node, ir.Convolution):
-            self.cse.store_cache[self.inout_dict["y"]] = "acc"
+            self.cse.store_cache[(self.inout_dict["y"], "*")] = "acc"
 
     def assign_block_numel(self):
         code = IndentedBuffer()

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -67,58 +67,6 @@ def stride_order2fill_order(order):
     return fill_order
 
 
-def reads_from_conv(buf, var_ranges):
-    """
-    return:
-    if reads_from_conv: boolean
-    the new memory_addr: Sympy Expression
-    """
-    if buf is None:
-        return False, None
-    if isinstance(buf, Convolution):
-        indexer = buf.layout.as_fixed().make_indexer()
-        # sizes = buf.get_size()
-        index_vars = sorted(var_ranges, key=lambda var: var.name)
-        index = indexer(index_vars)
-        return True, index
-    # for case like
-    # buf0 = conv(x, w)
-    # return torch.cat([buf0, buf1]), torch.cat([buf0, buf2])
-    # Because of ConcatKernel, it will create two bufs buf3 and 4
-    # buf3 has the AliasedLayout which reads from buf0(Convolution)
-    # but buf4 is a copy of buf3 which reads from buf3
-    # we want to know that buf4 also follows buf0 conv's layout
-    if isinstance(buf.layout, AliasedLayout):
-        reads = buf.get_read_writes().reads
-        reads_bufs = [
-            V.graph.name_to_buffer[r.name]
-            if r.name in V.graph.name_to_buffer.keys()
-            else None
-            for r in reads
-        ]
-        for reads_buf in reads_bufs:
-            read_from_conv, addr = reads_from_conv(reads_buf, var_ranges)
-            if read_from_conv:
-                return True, addr
-    return False, None
-
-
-def layout_priority_idx(reads_bufs, memory_addrs, var_ranges):
-    """
-    if reads from conv that needs to use specific layout
-    return:
-    priority_idx regarding memory_addrs idx
-    memory_addrs - update memory_addrs with the true addr if needed
-    """
-    priority_idx = []
-    for i, reads_buf in enumerate(reads_bufs):
-        read_from_conv, mem_addr = reads_from_conv(reads_buf, var_ranges)
-        if read_from_conv:
-            priority_idx.append(i)
-            memory_addrs[i] = mem_addr
-    return priority_idx, memory_addrs
-
-
 class ModularIndexing(sympy.Function):
     """
     ModularIndexing(a, b, c) => (a // b) % c


### PR DESCRIPTION
For fused kernels, although it is guaranteed that the reads from and writes to the same region of the buffer by checking the MemoryDep. But for the case when the 
`buf1 = buf0.permute(0,3,1,2); buf2 = buf1` where buf0 is NHWC layout and buf1 and buf2 is NCHW layout.
the indexing of `tl.store` to buf2 maybe wrong due to indexing mismatch of buf1.
Instead of creating a new RangeTreeEntry, we will try to split the current range on the existing RangeTreeEntries.
See the example below

Before (wrong):
```
@triton.jit
def kernel4(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr0, out_ptr1, out_ptr2, out_ptr3, ks0, xnumel, XBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK])
    xmask = xindex < xnumel
    x4 = xindex
    x0 = xindex % 64
    x0_next = xindex // 64
    x1 = x0_next % 3025
    x1_next = x0_next // 3025
    x2 = x1_next
    x5 = xindex % 193600
    x5_next = xindex // 193600
    x6 = x5_next
    tmp0 = tl.load(in_ptr0 + x4 + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp1 = tl.load(in_ptr1 + x0 + tl.zeros([XBLOCK], tl.int32), xmask) # NHWC layout
    tmp3 = tl.load(in_ptr2 + x4 + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp5 = tl.load(in_ptr3 + x4 + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp2 = tmp0 + tmp1
    tmp4 = tmp3 + tmp1 # NHWC layout
    tmp6 = tmp5 + tmp1
    tl.store(out_ptr0 + x1 + (3025*x0) + (387200*x2) + tl.zeros([XBLOCK], tl.int32), tmp2, xmask)
    tl.store(out_ptr1 + x1 + (3025*x0) + (387200*x2) + tl.zeros([XBLOCK], tl.int32), tmp4, xmask) # NCHW layout
    tl.store(out_ptr2 + x1 + (3025*x0) + (387200*x2) + tl.zeros([XBLOCK], tl.int32), tmp6, xmask)
    # wrong!! because it is equivalent to `tl.store(out_ptr3 + x0 + 64*x1 +  (387200*x6), tmp4)`, the indexing is wrong
    # we would expect `tl.store(out_ptr3 + x1 + (3025*x0) + (387200*x2), tmp6)`
    tl.store(out_ptr3 + x5 + (387200*x6) + tl.zeros([XBLOCK], tl.int32), tmp4, xmask) 
```
The RangeTree looks like this:
>>>
                    Root
                  /         \
            x0: 64      x5: 193600 (equivalent to x0 + 64*x1)
                /              \
         x1 : 3025       x6: s0
                |  
              x2: s0
>>>

After:
```
@triton.jit
def kernel4(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr0, out_ptr1, out_ptr2, out_ptr3, ks0, xnumel, XBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK])
    xmask = xindex < xnumel
    x4 = xindex
    x0 = xindex % 64
    x0_next = xindex // 64
    x1 = x0_next % 3025
    x1_next = x0_next // 3025
    x2 = x1_next
    x5 = x1 + (3025*x0)
    tmp0 = tl.load(in_ptr0 + x4 + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp1 = tl.load(in_ptr1 + x0 + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp3 = tl.load(in_ptr2 + x4 + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp5 = tl.load(in_ptr3 + x4 + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp2 = tmp0 + tmp1
    tmp4 = tmp3 + tmp1
    tmp6 = tmp5 + tmp1
    tl.store(out_ptr0 + x1 + (3025*x0) + (387200*x2) + tl.zeros([XBLOCK], tl.int32), tmp2, xmask)
    tl.store(out_ptr1 + x1 + (3025*x0) + (387200*x2) + tl.zeros([XBLOCK], tl.int32), tmp4, xmask)
    tl.store(out_ptr2 + x1 + (3025*x0) + (387200*x2) + tl.zeros([XBLOCK], tl.int32), tmp6, xmask)
    tl.store(out_ptr3 + x5 + (387200*x2) + tl.zeros([XBLOCK], tl.int32), tmp4, xmask)
```

The RangeTree looks like this:
>>>
                    Root
                  /         \
            x0: 64      x5 (AliasedEntry)
                /                 = x1 + 3025 * x0 (it is decided in cse.store_cache)
               /             /
         x1 : 3025        /
                |        /
                |     /
                x2: s0
>>>