### PR TITLE
[inductor] reordering loops based on reads's layout and their reordering order

### DIFF
--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -20,7 +20,7 @@ from ..virtualized import ops
 log = logging.getLogger(__name__)
 
 
-def _simplify_loops(index_vars, sizes, index_formulas):
+def _simplify_loops(index_vars, sizes, index_formulas, preserver_reoredering=False):
     """
     Try to remove as many axis from loop iterations as possible, by:
         1) removing size==1 dimensions
@@ -58,6 +58,11 @@ def _simplify_loops(index_vars, sizes, index_formulas):
             reversed(range(len(sizes))), reversed(range(len(sizes)))
         ):
             if i == j or sizes[i] is None or sizes[j] is None:
+                continue
+            # preseve the ordering of index_vars from _apply_loop_reordering
+            # otherwise, the reordering does not take effect
+            # so we only allow merge(i, j) where i > j
+            if preserver_reoredering and i < j:
                 continue
             if can_merge_dims(i, j):
                 changed = True

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -20,7 +20,7 @@ from ..virtualized import ops
 log = logging.getLogger(__name__)
 
 
-def _simplify_loops(index_vars, sizes, index_formulas, preserver_reoredering=False):
+def _simplify_loops(index_vars, sizes, index_formulas):
     """
     Try to remove as many axis from loop iterations as possible, by:
         1) removing size==1 dimensions
@@ -58,11 +58,6 @@ def _simplify_loops(index_vars, sizes, index_formulas, preserver_reoredering=Fal
             reversed(range(len(sizes))), reversed(range(len(sizes)))
         ):
             if i == j or sizes[i] is None or sizes[j] is None:
-                continue
-            # preseve the ordering of index_vars from _apply_loop_reordering
-            # otherwise, the reordering does not take effect
-            # so we only allow merge(i, j) where i > j
-            if preserver_reoredering and i < j:
                 continue
             if can_merge_dims(i, j):
                 changed = True

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -39,7 +39,9 @@ def _simplify_loops(index_vars, sizes, index_formulas):
 
     def can_merge_dims(a, b):
         for k in range(len(strides)):
