### PR TITLE
Push node associated stack trace one level deeper in dynamo->inductor

### DIFF
--- a/torchdynamo/optimizations/normalize.py
+++ b/torchdynamo/optimizations/normalize.py
@@ -388,7 +388,7 @@ class Functionalization(Transformer):
 
 
 def swap_node(graph, old_node, new_node):
-    assert(new_node.stack_trace is None), "New node must not have a "
+    assert new_node.stack_trace is None, "New node must not have a "
     new_node.stack_trace = old_node.stack_trace
     old_node.replace_all_uses_with(new_node)
     graph.erase_node(old_node)

--- a/torchdynamo/optimizations/normalize.py
+++ b/torchdynamo/optimizations/normalize.py
@@ -388,7 +388,7 @@ class Functionalization(Transformer):
 
 
 def swap_node(graph, old_node, new_node):
-    assert new_node.stack_trace is None, "New node must not have a "
+    assert new_node.stack_trace is None, "New node must not have a stack_trace"
     new_node.stack_trace = old_node.stack_trace
     old_node.replace_all_uses_with(new_node)
     graph.erase_node(old_node)

--- a/torchdynamo/optimizations/normalize.py
+++ b/torchdynamo/optimizations/normalize.py
@@ -388,6 +388,8 @@ class Functionalization(Transformer):
 
 
 def swap_node(graph, old_node, new_node):
+    assert(new_node.stack_trace is None), "New node must not have a "
+    new_node.stack_trace = old_node.stack_trace
     old_node.replace_all_uses_with(new_node)
     graph.erase_node(old_node)
 

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -110,7 +110,6 @@ def compile_fx_python_key(
     """Alternate version for inference only"""
     assert isinstance(model, torch.fx.GraphModule)
     assert all(isinstance(x, torch.Tensor) for x in example_inputs)
-
     with overrides.patch_functions():
         model = overrides.replace_fx(model)
         gm, wrap = python_key_normalize(


### PR DESCRIPTION
This sets it up so that the graph going into fx.Transformer has the right stack_trace associations on it, node by node