### PR TITLE
Benchmarking - Add start_latency, some fixes in TIMM

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -140,7 +140,7 @@ class Stats:
         return [cls.totals["aot_autograd"]["total"], cls.totals["aot_autograd"]["ok"]]
 
 
-def coverage_experiment(args, model_iter_fn, model, example_inputs):
+def coverage_experiment(args, model_iter_fn, model, example_inputs, start_latency):
     """
     Test operator/model coverage of TorchDynamo and record statistics
     taken from a profiler.  This target is mainly intended to check
@@ -168,7 +168,10 @@ def coverage_experiment(args, model_iter_fn, model, example_inputs):
             current_device,
             current_name,
         ]
-        + coverage_result.tocsv(),
+        + coverage_result.tocsv()
+        + [
+            start_latency,
+        ],
     )
     return coverage_result
 
@@ -807,10 +810,10 @@ class BenchmarkRunner:
         skip_accuracy_check=False,
         dynamic_shapes=False,
     ):
-        t0 = time.perf_counter()
         tolerance, cos_similarity = self.get_tolerance_and_cosine_flag(
             is_training, current_device, name
         )
+        experiment_kwargs = dict()
         with self.pick_grad(name, is_training):
             mode = "train" if is_training else "eval"
             sys.stdout.write(f"{current_device:4} {mode:5} {current_name:34} ")
@@ -844,6 +847,7 @@ class BenchmarkRunner:
                     if not skip_accuracy_check:
                         return sys.exit(-1)
 
+            t0 = time.perf_counter()
             torch.manual_seed(1337)
             torchdynamo.reset()
             if experiment.func is cold_start_experiment:
@@ -886,12 +890,17 @@ class BenchmarkRunner:
                 frames_third_pass = 0
 
             if output_filename and "coverage" in output_filename:
+                t1 = time.perf_counter()
                 results.append(
-                    f"{ok:3}/{total:3} +{frames_third_pass} frames {time.perf_counter()-t0:3.0f}s"
+                    f"{ok:3}/{total:3} +{frames_third_pass} frames {t1-t0:3.0f}s"
                 )
+                experiment_kwargs["start_latency"] = t1 - t0
+
             if not hasattr(model, name):
                 model.name = name
             results.append(experiment(model, example_inputs))
+
+            results.append(experiment(model, example_inputs, **experiment_kwargs))
             print(" ".join(map(str, results)))
 
 

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -894,12 +894,12 @@ class BenchmarkRunner:
                 results.append(
                     f"{ok:3}/{total:3} +{frames_third_pass} frames {t1-t0:3.0f}s"
                 )
+
+            if experiment.func is coverage_experiment:
                 experiment_kwargs["start_latency"] = t1 - t0
 
             if not hasattr(model, name):
                 model.name = name
-            results.append(experiment(model, example_inputs))
-
             results.append(experiment(model, example_inputs, **experiment_kwargs))
             print(" ".join(map(str, results)))
 

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -140,7 +140,7 @@ class Stats:
         return [cls.totals["aot_autograd"]["total"], cls.totals["aot_autograd"]["ok"]]
 
 
-def coverage_experiment(args, model_iter_fn, model, example_inputs, start_latency):
+def coverage_experiment(args, model_iter_fn, model, example_inputs):
     """
     Test operator/model coverage of TorchDynamo and record statistics
     taken from a profiler.  This target is mainly intended to check
@@ -168,10 +168,7 @@ def coverage_experiment(args, model_iter_fn, model, example_inputs, start_latenc
             current_device,
             current_name,
         ]
-        + coverage_result.tocsv()
-        + [
-            start_latency,
-        ],
+        + coverage_result.tocsv(),
     )
     return coverage_result
 
@@ -810,10 +807,10 @@ class BenchmarkRunner:
         skip_accuracy_check=False,
         dynamic_shapes=False,
     ):
+        t0 = time.perf_counter()
         tolerance, cos_similarity = self.get_tolerance_and_cosine_flag(
             is_training, current_device, name
         )
-        experiment_kwargs = dict()
         with self.pick_grad(name, is_training):
             mode = "train" if is_training else "eval"
             sys.stdout.write(f"{current_device:4} {mode:5} {current_name:34} ")
@@ -847,7 +844,6 @@ class BenchmarkRunner:
                     if not skip_accuracy_check:
                         return sys.exit(-1)
 
-            t0 = time.perf_counter()
             torch.manual_seed(1337)
             torchdynamo.reset()
             if experiment.func is cold_start_experiment:
@@ -890,17 +886,12 @@ class BenchmarkRunner:
                 frames_third_pass = 0
 
             if output_filename and "coverage" in output_filename:
-                t1 = time.perf_counter()
                 results.append(
-                    f"{ok:3}/{total:3} +{frames_third_pass} frames {t1-t0:3.0f}s"
+                    f"{ok:3}/{total:3} +{frames_third_pass} frames {time.perf_counter()-t0:3.0f}s"
                 )
-
-            if experiment.func is coverage_experiment:
-                experiment_kwargs["start_latency"] = t1 - t0
-
             if not hasattr(model, name):
                 model.name = name
-            results.append(experiment(model, example_inputs, **experiment_kwargs))
+            results.append(experiment(model, example_inputs))
             print(" ".join(map(str, results)))
 
 

--- a/benchmarks/timm_models.py
+++ b/benchmarks/timm_models.py
@@ -206,9 +206,16 @@ class TimmRunnner(BenchmarkRunner):
             recorded_batch_size = int(recorded_batch_size / 2)
         batch_size = batch_size or recorded_batch_size
 
-        example_inputs = torch.randn(
-            (batch_size,) + input_size, device=device, dtype=data_dtype
-        )
+        # example_inputs = torch.randn(
+        #     (batch_size,) + input_size, device=device, dtype=data_dtype
+        # )
+        input_tensor = torch.randint(
+            256, size=(batch_size,) + input_size, device=device
+        ).to(dtype=torch.float32)
+        mean = torch.mean(input_tensor)
+        std_dev = torch.std(input_tensor)
+        example_inputs = (input_tensor - mean) / std_dev
+
         if channels_last:
             example_inputs = example_inputs.contiguous(
                 memory_format=torch.channels_last

--- a/benchmarks/timm_models.py
+++ b/benchmarks/timm_models.py
@@ -216,6 +216,7 @@ class TimmRunnner(BenchmarkRunner):
         example_inputs = [
             example_inputs,
         ]
+        self.target = self._gen_target(batch_size, device)
 
         self.loss = torch.nn.CrossEntropyLoss().to(device)
         return device, model_name, model, example_inputs
@@ -269,8 +270,7 @@ class TimmRunnner(BenchmarkRunner):
         )
 
     def compute_loss(self, pred):
-        target = self._gen_target(pred.shape[0], pred.device)
-        return self.loss(pred, target)
+        return self.loss(pred, self.target)
 
     @torchdynamo.skip
     def forward_pass(self, mod, inputs, collect_outputs=True):


### PR DESCRIPTION
* ~Adding a new field `start_latency` (a better name suggestion is definitely welcome) to measure the latency of `torchdynamo.optimize` and first couple of inference calls.~ 
* Removing `random_` from the TIMM models in the loss calculation
* Somewhat more realistic inputs for TIMM models.

Update - Removed the start_latency portion as it was upsetting CircleCI.