-            if V.graph.sizevars.simplify(strides[k][a] * sizes[a]) == V.graph.sizevars.simplify(strides[k][b]):
+            if V.graph.sizevars.simplify(
+                strides[k][a] * sizes[a]
+            ) == V.graph.sizevars.simplify(strides[k][b]):
                 # approximate test passed, try sound version
                 va = index_vars[a]
                 vb = index_vars[b]

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -39,14 +39,14 @@ def _simplify_loops(index_vars, sizes, index_formulas, preserver_reoredering=Fal
 
     def can_merge_dims(a, b):
         for k in range(len(strides)):
-            if strides[k][a] * sizes[a] == strides[k][b]:
+            if V.graph.sizevars.simplify(strides[k][a] * sizes[a]) == V.graph.sizevars.simplify(strides[k][b]):
                 # approximate test passed, try sound version
                 va = index_vars[a]
                 vb = index_vars[b]
                 v = sympy.Symbol("_merge_tester")
                 expr1 = index_formulas[k].subs({va: v * sizes[a], vb: 0})
                 expr2 = index_formulas[k].subs({va: 0, vb: v})
-                if expr1 == expr2:
+                if V.graph.sizevars.simplify(expr1) == V.graph.sizevars.simplify(expr2):
                     continue
             return False
         return True

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -90,7 +90,7 @@ def index_prevent_reordering(index: typing.List[sympy.Expr], index_vars, sizes):
 
     res = index
     # added contiguous index prevents reordering
-    res.append(sympy_dot(index_vars, FlexibleLayout.contiguous_strides(sizes)))
+    return [*index, sympy_dot(index_vars, FlexibleLayout.contiguous_strides(sizes))]
     return res
 
 

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -13,6 +13,7 @@ import sympy
 from sympy.printing.printer import Printer
 
 from .. import metrics
+from ..utils import sympy_dot
 from ..utils import unique
 from ..virtualized import V
 from ..virtualized import ops
@@ -82,6 +83,15 @@ def _simplify_loops(index_vars, sizes, index_formulas):
         return [i for i, s in zip(index, sizes) if s is not None]
 
     return [x for x in sizes if x is not None], reindex, prune
+
+
+def index_prevent_reordering(index: typing.List[sympy.Expr], index_vars, sizes):
+    from ..ir import FlexibleLayout
+
+    res = index
+    # added contiguous index prevents reordering
+    res.append(sympy_dot(index_vars, FlexibleLayout.contiguous_strides(sizes)))
+    return res
 
 
 class ExprPrinter(Printer):

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -18,7 +18,6 @@ from .. import codecache
 from .. import config
 from .. import ir
 from ..utils import has_triton_libdevice
-from ..utils import sympy_dot
 from ..utils import sympy_product
 from ..virtualized import V
 from ..virtualized import ops
@@ -27,6 +26,7 @@ from .common import ExprPrinter
 from .common import IndentedBuffer
 from .common import Kernel
 from .common import OpOverrides
+from .common import index_prevent_reordering
 
 log = logging.getLogger(__name__)
 
@@ -573,13 +573,7 @@ class TritonKernel(Kernel):
         if not sizes:
             return index
         new_sizes, reindex, prune = ir._simplify_loops(
-            index_vars,
-            sizes,
-            [
-                index,
-                # added contiguous index prevents reordering
-                sympy_dot(index_vars, ir.FlexibleLayout.contiguous_strides(sizes)),
-            ],
+            index_vars, sizes, index_prevent_reordering([index], index_vars, sizes)
         )
         if new_sizes == sizes:
             return index

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -8,8 +8,8 @@ from typing import Set
 
 import sympy
 
-from .utils import sympy_dot
 from .codegen.common import _simplify_loops
+from .utils import sympy_dot
 from .virtualized import V
 
 log = logging.getLogger(__name__)
@@ -126,6 +126,7 @@ class RecordLoadStore(V.MockHandler):
 
     def canonicalize(self, index):
         from .ir import FlexibleLayout
+
         sizes = list(self._var_ranges.values())
         sizes = [V.graph.sizevars.simplify(x) for x in sizes]
         if not self._normalize:
@@ -142,7 +143,7 @@ class RecordLoadStore(V.MockHandler):
                 index,
                 # added contiguous index prevents reordering
                 sympy_dot(index_vars, FlexibleLayout.contiguous_strides(sizes)),
-            ]
+            ],
         )
 
         # assign new variables each dimension to deal with numbering mismatches

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -9,7 +9,7 @@ from typing import Set
 import sympy
 
 from .codegen.common import _simplify_loops
-from .utils import sympy_dot
+from .codegen.common import index_prevent_reordering
 from .virtualized import V
 
 log = logging.getLogger(__name__)
@@ -125,8 +125,6 @@ class RecordLoadStore(V.MockHandler):
         self._normalize = normalize
 
     def canonicalize(self, index):
-        from .ir import FlexibleLayout
-
         sizes = list(self._var_ranges.values())
         sizes = [V.graph.sizevars.simplify(x) for x in sizes]
         if not self._normalize:
@@ -139,11 +137,7 @@ class RecordLoadStore(V.MockHandler):
         new_sizes, reindex, prune = _simplify_loops(
             index_vars,
             sizes,
-            [
-                index,
-                # added contiguous index prevents reordering
-                sympy_dot(index_vars, FlexibleLayout.contiguous_strides(sizes)),
-            ],
+            index_prevent_reordering([index], index_vars, sizes),
         )
 
         # assign new variables each dimension to deal with numbering mismatches

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -122,7 +122,9 @@ class RecordLoadStore(V.MockHandler):
         # convert it to the simpliest form because of the interference from
         # different indexing formulas.
         index_vars = list(self._var_ranges.keys())
