### PR TITLE
Support torch.jit.annotate

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -3,7 +3,7 @@ import functools
 import inspect
 import itertools
 import operator
-import typing
+from typing import Any
 
 import torch
 from torch import sub
@@ -574,7 +574,7 @@ class FunctionTests(torchdynamo.testing.TestCase):
 
     @make_test
     def test_jit_annotate(x):
-        y = torch.jit.annotate(typing.Any, x + 1)
+        y = torch.jit.annotate(Any, x + 1)
         return y + 2
 
     @requires_static_shapes

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -3,6 +3,7 @@ import functools
 import inspect
 import itertools
 import operator
+import typing
 
 import torch
 from torch import sub
@@ -570,6 +571,11 @@ class FunctionTests(torchdynamo.testing.TestCase):
         y = torch.rand(5, 8)
         z = x.new(y.shape)
         assert z.size() == y.size()
+
+    @make_test
+    def test_jit_annotate(x):
+        y = torch.jit.annotate(typing.Any, x + 1)
+        return y + 2
 
     # # This is to test the new syntax for pattern matching
     # # ("match ... case ...") added on python 3.10.

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -577,6 +577,14 @@ class FunctionTests(torchdynamo.testing.TestCase):
         y = torch.jit.annotate(typing.Any, x + 1)
         return y + 2
 
+    @requires_static_shapes
+    @make_test
+    def test_is_contiguous_memory_format(tensor):
+        if torch.jit.is_scripting():
+            return None
+        elif tensor.is_contiguous(memory_format=torch.contiguous_format):
+            return tensor + 1
+
     # # This is to test the new syntax for pattern matching
     # # ("match ... case ...") added on python 3.10.
     # # Uncomment these test cases if you run on 3.10+

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -75,11 +75,12 @@ class TorchVariable(VariableTracker):
 
     def can_constant_fold_through(self):
         if self.value in (
+            torch._assert,
             torch.device,
             torch.finfo,
             torch.iinfo,
-            torch.is_tensor,
             torch.is_floating_point,
+            torch.is_tensor,
             torch.overrides.is_tensor_like,
         ):
             return True
@@ -195,6 +196,9 @@ class TorchVariable(VariableTracker):
         elif self.value is torch.autograd.profiler.record_function:
             assert len(args) == 1
             return ProfileRecordFunctionVariable(str(args[0].as_proxy()), **options)
+        elif self.value is torch.jit.annotate:
+            assert len(args) == 2
+            return args[1]
         else:
             tensor_variable = TensorVariable.create(
                 tx=tx,


### PR DESCRIPTION
Fixes this in some timm models:
```
  File "/home/jansel/torchdynamo/torchdynamo/variables/torch.py", line 203, in call_function
    proxy=tx.output.create_proxy(
  File "/home/jansel/torchdynamo/torchdynamo/output_graph.py", line 448, in create_proxy
    rv = super().create_proxy(
  File "/home/jansel/pytorch/torch/fx/proxy.py", line 65, in create_proxy
    args_ = self.create_arg(args)
  File "/home/jansel/pytorch/torch/fx/_symbolic_trace.py", line 342, in create_arg
    return super().create_arg(a)
  File "/home/jansel/pytorch/torch/fx/proxy.py", line 127, in create_arg
    return type(a)(self.create_arg(elem) for elem in a)
  File "/home/jansel/pytorch/torch/fx/proxy.py", line 127, in <genexpr>
    return type(a)(self.create_arg(elem) for elem in a)
  File "/home/jansel/pytorch/torch/fx/_symbolic_trace.py", line 342, in create_arg
    return super().create_arg(a)
  File "/home/jansel/pytorch/torch/fx/proxy.py", line 153, in create_arg
    raise NotImplementedError(f"argument of type: {type(a)}")
NotImplementedError: argument of type: <class 'typing._GenericAlias'>
```