### PR TITLE
Autotune framework for conv and mm

### DIFF
--- a/benchmarks/microbenchmarks/bench_mm_fusion.py
+++ b/benchmarks/microbenchmarks/bench_mm_fusion.py
@@ -67,9 +67,9 @@ def bench(shape, layer_id, p, fusion_types=[""]):
         def fn():
             return fn_mm(*args)
 
-        torchinductor.config.triton.use_mm = False
+        torchinductor.config.triton.mm = "aten"
         torch_mm_ms, _, _ = triton.testing.do_bench(fn)
-        torchinductor.config.triton.use_mm = True
+        torchinductor.config.triton.mm = "triton"
         # reset to force code gen new python code
         torchdynamo.reset()
         torchinductor.metrics.reset()

--- a/benchmarks/microbenchmarks/inductor_mm.py
+++ b/benchmarks/microbenchmarks/inductor_mm.py
@@ -33,20 +33,20 @@ def test_total_time(shapes):
         a = torch.randn(a_shape, device="cuda", dtype=torch.float16)
         b = torch.randn(b_shape, device="cuda", dtype=a.dtype)
 
-        config.triton.use_mm = False
+        config.triton.mm = "aten"
         inductor_aten_mm(a, b)
 
-        config.triton.use_mm = True
+        config.triton.mm = "triton"
         inductor_triton_mm(a, b)
 
         torch_ms = time_with_torch_timer(torch_mm, (a, b)).mean * 1000
 
         triton_ms = time_with_torch_timer(triton_mm, (a, b)).mean * 1000
 
-        config.triton.use_mm = False
+        config.triton.mm = "aten"
         ind_aten_ms = time_with_torch_timer(inductor_aten_mm, (a, b)).mean * 1000
 
-        config.triton.use_mm = True
+        config.triton.mm = "triton"
         ind_triton_ms = time_with_torch_timer(inductor_triton_mm, (a, b)).mean * 1000
 
         print(torch_ms, triton_ms, ind_aten_ms, ind_triton_ms, sep="; ")
@@ -62,10 +62,10 @@ def test_GPU_time(shapes):
         a = torch.randn(a_shape, device="cuda", dtype=torch.float16)
         b = torch.randn(b_shape, device="cuda", dtype=a.dtype)
 
-        config.triton.use_mm = False
+        config.triton.mm = "aten"
         inductor_aten_mm(a, b)
 
-        config.triton.use_mm = True
+        config.triton.mm = "triton"
         inductor_triton_mm(a, b)
 
         torch_ms, _, _ = triton.testing.do_bench(lambda: torch_mm(a, b))

--- a/benchmarks/microbenchmarks/matmul_relu.py
+++ b/benchmarks/microbenchmarks/matmul_relu.py
@@ -4,7 +4,7 @@ from benchmark_helper import time_with_torch_timer
 import torchdynamo
 import torchinductor.config as inductor_config
 
-inductor_config.triton.use_mm = True
+inductor_config.triton.mm = "triton"
 
 
 @torchdynamo.optimize("inductor", nopython=True)

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -16,25 +16,25 @@ import torchdynamo
 from torchdynamo.testing import rand_strided
 from torchdynamo.testing import same
 
-try:
-    import sympy
+# try:
+import sympy
 
-    importlib.import_module("functorch")
+importlib.import_module("functorch")
 
-    from torch._decomp import get_decompositions
+from torch._decomp import get_decompositions
 
-    import torchinductor.config
-    from torchinductor import config
-    from torchinductor.compile_fx import compile_fx
-    from torchinductor.ir import IndexingDiv
-    from torchinductor.ir import ModularIndexing
-    from torchinductor.sizevars import SizeVarAllocator
-    from torchinductor.utils import has_torchvision_roi_align
+import torchinductor.config
+from torchinductor import config
+from torchinductor.compile_fx import compile_fx
+from torchinductor.ir import IndexingDiv
+from torchinductor.ir import ModularIndexing
+from torchinductor.sizevars import SizeVarAllocator
+from torchinductor.utils import has_torchvision_roi_align
 
-    # This will only pass on pytorch builds newer than roughly 5/15/2022
-    assert get_decompositions([torch.ops.aten.trace])
-except (ImportError, ModuleNotFoundError, AssertionError):
-    raise unittest.SkipTest("requires sympy/functorch")
+# This will only pass on pytorch builds newer than roughly 5/15/2022
+assert get_decompositions([torch.ops.aten.trace])
+# except (ImportError, ModuleNotFoundError, AssertionError):
+#     raise unittest.SkipTest("requires sympy/functorch")
 
 
 HAS_CPU = False

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -1321,7 +1321,7 @@ class CommonTemplate:
         y_correct = torch.conv2d(x, w, bias, stride, padding, dilation, groups)
         self.assertTrue(same(y, y_correct, cos_similarity=True, tol=0.1))
 
-    @patch.object(config.triton, "use_mm", True)
+    @patch.object(config.triton, "mm", "triton")
     def test_triton_mm2(self):
         @torchdynamo.optimize("inductor", nopython=True)
         def fn(x, y):