-        new_sizes, reindex, prune = _simplify_loops(index_vars, sizes, [index])
+        new_sizes, reindex, prune = _simplify_loops(
+            index_vars, sizes, [index], preserver_reoredering=True
+        )
 
         # assign new variables each dimension to deal with numbering mismatches
         # d0, d1, d2 could become d0, d2 -- which won't match d0, d1

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1530,7 +1530,7 @@ class ComputedBuffer(Buffer):
                     *index_formulas,
                     # added contiguous index prevents reordering
                     sympy_dot(x_vars, FlexibleLayout.contiguous_strides(sizes)),
-                ]
+                ],
             )
             x_vars = prune(x_vars)
             # sizes, reindex1, prune = _simplify_loops(x_vars, sizes, index_formulas)

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -23,6 +23,7 @@ from . import dependencies
 from .codegen.common import _simplify_loops
 from .dependencies import extract_read_writes
 from .dependencies import var_builder
+from .utils import sympy_dot
 from .utils import sympy_product
 from .virtualized import V
 from .virtualized import ops
@@ -1523,7 +1524,13 @@ class ComputedBuffer(Buffer):
             # for NHWC: reindex0([0,1,2,3]) = [0,2,3,1], reindex1([0,1,2,3]) = [0,3,2,1]
             x_vars = reindex0(x_vars)
             sizes, reindex2, prune = _simplify_loops(
-                x_vars, sizes, index_formulas, preserver_reoredering=True
+                x_vars,
+                sizes,
+                [
+                    *index_formulas,
+                    # added contiguous index prevents reordering
+                    sympy_dot(x_vars, FlexibleLayout.contiguous_strides(sizes)),
+                ]
             )
             x_vars = prune(x_vars)
             # sizes, reindex1, prune = _simplify_loops(x_vars, sizes, index_formulas)

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -21,9 +21,9 @@ from sympy import Integer
 from . import config
 from . import dependencies
 from .codegen.common import _simplify_loops
+from .codegen.common import index_prevent_reordering
 from .dependencies import extract_read_writes
 from .dependencies import var_builder
-from .utils import sympy_dot
 from .utils import sympy_product
 from .virtualized import V
 from .virtualized import ops
@@ -1590,11 +1590,7 @@ class ComputedBuffer(Buffer):
             sizes, reindex2, prune = _simplify_loops(
                 x_vars,
                 sizes,
-                [
-                    *index_formulas,
-                    # added contiguous index prevents reordering
-                    sympy_dot(x_vars, FlexibleLayout.contiguous_strides(sizes)),
-                ],
+                index_prevent_reordering(index_formulas, x_vars, sizes),
             )
             x_vars = prune(x_vars)
             # sizes, reindex1, prune = _simplify_loops(x_vars, sizes, index_formulas)

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1477,20 +1477,24 @@ class ComputedBuffer(Buffer):
                 var_ranges,
             )
         index_formulas = [*body.indexing_exprs.values()]
-        memory_addrs = [*body.reads_name2expr.values(), *body.writes_name2expr.values()]
+        # memory_addrs = [*body.reads_name2expr.values(), *body.writes_name2expr.values()]
+        # prioritize reads layout/loop_ordering over writes
+        if len(body.reads_name2expr.values()) > 0:
+            memory_addrs = [*body.reads_name2expr.values()]
+        else:
+            memory_addrs = [*body.writes_name2expr.values()]
         priority_idx = []
+
+        reads_bufs = [
+            V.graph.name_to_buffer[reads_name]
+            if reads_name in V.graph.name_to_buffer.keys()
+            else None
+            for reads_name in body.reads_name2expr.keys()
+        ]
+
         if config.triton.convolution != "aten":
-            reads_bufs = [
-                V.graph.name_to_buffer[reads_name]
-                if reads_name in V.graph.name_to_buffer.keys()
-                else None
-                for reads_name in body.reads_name2expr.keys()
-            ]
             for i, reads_buf in enumerate(reads_bufs):
                 if isinstance(reads_buf, Convolution):
-                    # [ 3, 0, 2, 1] to [ 1, 3, 2, 0]
-                    # preferred_stride_order = reads_buf.preferred_stride_order
-                    # preferred_order = stride_order2fill_order(preferred_stride_order)
                     priority_idx.append(i)
 
         index_vars = []
