### PR TITLE
Changed partitioner to use inductor-specific compiler

### DIFF
--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -270,8 +270,9 @@ def compile_fx_aot(model_: torch.fx.GraphModule, example_inputs_: List[torch.Ten
             fw_compiler=fw_compiler,
             bw_compiler=bw_compiler,
             decompositions=decompositions,
-            # Note, update this to use compiler kwarg when functorch pin is updated
-            partition_fn=min_cut_rematerialization_partition,
+            partition_fn=functools.partial(
+                min_cut_rematerialization_partition, compiler="inductor"
+            ),
         )
 
 


### PR DESCRIPTION
This commit allowed us to enable inductor-specific ops for rematerialization: https://github.com/pytorch/pytorch/pull/82772 After the pin update, should be able to land this.