@@ -2492,8 +2492,10 @@ class CommonTemplate:
         )
         expected_kernel = 0
         # codegen mm kernel from template
-        if config.triton.use_mm and self.device == "cuda":
+        if config.triton.mm != "aten" and self.device == "cuda":
             expected_kernel = 1
+        if config.triton.mm == "autotune":
+            self.assertLessEqual(torchinductor.metrics.generated_kernel_count, expected_kernel)
         self.assertEqual(torchinductor.metrics.generated_kernel_count, expected_kernel)
 
     @patch.object(config.triton, "cudagraphs", False)
@@ -2567,11 +2569,13 @@ class CommonTemplate:
         result.sum().backward()
 
         expected_kernel = 4
-        if config.triton.use_mm and self.device == "cuda":
+        if config.triton.mm != "aten" and self.device == "cuda":
             # fwd: 2 * (mm+dropout) kernels = 2 kernels
             # bwd: dropout + (mm) + 2 * (mm+dropout) kernels = 4 kernels
             # expect 2 + 4 = 6 kernels
             expected_kernel = 6
+        if config.triton.mm == "autotune":
+            self.assertLessEqual(torchinductor.metrics.generated_kernel_count, expected_kernel)
         self.assertEqual(torchinductor.metrics.generated_kernel_count, expected_kernel)
 
 

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -16,25 +16,25 @@ import torchdynamo
 from torchdynamo.testing import rand_strided
 from torchdynamo.testing import same
 
-# try:
-import sympy
+try:
+    import sympy
 
-importlib.import_module("functorch")
+    importlib.import_module("functorch")
 
-from torch._decomp import get_decompositions
+    from torch._decomp import get_decompositions
 
-import torchinductor.config
-from torchinductor import config
-from torchinductor.compile_fx import compile_fx
-from torchinductor.ir import IndexingDiv
-from torchinductor.ir import ModularIndexing
-from torchinductor.sizevars import SizeVarAllocator
-from torchinductor.utils import has_torchvision_roi_align
+    import torchinductor.config
+    from torchinductor import config
+    from torchinductor.compile_fx import compile_fx
+    from torchinductor.ir import IndexingDiv
+    from torchinductor.ir import ModularIndexing
+    from torchinductor.sizevars import SizeVarAllocator
+    from torchinductor.utils import has_torchvision_roi_align
 
-# This will only pass on pytorch builds newer than roughly 5/15/2022
-assert get_decompositions([torch.ops.aten.trace])
-# except (ImportError, ModuleNotFoundError, AssertionError):
-#     raise unittest.SkipTest("requires sympy/functorch")
+    # This will only pass on pytorch builds newer than roughly 5/15/2022
+    assert get_decompositions([torch.ops.aten.trace])
+except (ImportError, ModuleNotFoundError, AssertionError):
+    raise unittest.SkipTest("requires sympy/functorch")
 
 
 HAS_CPU = False

--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -2495,7 +2495,9 @@ class CommonTemplate:
         if config.triton.mm != "aten" and self.device == "cuda":
             expected_kernel = 1
         if config.triton.mm == "autotune":
-            self.assertLessEqual(torchinductor.metrics.generated_kernel_count, expected_kernel)
+            self.assertLessEqual(
+                torchinductor.metrics.generated_kernel_count, expected_kernel
+            )
         self.assertEqual(torchinductor.metrics.generated_kernel_count, expected_kernel)
 
     @patch.object(config.triton, "cudagraphs", False)
@@ -2575,7 +2577,9 @@ class CommonTemplate:
             # expect 2 + 4 = 6 kernels
             expected_kernel = 6
         if config.triton.mm == "autotune":
-            self.assertLessEqual(torchinductor.metrics.generated_kernel_count, expected_kernel)
+            self.assertLessEqual(
+                torchinductor.metrics.generated_kernel_count, expected_kernel
+            )
         self.assertEqual(torchinductor.metrics.generated_kernel_count, expected_kernel)
 
 

