### PR TITLE
Tag the module class Dynamic instead of just instances

### DIFF
--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -84,7 +84,10 @@ class NNModuleVariable(VariableTracker):
         """Restart analysis treating this module as an UnspecializedNNModuleVariable"""
         mod = tx.output.get_submodule(self.module_key)
         GenerationTracker.tag(mod)
-        GenerationTracker.mark_class_dynamic(type(mod))
+
+        # Mark the class dynamic unless its module initialization
+        if tx.f_code.co_name != "__init__":
+            GenerationTracker.mark_class_dynamic(type(mod))
         raise RestartAnalysis()
 
     def var_getattr(self, tx, name):

--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -84,7 +84,7 @@ class NNModuleVariable(VariableTracker):
         """Restart analysis treating this module as an UnspecializedNNModuleVariable"""
         mod = tx.output.get_submodule(self.module_key)
         GenerationTracker.tag(mod)
-        # GenerationTracker.mark_class_dynamic(type(mod))
+        GenerationTracker.mark_class_dynamic(type(mod))
         raise RestartAnalysis()
 
     def var_getattr(self, tx, name):


### PR DESCRIPTION
Densenet had one module that was instantiated > 50 times. This module was changing the state of the module. Currently, Dynamo marks the instance of this module as UnSpecialized and then restarts Analysis.

Since, the module was instantiated many times, we were stuck in these restarts.

Solution (which was already present and commented) is to mark the class dynamic, so there will be just one restart and then all the instances will be of UnSpecialized type.

With this, the compile time latency reduced from 94 to 9 seconds for densenet121, and 640 to 19 seconds for dpn107.

xRef - https://github.com/pytorch/torchdynamo/issues/687