### PR TITLE
Fix `requirements.txt` on Mac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,6 @@ pytest
 pyyaml
 sympy
 tabulate
+cmake
+setuptools==59.5.0
 torch>=1.12.0


### PR DESCRIPTION
Logs

I got the distutils version from here https://github.com/pytorch/pytorch/issues/69894#issuecomment-1080635462

```
(dynamo) ➜  pytorch git:(master) python setup.py develop

Building wheel torch-1.10.0a0+git255a324
Traceback (most recent call last):
  File "/Users/marksaroufim/Dev/pytorch/setup.py", line 300, in <module>
    cmake = CMake()
  File "/Users/marksaroufim/Dev/pytorch/tools/setup_helpers/cmake.py", line 102, in __init__
    self._cmake_command = CMake._get_cmake_command()
  File "/Users/marksaroufim/Dev/pytorch/tools/setup_helpers/cmake.py", line 129, in _get_cmake_command
    raise RuntimeError('no cmake or cmake3 with version >= 3.5.0 found')
RuntimeError: no cmake or cmake3 with version >= 3.5.0 found
(dynamo) ➜  pytorch git:(master) pip install cmake
Collecting cmake
  Downloading cmake-3.23.3-py2.py3-none-macosx_10_10_universal2.macosx_10_10_x86_64.macosx_11_0_arm64.macosx_11_0_universal2.whl (76.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 76.2/76.2 MB 23.3 MB/s eta 0:00:00
Installing collected packages: cmake
Successfully installed cmake-3.23.3
(dynamo) ➜  pytorch git:(master) python setup.py develop

Building wheel torch-1.10.0a0+git255a324
Traceback (most recent call last):
  File "/Users/marksaroufim/Dev/pytorch/setup.py", line 300, in <module>
    cmake = CMake()
  File "/Users/marksaroufim/Dev/pytorch/tools/setup_helpers/cmake.py", line 102, in __init__
    self._cmake_command = CMake._get_cmake_command()
  File "/Users/marksaroufim/Dev/pytorch/tools/setup_helpers/cmake.py", line 126, in _get_cmake_command
    elif cmake is not None and CMake._get_version(cmake) >= distutils.version.LooseVersion("3.5.0"):
  File "/Users/marksaroufim/Dev/pytorch/tools/setup_helpers/cmake.py", line 137, in _get_version
    return distutils.version.LooseVersion(line.strip().split(' ')[2])
AttributeError: module 'distutils' has no attribute 'version'
(dynamo) ➜  pytorch git:(master) pip install setuptools==59.5.0
Collecting setuptools==59.5.0
  Downloading setuptools-59.5.0-py3-none-any.whl (952 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 952.4/952.4 kB 4.1 MB/s eta 0:00:00
Installing collected packages: setuptools
  Attempting uninstall: setuptools
    Found existing installation: setuptools 61.2.0
    Uninstalling setuptools-61.2.0:
      Successfully uninstalled setuptools-61.2.0
Successfully installed setuptools-59.5.0
(dynamo) ➜  pytorch git:(master) python setup.py develop

Building wheel torch-1.10.0a0+git255a324
-- Building version 1.10.0a0+git255a324
 --- Trying to initialize submodules
Submodule 'android/libs/fbjni' (https://github.com/facebookincubator/fbjni.git) registered for path 'android/libs/fbjni'
Submodule 'third_party/NNPACK_deps/FP16' (https://github.com/Maratyszcza/FP16.git) registered for path 'third_party/FP16'
Submodule 'third_party/NNPACK_deps/FXdiv' (https://github.com/Maratyszcza/FXdiv.git) registered for path 'third_party/FXdiv'
Submodule 'third_party/NNPACK' (https://github.com/Maratyszcza/NNPACK.git) registered for path 'third_party/NNPACK'
Submodule 'third_party/QNNPACK' (https://github.com/pytorch/QNNPACK) registered for path 'third_party/QNNPACK'
Submodule 'third_party/XNNPACK' (https://github.com/google/XNNPACK.git) registered for path 'third_party/XNNPACK'
Submodule 'third_party/benchmark' (https://github.com/google/benchmark.git) registered for path 'third_party/benchmark'
Submodule 'third_party/cpuinfo' (https://github.com/pytorch/cpuinfo.git) registered for path 'third_party/cpuinfo'
Submodule 'third_party/cub' (https://github.com/NVlabs/cub.git) registered for path 'third_party/cub'
Submodule 'third_party/cudnn_frontend' (https://github.com/NVIDIA/cudnn-frontend.git) registered for path 'third_party/cudnn_frontend'
Submodule 'third_party/eigen' (https://github.com/eigenteam/eigen-git-mirror.git) registered for path 'third_party/eigen'
Submodule 'third_party/fbgemm' (https://github.com/pytorch/fbgemm) registered for path 'third_party/fbgemm'
Submodule 'third_party/fmt' (https://github.com/fmtlib/fmt.git) registered for path 'third_party/fmt'
Submodule 'third_party/foxi' (https://github.com/houseroad/foxi.git) registered for path 'third_party/foxi'
Submodule 'third_party/gemmlowp/gemmlowp' (https://github.com/google/gemmlowp.git) registered for path 'third_party/gemmlowp/gemmlowp'
Submodule 'third_party/gloo' (https://github.com/facebookincubator/gloo) registered for path 'third_party/gloo'
Submodule 'third_party/googletest' (https://github.com/google/googletest.git) registered for path 'third_party/googletest'
Submodule 'third_party/ideep' (https://github.com/intel/ideep) registered for path 'third_party/ideep'
Submodule 'third_party/ios-cmake' (https://github.com/Yangqing/ios-cmake.git) registered for path 'third_party/ios-cmake'
Submodule 'third_party/kineto' (https://github.com/pytorch/kineto) registered for path 'third_party/kineto'
Submodule 'third_party/nccl/nccl' (https://github.com/NVIDIA/nccl) registered for path 'third_party/nccl/nccl'
Submodule 'third_party/neon2sse' (https://github.com/intel/ARM_NEON_2_x86_SSE.git) registered for path 'third_party/neon2sse'
Submodule 'third_party/onnx' (https://github.com/onnx/onnx.git) registered for path 'third_party/onnx'
Submodule 'third_party/onnx-tensorrt' (https://github.com/onnx/onnx-tensorrt) registered for path 'third_party/onnx-tensorrt'
Submodule 'third_party/protobuf' (https://github.com/protocolbuffers/protobuf.git) registered for path 'third_party/protobuf'
Submodule 'third_party/NNPACK_deps/psimd' (https://github.com/Maratyszcza/psimd.git) registered for path 'third_party/psimd'
Submodule 'third_party/NNPACK_deps/pthreadpool' (https://github.com/Maratyszcza/pthreadpool.git) registered for path 'third_party/pthreadpool'
Submodule 'third_party/pybind11' (https://github.com/pybind/pybind11.git) registered for path 'third_party/pybind11'
Submodule 'third_party/python-enum' (https://github.com/PeachPy/enum34.git) registered for path 'third_party/python-enum'
Submodule 'third_party/python-peachpy' (https://github.com/Maratyszcza/PeachPy.git) registered for path 'third_party/python-peachpy'
Submodule 'third_party/python-six' (https://github.com/benjaminp/six.git) registered for path 'third_party/python-six'
Submodule 'third_party/sleef' (https://github.com/shibatch/sleef) registered for path 'third_party/sleef'
Submodule 'third_party/tbb' (https://github.com/01org/tbb) registered for path 'third_party/tbb'
Submodule 'third_party/tensorpipe' (https://github.com/pytorch/tensorpipe.git) registered for path 'third_party/tensorpipe'
Submodule 'third_party/zstd' (https://github.com/facebook/zstd.git) registered for path 'third_party/zstd'
Cloning into '/Users/marksaroufim/Dev/pytorch/android/libs/fbjni'...
Cloning into '/Users/marksaroufim/Dev/pytorch/third_party/FP16'...
Cloning into '/Users/marksaroufim/Dev/pytorch/third_party/FXdiv'...
Cloning into '/Users/marksaroufim/Dev/pytorch/third_party/NNPACK'...
```