--- a/torchinductor/codegen/autotuner.py
+++ b/torchinductor/codegen/autotuner.py
@@ -207,9 +207,9 @@ def tuned_mm(
         # bench_end = time.time()
         # bench_time = bench_end - bench_start
         autotune.cache[key] = builtins.min(timings, key=timings.get)
-        # if torchinductor.config.debug:
-        print("for key = ", key)
-        print("timing", timings)
-        print("best_kernel", autotune.cache[key])
+        if torchinductor.config.debug:
+            print("for key = ", key)
+            print("timing", timings)
+            print("best_kernel", autotune.cache[key])
     best_kernel = autotune.cache[key]
     return best_kernel

--- a/torchinductor/codegen/autotuner.py
+++ b/torchinductor/codegen/autotuner.py
@@ -6,9 +6,9 @@ import triton
 import torchinductor
 import torchinductor.triton_ops
 from torchdynamo.testing import rand_strided
+
 from ..triton_ops.autotune import mm_autotune
 from ..triton_ops.autotune import mm_heuristics
-
 from ..virtualized import V
 
 aten = torch.ops.aten
@@ -191,7 +191,9 @@ def tuned_mm(
             if "triton_ops" in kernel:
                 run_args = (a, b, c)
                 run_kwargs = {}
-                inner_kernel = str2func(kernel.replace("matmul_out", "_matmul_out")+".kernel")
+                inner_kernel = str2func(
+                    kernel.replace("matmul_out", "_matmul_out") + ".kernel"
+                )
                 inner_kernel.kernel_decorators = []
                 # fix SPLIT_K = 1 for fusable kernels
                 mm_heuristics()(mm_autotune(get_io_bound_configs=False)(inner_kernel))

--- a/torchinductor/codegen/autotuner.py
+++ b/torchinductor/codegen/autotuner.py
@@ -38,7 +38,7 @@ class Autotuner:
         def kernel_call():
             kernel(*args, **kwargs)
 
-        return triton.testing.do_bench(kernel_call, warmup=10, rep=50)
+        return triton.testing.do_bench(kernel_call)
 
 
 autotune = Autotuner()
@@ -207,9 +207,9 @@ def tuned_mm(
         # bench_end = time.time()
         # bench_time = bench_end - bench_start
         autotune.cache[key] = builtins.min(timings, key=timings.get)
-        if torchinductor.config.debug:
-            print("for key = ", key)
-            print("timing", timings)
-            print("best_kernel", autotune.cache[key])
+        # if torchinductor.config.debug:
+        print("for key = ", key)
+        print("timing", timings)
+        print("best_kernel", autotune.cache[key])
     best_kernel = autotune.cache[key]
     return best_kernel

--- a/torchinductor/codegen/autotuner.py
+++ b/torchinductor/codegen/autotuner.py
@@ -6,6 +6,8 @@ import triton
 import torchinductor
 import torchinductor.triton_ops
 from torchdynamo.testing import rand_strided
+from ..triton_ops.autotune import mm_autotune
+from ..triton_ops.autotune import mm_heuristics
 
 from ..virtualized import V
 
@@ -189,6 +191,10 @@ def tuned_mm(
             if "triton_ops" in kernel:
                 run_args = (a, b, c)
                 run_kwargs = {}
+                inner_kernel = str2func(kernel.replace("matmul_out", "_matmul_out")+".kernel")
+                inner_kernel.kernel_decorators = []
+                # fix SPLIT_K = 1 for fusable kernels
+                mm_heuristics()(mm_autotune(get_io_bound_configs=False)(inner_kernel))
             else:
                 run_args = (a, b)
                 run_kwargs = {"out": c}
@@ -199,9 +205,9 @@ def tuned_mm(
         # bench_end = time.time()
         # bench_time = bench_end - bench_start
         autotune.cache[key] = builtins.min(timings, key=timings.get)
-        # if torchinductor.config.debug:
-        print("for key = ", key)
-        print("timing", timings)
-        print("best_kernel", autotune.cache[key])
+        if torchinductor.config.debug:
+            print("for key = ", key)
+            print("timing", timings)
+            print("best_kernel", autotune.cache[key])
     best_kernel = autotune.cache[key]
     return best_kernel

--- a/torchinductor/codegen/triton_conv_delta_x.j2
+++ b/torchinductor/codegen/triton_conv_delta_x.j2
@@ -1,11 +1,3 @@
-import torch
-import triton
-import triton.language as tl
-
-from torchinductor.triton_ops.conv_perf_model import early_config_prune
-from torchinductor.triton_ops.conv_perf_model import estimate_conv_time
-from torchinductor.triton_ops.autotune import conv_heuristics
-
 @conv_heuristics()
 @triton.jit
 def {{kernel_name}}(

--- a/torchinductor/codegen/triton_conv_delta_x.j2
+++ b/torchinductor/codegen/triton_conv_delta_x.j2
@@ -80,7 +80,7 @@ def {{kernel_name}}(
     # load inc ptr of x, upade x_ptrs
     if not CONV1X1_NHWC:
         delta_x_ptrs = delta_x_ptr + off_x_crs
-        off_x_crs_unpacked = tl.load(delta_x_ptrs, mask=off_x_crs < CRS)
+        off_x_crs_unpacked = tl.load(delta_x_ptrs, mask=off_x_crs < CRS, other=0)
         x_ptrs = x + off_x_nhw[:, None] + off_x_crs_unpacked[None, :]
     else:
         x_ptrs = x + off_x_nhw[:, None] + off_x_crs[None, :]
@@ -100,9 +100,9 @@ def {{kernel_name}}(
     mask_w = (off_x_crs < CRS)[:, None] & (off_w_k < KERNEL_N)[None, :]
 
     # ------ load x ------
-    matrix_x = tl.load(x_ptrs, mask=mask_x)
+    matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
     # ------ load w ------
-    matrix_w = tl.load(w_ptrs, mask=mask_w)
+    matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
 
     # -----------------------------------------------------------
     # allocate accumulator
@@ -117,7 +117,7 @@ def {{kernel_name}}(
         if not CONV1X1_NHWC:
             delta_x_ptrs += BLOCK_K
             off_x_crs = crs + BLOCK_K + tl.arange(0, BLOCK_K)
-            off_x_crs_unpacked = tl.load(delta_x_ptrs, mask=off_x_crs < CRS)
+            off_x_crs_unpacked = tl.load(delta_x_ptrs, mask=off_x_crs < CRS, other=0)
             x_ptrs = x + off_x_nhw[:, None] + off_x_crs_unpacked[None, :]
         else:
             off_x_crs = crs + BLOCK_K + tl.arange(0, BLOCK_K)
@@ -133,9 +133,9 @@ def {{kernel_name}}(
         mask_w = (off_x_crs < CRS)[:, None] & (off_w_k < KERNEL_N)[None, :]
         # ------ prefetch ------
         # ------ load x ------
-        matrix_x = tl.load(x_ptrs, mask=mask_x)
+        matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
         # ------ load w ------
-        matrix_w = tl.load(w_ptrs, mask=mask_w)
+        matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
 
     acc = acc.to({{out_def}}.dtype.element_ty)
 

--- a/torchinductor/codegen/triton_conv_delta_x_hwc.j2
+++ b/torchinductor/codegen/triton_conv_delta_x_hwc.j2
@@ -1,11 +1,3 @@
-import torch
-import triton
-import triton.language as tl
-
-from torchinductor.triton_ops.conv_perf_model import early_config_prune
-from torchinductor.triton_ops.conv_perf_model import estimate_conv_time
-from torchinductor.triton_ops.autotune import conv_heuristics
-
 @conv_heuristics()
 @triton.jit
 def {{kernel_name}}(

--- a/torchinductor/codegen/triton_conv_delta_x_hwc.j2
+++ b/torchinductor/codegen/triton_conv_delta_x_hwc.j2
@@ -84,9 +84,9 @@ def {{kernel_name}}(
         delta_xh_ptrs = delta_xh_ptr + off_x_crs
         delta_xw_ptrs = delta_xw_ptr + off_x_crs
         delta_xc_ptrs = delta_xc_ptr + off_x_crs
-        delta_xh = tl.load(delta_xh_ptrs, mask=off_x_crs < CRS)
-        delta_xw = tl.load(delta_xw_ptrs, mask=off_x_crs < CRS)
-        delta_xc = tl.load(delta_xc_ptrs, mask=off_x_crs < CRS)
+        delta_xh = tl.load(delta_xh_ptrs, mask=off_x_crs < CRS, other=0)
+        delta_xw = tl.load(delta_xw_ptrs, mask=off_x_crs < CRS, other=0)
+        delta_xc = tl.load(delta_xc_ptrs, mask=off_x_crs < CRS, other=0)
         off_x_crs_unpacked = (
             delta_xh * stride_xh + delta_xw * stride_xw + delta_xc * stride_xc
         )
@@ -112,9 +112,9 @@ def {{kernel_name}}(
     mask_w = (off_x_crs < CRS)[:, None] & (off_w_k < KERNEL_N)[None, :]
 
     # ------ load x ------
-    matrix_x = tl.load(x_ptrs, mask=mask_x)
+    matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
     # ------ load w ------
-    matrix_w = tl.load(w_ptrs, mask=mask_w)
+    matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
 
     # -----------------------------------------------------------
     # allocate accumulator
@@ -131,9 +131,9 @@ def {{kernel_name}}(
             delta_xh_ptrs += BLOCK_K
             delta_xw_ptrs += BLOCK_K
             delta_xc_ptrs += BLOCK_K
-            delta_xh = tl.load(delta_xh_ptrs, mask=off_x_crs < CRS)
-            delta_xw = tl.load(delta_xw_ptrs, mask=off_x_crs < CRS)
-            delta_xc = tl.load(delta_xc_ptrs, mask=off_x_crs < CRS)
+            delta_xh = tl.load(delta_xh_ptrs, mask=off_x_crs < CRS, other=0)
+            delta_xw = tl.load(delta_xw_ptrs, mask=off_x_crs < CRS, other=0)
+            delta_xc = tl.load(delta_xc_ptrs, mask=off_x_crs < CRS, other=0)
             off_x_crs_unpacked = (
                 delta_xh * stride_xh + delta_xw * stride_xw + delta_xc * stride_xc
             )
@@ -152,9 +152,9 @@ def {{kernel_name}}(
         mask_w = (off_x_crs < CRS)[:, None] & (off_w_k < KERNEL_N)[None, :]
         # ------ prefetch ------
         # ------ load x ------
-        matrix_x = tl.load(x_ptrs, mask=mask_x)
+        matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
         # ------ load w ------
-        matrix_w = tl.load(w_ptrs, mask=mask_w)
+        matrix_w = tl.load(w_ptrs, mask=mask_w, other=0.0)
 
     acc = acc.to({{out_def}}.dtype.element_ty)
 

--- a/torchinductor/codegen/triton_mm.j2
+++ b/torchinductor/codegen/triton_mm.j2
@@ -2,47 +2,9 @@ import torch
 import triton
 import triton.language as tl
 {# from triton.ops.matmul import get_configs_io_bound #}
-from triton.ops.matmul_perf_model import early_config_prune
-from torchinductor.triton_ops.mm_perf_model import estimate_matmul_time
 
-
-@triton.heuristics(
-    {
-        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0,
-    }
-)
-@triton.autotune(
-    configs=[
-        # basic configs for compute-bound matmuls
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=3,num_warps=8,),
-        triton.Config({"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=3,num_warps=8,),
-        triton.Config({"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=5,num_warps=2,),
-        # good for int8
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},num_stages=3,num_warps=8,),
-        triton.Config({"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},num_stages=3,num_warps=8,),
-        triton.Config({"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 128, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},num_stages=5,num_warps=2,),
-    ],
-    # Do not allow SPLIT_K > 1, otherwise, the fusable add-pointwise kernels will be added multiple times
-    # + get_configs_io_bound(),
-    key=["M", "N", "K"],
-    prune_configs_by={
-        "early_config_prune": early_config_prune,
-        "perf_model": estimate_matmul_time,
-        "top_k": 10,
-    },
-)
+@mm_heuristics()
+@mm_autotune()
 @triton.jit
 def {{kernel_name}}(
     {% for i in template_inout_argdefs %}

--- a/torchinductor/codegen/triton_template.py
+++ b/torchinductor/codegen/triton_template.py
@@ -122,9 +122,7 @@ class TritonTemplateKernel(TritonKernel):
         render_dict["pointwise_code"] = self.pointwise_code.getvalue() if fuse else None
         render_dict["keep_store"] = not could_remove_kernel_buf
         render_dict["out_def"] = (
-            self.out_def()
-            if not could_remove_kernel_buf
-            else kernel_buf_replace_def
+            self.out_def() if not could_remove_kernel_buf else kernel_buf_replace_def
         )
         self.body = self.template.render(render_dict) + "\n"
 

--- a/torchinductor/codegen/triton_template.py
+++ b/torchinductor/codegen/triton_template.py
@@ -123,7 +123,7 @@ class TritonTemplateKernel(TritonKernel):
         render_dict["keep_store"] = not could_remove_kernel_buf
         render_dict["out_def"] = (
             self.out_def()
-            if kernel_buf_replace_name is None
+            if not could_remove_kernel_buf
             else kernel_buf_replace_def
         )
         self.body = self.template.render(render_dict) + "\n"

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -208,8 +208,12 @@ class WrapperCodeGen(CodeGen):
                 )
 
             if config.triton.mm != "aten":
-                self.header.writeline(
-                    "from torchinductor.triton_ops.matmul import matmul_out as triton_mm_out"
+                self.header.splice(
+                    #"from torchinductor.triton_ops.matmul import matmul_out as triton_mm_out"
+                    """
+                    from torchinductor.triton_ops.autotune import mm_heuristics
+                    from torchinductor.triton_ops.autotune import mm_autotune
+                    """
                 )
 
             if config.triton.use_bmm:

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -198,7 +198,16 @@ class WrapperCodeGen(CodeGen):
                 """
             )
 
-            if config.triton.use_mm:
+            if config.triton.convolution != "aten":
+                self.header.splice(
+                    """
+                    from torchinductor.triton_ops.conv_perf_model import early_config_prune
+                    from torchinductor.triton_ops.conv_perf_model import estimate_conv_time
+                    from torchinductor.triton_ops.autotune import conv_heuristics
+                    """
+                )
+
+            if config.triton.mm != "aten":
                 self.header.writeline(
                     "from torchinductor.triton_ops.matmul import matmul_out as triton_mm_out"
                 )

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -209,7 +209,6 @@ class WrapperCodeGen(CodeGen):
 
             if config.triton.mm != "aten":
                 self.header.splice(
-                    #"from torchinductor.triton_ops.matmul import matmul_out as triton_mm_out"
                     """
                     from torchinductor.triton_ops.autotune import mm_heuristics
                     from torchinductor.triton_ops.autotune import mm_autotune

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -68,6 +68,9 @@ class triton:
     # choose conv backend, "aten" or "triton" or "autotune"
     convolution = "aten"
 
+    # choose mm backend, "aten" or "triton" or "autotune"
+    mm = "aten"
+
     # Always load full blocks (rather than broadcasting inside the block)
     # Set default as True because otherwise will encouter `map::at` error
     # in triton if loading from 1-dim tensor using 2-dim pointer offset
@@ -83,8 +86,5 @@ class triton:
 
     # use triton.autotune?
     autotune = True
-
-    # enable codegen to use Triton's mm
-    use_mm = False
 
     use_bmm = False

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2526,11 +2526,6 @@ class Convolution(ExternKernelAlloc):
             wrapper.header.writeline(
                 f"import torchinductor.triton_ops.conv as {self.kernel}"
             )
-        # # choose from different conv kernels
-        # elif self.kernel == "tuned_conv":
-        #     wrapper.header.writeline(
-        #         f"from torchinductor.codegen.autotuner import {self.kernel}"
-        #     )
         wrapper.writeline(
             f"{self.get_name()} = {self.kernel}({', '.join(self.codegen_args())})"
         )

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2159,6 +2159,7 @@ class MatrixMultiply(ExternKernelOut):
             kernel = "triton_ops.matmul_out"
         elif config_mm == "autotune":
             from .codegen.autotuner import tuned_mm
+
             kernel = tuned_mm(
                 a.get_size(),
                 b.get_size(),
@@ -2640,6 +2641,7 @@ class Convolution(ExternKernelAlloc):
         else:
             assert config_conv == "autotune"
             from .codegen.autotuner import tuned_conv
+
             # kernel = "tuned_conv"
             kernel = tuned_conv(
                 x.get_size(),

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -20,8 +20,6 @@ from sympy import Integer
 
 from . import config
 from . import dependencies
-from .codegen.autotuner import tuned_conv
-from .codegen.autotuner import tuned_mm
 from .codegen.common import _simplify_loops
 from .codegen.common import index_prevent_reordering
 from .dependencies import extract_read_writes
@@ -2160,6 +2158,7 @@ class MatrixMultiply(ExternKernelOut):
         elif config_mm == "triton" and a.get_device().type == "cuda":
             kernel = "triton_ops.matmul_out"
         elif config_mm == "autotune":
+            from .codegen.autotuner import tuned_mm
             kernel = tuned_mm(
                 a.get_size(),
                 b.get_size(),
@@ -2640,6 +2639,7 @@ class Convolution(ExternKernelAlloc):
             kernel = "triton_ops.conv"
         else:
             assert config_conv == "autotune"
+            from .codegen.autotuner import tuned_conv
             # kernel = "tuned_conv"
             kernel = tuned_conv(
                 x.get_size(),

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2632,8 +2632,8 @@ class Convolution(ExternKernelAlloc):
             or not is_triton(x.get_device())
             or transposed
             or groups != 1
-            or x.get_dtype() == torch.float16
-            or x.get_dtype() == torch.bfloat16
+            # or x.get_dtype() == torch.float16
+            # or x.get_dtype() == torch.bfloat16
         ):
             kernel = "aten.convolution"
         elif config_conv == "triton":

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -38,7 +38,7 @@ def should_use_template(node: ir.ExternKernel):
         if isinstance(node, ir.Convolution):
             return node.kernel != "aten.convolution"
         elif isinstance(node, ir.MatrixMultiply):
-            return config.triton.use_mm
+            return node.kernel != "aten.mm.out"
     return False
 
 

--- a/torchinductor/triton_ops/__init__.py
+++ b/torchinductor/triton_ops/__init__.py
@@ -2,5 +2,6 @@ from .conv import _conv
 from .conv import conv
 from .conv1x1 import _conv1x1
 from .conv1x1 import conv1x1
+from .matmul import matmul_out
 
-__all__ = ["_conv", "conv", "_conv1x1", "conv1x1"]
+__all__ = ["_conv", "conv", "_conv1x1", "conv1x1", "matmul_out"]

--- a/torchinductor/triton_ops/__init__.py
+++ b/torchinductor/triton_ops/__init__.py
@@ -2,6 +2,7 @@ from .conv import _conv
 from .conv import conv
 from .conv1x1 import _conv1x1
 from .conv1x1 import conv1x1
+from .matmul import _matmul_out
 from .matmul import matmul_out
 
-__all__ = ["_conv", "conv", "_conv1x1", "conv1x1", "matmul_out"]
+__all__ = ["_conv", "conv", "_conv1x1", "conv1x1", "_matmul_out", "matmul_out"]

--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -5,6 +5,7 @@ from triton import Config
 from triton import cdiv
 from triton import heuristics
 from triton import next_power_of_2
+from triton.ops.matmul import get_configs_io_bound
 from triton.ops.matmul_perf_model import early_config_prune as mm_early_config_prune
 
 from torchinductor import config
@@ -332,7 +333,7 @@ def mm_heuristics():
     return mm_heuristic
 
 
-def mm_autotune():
+def mm_autotune(get_io_bound_configs=False):
     configs = [
         # basic configs for compute-bound matmuls
         triton.Config(
@@ -427,8 +428,8 @@ def mm_autotune():
             num_warps=2,
         ),
     ]
-    # Do not allow SPLIT_K > 1, otherwise, the fusable add-pointwise kernels will be added multiple times
-    # + get_configs_io_bound(),
+    if get_io_bound_configs:
+        configs += get_configs_io_bound()
     key = ["M", "N", "K"]
     prune_configs_by = {
         "early_config_prune": mm_early_config_prune,

--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -5,14 +5,14 @@ from triton import Config
 from triton import cdiv
 from triton import heuristics
 from triton import next_power_of_2
+from triton.ops.matmul_perf_model import early_config_prune as mm_early_config_prune
 
 from torchinductor import config
+from torchinductor.triton_ops.mm_perf_model import estimate_matmul_time
 from torchinductor.utils import conditional_product
 
 from .conv_perf_model import early_config_prune as conv_early_config_prune
 from .conv_perf_model import estimate_conv_time
-from triton.ops.matmul_perf_model import early_config_prune as mm_early_config_prune
-from torchinductor.triton_ops.mm_perf_model import estimate_matmul_time
 
 log = logging.getLogger(__name__)
 
@@ -333,37 +333,110 @@ def mm_heuristics():
 
 
 def mm_autotune():
-    configs=[
+    configs = [
         # basic configs for compute-bound matmuls
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=3,num_warps=8,),
-        triton.Config({"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=3,num_warps=8,),
-        triton.Config({"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},num_stages=5,num_warps=2,),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=5,
+            num_warps=2,
+        ),
         # good for int8
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},num_stages=3,num_warps=8,),
-        triton.Config({"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},num_stages=3,num_warps=8,),
-        triton.Config({"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 128, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},num_stages=4,num_warps=4,),
-        triton.Config({"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},num_stages=5,num_warps=2,),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=5,
+            num_warps=2,
+        ),
     ]
     # Do not allow SPLIT_K > 1, otherwise, the fusable add-pointwise kernels will be added multiple times
     # + get_configs_io_bound(),
-    key=["M", "N", "K"]
-    prune_configs_by={
+    key = ["M", "N", "K"]
+    prune_configs_by = {
         "early_config_prune": mm_early_config_prune,
         "perf_model": estimate_matmul_time,
         "top_k": 10,
     }
     return autotune(configs, key, prune_configs_by=prune_configs_by)
+
 
 def grid(xnumel, ynumel=None, znumel=None):
     """Helper function to compute triton grids"""

--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -288,9 +288,9 @@ def conv_heuristics():
         triton.Config(
             {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 64}, num_stages=4, num_warps=2
         ),
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 16, "BLOCK_K": 64}, num_stages=4, num_warps=2
-        ),
+        # triton.Config(
+        #     {"BLOCK_M": 128, "BLOCK_N": 16, "BLOCK_K": 64}, num_stages=4, num_warps=2
+        # ),
     ]
     key = [
         "BATCH",

--- a/torchinductor/triton_ops/conv.py
+++ b/torchinductor/triton_ops/conv.py
@@ -91,9 +91,9 @@ def _kernel_delta_x_hwc(
         delta_xh_ptrs = delta_xh_ptr + off_x_crs
         delta_xw_ptrs = delta_xw_ptr + off_x_crs
         delta_xc_ptrs = delta_xc_ptr + off_x_crs
-        delta_xh = tl.load(delta_xh_ptrs, mask=off_x_crs < CRS)
-        delta_xw = tl.load(delta_xw_ptrs, mask=off_x_crs < CRS)
-        delta_xc = tl.load(delta_xc_ptrs, mask=off_x_crs < CRS)
+        delta_xh = tl.load(delta_xh_ptrs, mask=off_x_crs < CRS, other=0)
+        delta_xw = tl.load(delta_xw_ptrs, mask=off_x_crs < CRS, other=0)
+        delta_xc = tl.load(delta_xc_ptrs, mask=off_x_crs < CRS, other=0)
         off_x_crs_unpacked = (
             delta_xh * stride_xh + delta_xw * stride_xw + delta_xc * stride_xc
         )

--- a/torchinductor/triton_ops/matmul.py
+++ b/torchinductor/triton_ops/matmul.py
@@ -1,119 +1,11 @@
 import torch
 import triton
 import triton.language as tl
-from triton.ops.matmul import get_configs_io_bound
-from triton.ops.matmul_perf_model import early_config_prune
-from triton.ops.matmul_perf_model import estimate_matmul_time
+from .autotune import mm_autotune
+from .autotune import mm_heuristics
 
-
-@triton.heuristics(
-    {
-        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0,
-    }
-)
-@triton.autotune(
-    configs=[
-        # basic configs for compute-bound matmuls
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
-            num_stages=3,
-            num_warps=8,
-        ),
-        triton.Config(
-            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
-            num_stages=3,
-            num_warps=8,
-        ),
-        triton.Config(
-            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
-            num_stages=5,
-            num_warps=2,
-        ),
-        # good for int8
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},
-            num_stages=3,
-            num_warps=8,
-        ),
-        triton.Config(
-            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
-            num_stages=3,
-            num_warps=8,
-        ),
-        triton.Config(
-            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 128, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
-            num_stages=4,
-            num_warps=4,
-        ),
-        triton.Config(
-            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
-            num_stages=5,
-            num_warps=2,
-        ),
-    ]
-    + get_configs_io_bound(),
-    key=["M", "N", "K"],
-    prune_configs_by={
-        "early_config_prune": early_config_prune,
-        "perf_model": estimate_matmul_time,
-        "top_k": 10,
-    },
-)
+@mm_heuristics()
+@mm_autotune(get_io_bound_configs=True)
 @triton.jit
 def _kernel(
     A,
@@ -180,49 +72,60 @@ def _kernel(
         tl.atomic_add(C, acc, mask=mask)
 
 
-def matmul_out(a, b, out):
-    # handle non-contiguous inputs if necessary
-    if a.stride(0) > 1 and a.stride(1) > 1:
-        a = a.contiguous()
-    if b.stride(0) > 1 and b.stride(1) > 1:
-        b = b.contiguous()
-    # checks constraints
-    assert a.shape[1] == b.shape[0], "incompatible dimensions"
-    M, K = a.shape
-    _, N = b.shape
-    # allocates output
-    c = out
-    # accumulator types
-    ACC_TYPE = (
-        tl.float32
-        if a.dtype in [torch.float16, torch.bfloat16, torch.float32]
-        else tl.int32
-    )
+class _matmul_out:
+    kernel = _kernel
 
-    # launch kernel (grid defined as using def instead of lambda to pass `make lint`)
-    def grid(META):
-        return (
-            triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
-            META["SPLIT_K"],
+    @staticmethod
+    def _call(a, b, out):
+        # handle non-contiguous inputs if necessary
+        if a.stride(0) > 1 and a.stride(1) > 1:
+            a = a.contiguous()
+        if b.stride(0) > 1 and b.stride(1) > 1:
+            b = b.contiguous()
+        # checks constraints
+        assert a.shape[1] == b.shape[0], "incompatible dimensions"
+        M, K = a.shape
+        _, N = b.shape
+        # allocates output
+        c = out
+        # accumulator types
+        ACC_TYPE = (
+            tl.float32
+            if a.dtype in [torch.float16, torch.bfloat16, torch.float32]
+            else tl.int32
         )
 
-    # grid = lambda META: (
-    #     triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
-    #     META["SPLIT_K"],
-    # )
-    _kernel[grid](
-        a,
-        b,
-        c,
-        M,
-        N,
-        K,
-        a.stride(0),
-        a.stride(1),
-        b.stride(0),
-        b.stride(1),
-        c.stride(0),
-        c.stride(1),
-        GROUP_M=8,
-        ACC_TYPE=ACC_TYPE,
-    )
+        # launch kernel (grid defined as using def instead of lambda to pass `make lint`)
+        def grid(META):
+            return (
+                triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+                META["SPLIT_K"],
+            )
+
+        # grid = lambda META: (
+        #     triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        #     META["SPLIT_K"],
+        # )
+        _kernel[grid](
+            a,
+            b,
+            c,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            c.stride(0),
+            c.stride(1),
+            GROUP_M=8,
+            ACC_TYPE=ACC_TYPE,
+        )
+
+
+    @staticmethod
+    def forward(a, b, out):
+        return _matmul_out._call(a, b, out)
+
+matmul_out = _matmul_out.forward

--- a/torchinductor/triton_ops/matmul.py
+++ b/torchinductor/triton_ops/matmul.py
@@ -1,8 +1,10 @@
 import torch
 import triton
 import triton.language as tl
+
 from .autotune import mm_autotune
 from .autotune import mm_heuristics
+
 
 @mm_heuristics()
 @mm_autotune(get_io_bound_configs=True)
@@ -123,9 +125,9 @@ class _matmul_out:
             ACC_TYPE=ACC_TYPE,
         )
 
-
     @staticmethod
     def forward(a, b, out):
         return _matmul_out._call(a, b, out)
+
 
 matmul_out = _matmul_out.forward

--- a/torchinductor/triton_ops/tests/test_mm_fusion.py
+++ b/torchinductor/triton_ops/tests/test_mm_fusion.py
@@ -47,14 +47,14 @@ def test(shape, fusion_type="add"):
     else:
         mm_fusion = getattr(Func, f"mm_{fusion_type}")
     # torchinductor from template
-    torchinductor.config.triton.use_mm = True
+    torchinductor.config.triton.mm = "triton"
     torchinductor.metrics.reset()
     y = mm_fusion(a, b, bias)
     assert torchinductor.metrics.generated_kernel_count == 1, f"codegen #kernel != 1"
     # baseline
     # reset to force code gen new python code
     torchdynamo.reset()
-    torchinductor.config.triton.use_mm = False
+    torchinductor.config.triton.mm = "aten"
     y_correct = mm_fusion(a, b, bias)
     assert(same(y, y_correct, cos_similarity=True))
 


### PR DESCRIPTION
Similar to #364 
But decide best kernels at compile time because fusion is done at runtime. Use `triton.testing.do_bench` to benchmarking on given input shapes/ layer parameters and choose the best kernels with smallest execution time.