### PR TITLE
tl.load other=0 to ensure correctness of fp16

### DIFF
--- a/torchinductor/triton_ops/conv.py
+++ b/torchinductor/triton_ops/conv.py
@@ -119,9 +119,9 @@ def _kernel_delta_x_hwc(
     mask_w = (off_x_crs < CRS)[:, None] & (off_w_k < KERNEL_N)[None, :]
 
     # ------ load x ------
-    matrix_x = tl.load(x_ptrs, mask=mask_x)
+    matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
     # ------ load w ------
-    matrix_w = tl.load(w_ptrs, mask=mask_w)
+    matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
 
     # -----------------------------------------------------------
     # allocate accumulator
@@ -138,9 +138,9 @@ def _kernel_delta_x_hwc(
             delta_xh_ptrs += BLOCK_K
             delta_xw_ptrs += BLOCK_K
             delta_xc_ptrs += BLOCK_K
-            delta_xh = tl.load(delta_xh_ptrs, mask=off_x_crs < CRS)
-            delta_xw = tl.load(delta_xw_ptrs, mask=off_x_crs < CRS)
-            delta_xc = tl.load(delta_xc_ptrs, mask=off_x_crs < CRS)
+            delta_xh = tl.load(delta_xh_ptrs, mask=off_x_crs < CRS, other=0)
+            delta_xw = tl.load(delta_xw_ptrs, mask=off_x_crs < CRS, other=0)
+            delta_xc = tl.load(delta_xc_ptrs, mask=off_x_crs < CRS, other=0)
             off_x_crs_unpacked = (
                 delta_xh * stride_xh + delta_xw * stride_xw + delta_xc * stride_xc
             )
@@ -159,9 +159,9 @@ def _kernel_delta_x_hwc(
         mask_w = (off_x_crs < CRS)[:, None] & (off_w_k < KERNEL_N)[None, :]
         # ------ prefetch ------
         # ------ load x ------
-        matrix_x = tl.load(x_ptrs, mask=mask_x)
+        matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
         # ------ load w ------
-        matrix_w = tl.load(w_ptrs, mask=mask_w)
+        matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
 
     acc = acc.to(y.dtype.element_ty)
 
@@ -297,9 +297,9 @@ def _kernel_delta_x(
     mask_w = (off_x_crs < CRS)[:, None] & (off_w_k < KERNEL_N)[None, :]
 
     # ------ load x ------
-    matrix_x = tl.load(x_ptrs, mask=mask_x)
+    matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
     # ------ load w ------
-    matrix_w = tl.load(w_ptrs, mask=mask_w)
+    matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
 
     # -----------------------------------------------------------
     # allocate accumulator
@@ -314,7 +314,7 @@ def _kernel_delta_x(
         if not CONV1X1_NHWC:
             delta_x_ptrs += BLOCK_K
             off_x_crs = crs + BLOCK_K + tl.arange(0, BLOCK_K)
-            off_x_crs_unpacked = tl.load(delta_x_ptrs, mask=off_x_crs < CRS)
+            off_x_crs_unpacked = tl.load(delta_x_ptrs, mask=off_x_crs < CRS, other=0)
             x_ptrs = x + off_x_nhw[:, None] + off_x_crs_unpacked[None, :]
         else:
             off_x_crs = crs + BLOCK_K + tl.arange(0, BLOCK_K)
@@ -330,9 +330,9 @@ def _kernel_delta_x(
         mask_w = (off_x_crs < CRS)[:, None] & (off_w_k < KERNEL_N)[None, :]
         # ------ prefetch ------
         # ------ load x ------
-        matrix_x = tl.load(x_ptrs, mask=mask_x)
+        matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
         # ------ load w ------
-        matrix_w = tl.load(w_ptrs, mask=mask_w)
+        matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
 
     acc = acc.to(y.dtype.element_ty)
 


### PR DESCRIPTION
for masked tl.load(), other=0.0/ 0 to ensure correctness. Otherwise, fp16 will have wrong outputs