@@ -1507,22 +1511,37 @@ class ComputedBuffer(Buffer):
                 reduce_vars.append(v)
                 reduce_size.append(s)
 
-        def simplify_and_reorder(x_vars, sizes):
+        # the reordering_reindex in reads' simplify_reorder_and_tile
+        reordering_reindex = [same_reorder(range(len(index_vars)))] * len(memory_addrs)
+        for i, reads_buf in enumerate(reads_bufs):
+            if isinstance(reads_buf, ComputedBuffer):
+                reordering_reindex[i] = reads_buf.iter_reordering_reindex
+
+        def simplify_and_reorder(x_vars, sizes, reordering_reindex=None):
             sizes, reindex0, reindex1 = self._apply_loop_reordering(
-                x_vars, sizes, memory_addrs, priority_idx
+                x_vars, sizes, memory_addrs, reordering_reindex, priority_idx
             )
+            # for NHWC: reindex0([0,1,2,3]) = [0,2,3,1], reindex1([0,1,2,3]) = [0,3,2,1]
             x_vars = reindex0(x_vars)
-            sizes, reindex2, prune = _simplify_loops(x_vars, sizes, index_formulas)
+            sizes, reindex2, prune = _simplify_loops(
+                x_vars, sizes, index_formulas, preserver_reoredering=True
+            )
             x_vars = prune(x_vars)
             # sizes, reindex1, prune = _simplify_loops(x_vars, sizes, index_formulas)
             # x_vars = prune(x_vars)
             # sizes, reindex2 = self._apply_loop_reordering(x_vars, sizes, memory_addrs)
             reindex = fuse_reindexing(reindex1, reindex2)
-            return sizes, reindex
+            return sizes, reindex, reindex1
 
-        iter_ranges, iter_reindex = simplify_and_reorder(index_vars, index_size)
-        reduce_ranges, reduce_reindex = simplify_and_reorder(reduce_vars, reduce_size)
+        iter_ranges, iter_reindex, iter_reordering_reindex = simplify_and_reorder(
+            index_vars, index_size, reordering_reindex
+        )
+        reduce_ranges, reduce_reindex, _ = simplify_and_reorder(
+            reduce_vars, reduce_size
+        )
 
+        # remember the reordering order
+        self.iter_reordering_reindex = iter_reordering_reindex
         # retrace the loop body with simplification and reordering applied
         (iter_vars, reduce_vars), var_ranges = dependencies.index_vars_no_squeeze(
             iter_ranges, reduce_ranges, prefix="z"
@@ -1649,7 +1668,9 @@ class ComputedBuffer(Buffer):
             return (iter_ranges,), body
 
     @staticmethod
-    def _apply_loop_reordering(index_vars, sizes, memory_addrs, priority_idx=[]):
+    def _apply_loop_reordering(
+        index_vars, sizes, memory_addrs, reordering_reindex=None, priority_idx=[]
+    ):
         """
         Shuffle the order of loops around to hopefully improve performance.
         """
@@ -1664,6 +1685,9 @@ class ComputedBuffer(Buffer):
                 dtype=numpy.int64,
             )
             assert strides.shape == (len(memory_addrs), len(index_vars))
+            if reordering_reindex is not None:
+                for i in range(len(memory_addrs)):
+                    strides[i] = reordering_reindex[i](strides[i])
             order = list(reversed(pick_loop_order(strides, sizes, priority_idx)))
         except Exception:
             if config.debug:

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2489,6 +2489,7 @@ class Convolution(ExternKernelAlloc):
             config_conv == "aten"
             or len(kernel_size) != 2
             or not is_triton(x.get_device())
+            or transposed
             or groups != 1
             or x.get_dtype() == torch.float16
             or x.get_dtype() == torch.bfloat16


### PR DESCRIPTION
- refactor index_prevent_reordering
- reordering loops based on reads' layout AND reordering_reindex

We want to solve the same issue as in #685. But instead change indexing at run-time, reorder the loop order by checking both reads' layout and reordering_reindex in `_apply_loop_reordering()`.
To avoid `_simplify_loops` will flatten to a single dimension regardless of the reordering, use index_prevent_reordering

