### PR TITLE
make precision args float16/float32/amp mutually exclusive

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -973,8 +973,6 @@ def parse_args():
         help="dump raw timing metrics from speedup experiment",
     )
 
-    parser.add_argument("--float16", action="store_true", help="cast model to fp16")
-    parser.add_argument("--float32", action="store_true", help="cast model to fp32")
     parser.add_argument(
         "--channels-last",
         action="store_true",
@@ -984,9 +982,6 @@ def parse_args():
     parser.add_argument("--batch_size", type=int, help="batch size for benchmarking")
     parser.add_argument(
         "--batch_size_file", type=str, help="String to load batch size from"
-    )
-    parser.add_argument(
-        "--amp", action="store_true", help="use automatic mixed precision"
     )
     parser.add_argument("--cosine", action="store_true", help="use cosine similarity")
     parser.add_argument(
@@ -1046,6 +1041,13 @@ def parse_args():
         help="exports trace of kineto profiler",
     )
     parser.add_argument("--profiler_trace_name", help="Overwrites exported trace name")
+
+    group_prec = parser.add_mutually_exclusive_group()
+    group_prec.add_argument("--float16", action="store_true", help="cast model to fp16")
+    group_prec.add_argument("--float32", action="store_true", help="cast model to fp32")
+    group_prec.add_argument(
+        "--amp", action="store_true", help="use automatic mixed precision"
+    )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--coverage", action="store_true", help="(default) " + help(coverage_experiment)


### PR DESCRIPTION
I made a mistake of specifying --float16 with --amp and it didn't produce expected results, so to prevent these mistakes from happening in future, I move precision args to mutually exclusive group. 