Before
```
@triton.jit
def kernel4(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr0, out_ptr1, out_ptr2, out_ptr3, ks0, xnumel, XBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK])
    xmask = xindex < xnumel
    x4 = xindex
    x0 = xindex % 64
    x0_next = xindex // 64
    x1 = x0_next % 3025
    x1_next = x0_next // 3025
    x2 = x1_next
    x5 = xindex % 193600
    x5_next = xindex // 193600
    x6 = x5_next
    tmp0 = tl.load(in_ptr0 + x4 + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp1 = tl.load(in_ptr1 + x0 + tl.zeros([XBLOCK], tl.int32), xmask) # NHWC layout
    tmp3 = tl.load(in_ptr2 + x4 + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp5 = tl.load(in_ptr3 + x4 + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp2 = tmp0 + tmp1
    tmp4 = tmp3 + tmp1 # NHWC layout
    tmp6 = tmp5 + tmp1
    tl.store(out_ptr0 + x1 + (3025*x0) + (387200*x2) + tl.zeros([XBLOCK], tl.int32), tmp2, xmask)
    tl.store(out_ptr1 + x1 + (3025*x0) + (387200*x2) + tl.zeros([XBLOCK], tl.int32), tmp4, xmask) # NCHW layout
    tl.store(out_ptr2 + x1 + (3025*x0) + (387200*x2) + tl.zeros([XBLOCK], tl.int32), tmp6, xmask)
    # wrong!! because it is equivalent to `tl.store(out_ptr3 + x0 + 64*x1 +  (387200*x6), tmp4)`, the indexing is wrong
    # we would expect `tl.store(out_ptr3 + x1 + (3025*x0) + (387200*x2), tmp6)`
    tl.store(out_ptr3 + x5 + (387200*x6) + tl.zeros([XBLOCK], tl.int32), tmp4, xmask) 
```
After
```
@pointwise_heuristics(size_hints=[131072, 64])
@triton.jit
def kernel4(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr0, out_ptr1, out_ptr2, out_ptr3, ks0, xnumel, ynumel, XBLOCK : tl.constexpr, YBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK, 1])
    xmask = xindex < xnumel
    yoffset = tl.program_id(1) * YBLOCK
    yindex = yoffset + tl.reshape(tl.arange(0, YBLOCK), [1, YBLOCK])
    ymask = yindex < ynumel
    x3 = xindex
    y2 = yindex
    x0 = xindex % 3025
    x0_next = xindex // 3025
    x1 = x0_next
    tmp0 = tl.load(in_ptr0 + y2 + (64*x3) + tl.zeros([XBLOCK, YBLOCK], tl.int32), xmask & ymask)
    tmp1 = tl.load(in_ptr1 + y2 + tl.zeros([XBLOCK, YBLOCK], tl.int32), xmask & ymask)
    tmp3 = tl.load(in_ptr2 + y2 + (64*x3) + tl.zeros([XBLOCK, YBLOCK], tl.int32), xmask & ymask)
    tmp5 = tl.load(in_ptr3 + y2 + (64*x3) + tl.zeros([XBLOCK, YBLOCK], tl.int32), xmask & ymask)
    tmp2 = tmp0 + tmp1
    tmp4 = tmp3 + tmp1
    tmp6 = tmp5 + tmp1
    tl.store(out_ptr0 + x0 + (3025*y2) + (387200*x1) + tl.zeros([XBLOCK, YBLOCK], tl.int32), tmp2, xmask & ymask)
    tl.store(out_ptr1 + x0 + (3025*y2) + (387200*x1) + tl.zeros([XBLOCK, YBLOCK], tl.int32), tmp4, xmask & ymask)
    tl.store(out_ptr2 + x0 + (3025*y2) + (387200*x1) + tl.zeros([XBLOCK, YBLOCK], tl.int32), tmp6, xmask & ymask)
    tl.store(out_ptr3 + x0 + (3025*y2) + (387200*x1) + tl.zeros([XBLOCK, YBLOCK], tl.int32), tmp4, xmask & ymask)
```
