### PR TITLE
Associate fx node as origins on IRNode, ensure all nodes going to scheduling have an associate FX Node

### DIFF
--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -269,19 +269,16 @@ class GraphLowering(torch.fx.Interpreter):
             buf.decide_layout()
 
     def run_node(self, n: torch.fx.Node):
-        lowering.current_origin = n
-        result = super().run_node(n)
-        num_users = len(set(n.users))
-        if num_users > 1 and isinstance(result, TensorBox):
-            for user in n.users:
-                if user.target in needs_realized_inputs or user.op == "output":
-                    result.associate_origin(n)
-                    result.realize_hint()
+        with ir.IRNode.current_origins({n}):
+            result = super().run_node(n)
+            num_users = len(set(n.users))
+            if num_users > 1 and isinstance(result, TensorBox):
+                for user in n.users:
+                    if user.target in needs_realized_inputs or user.op == "output":
+                        result.realize_hint()
 
-            # TODO(jansel): introduce a store vs inline choice
-            result.mark_reuse(len(n.users))
-
-        lowering.current_origin = None
+                # TODO(jansel): introduce a store vs inline choice
+                result.mark_reuse(len(n.users))
         return result
 
     def codegen(self):

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -22,6 +22,7 @@ from .lowering import lowerings
 from .lowering import make_fallback
 from .lowering import needs_realized_inputs
 from .sizevars import SizeVarAllocator
+from torchinductor import lowering
 
 log = logging.getLogger(__name__)
 
@@ -267,6 +268,7 @@ class GraphLowering(torch.fx.Interpreter):
             buf.decide_layout()
 
     def run_node(self, n: torch.fx.Node):
+        lowering.current_origin = n
         result = super().run_node(n)
         num_users = len(set(n.users))
         if num_users > 1 and isinstance(result, TensorBox):
@@ -276,6 +278,8 @@ class GraphLowering(torch.fx.Interpreter):
 
             # TODO(jansel): introduce a store vs inline choice
             result.mark_reuse(len(n.users))
+
+        lowering.current_origin = None
         return result
 
     def codegen(self):

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -274,11 +274,12 @@ class GraphLowering(torch.fx.Interpreter):
         if num_users > 1 and isinstance(result, TensorBox):
             for user in n.users:
                 if user.target in needs_realized_inputs or user.op == "output":
+                    result.associate_origin(n)
                     result.realize_hint()
 
             # TODO(jansel): introduce a store vs inline choice
             result.mark_reuse(len(n.users))
-
+        
         lowering.current_origin = None
         return result
 

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -8,8 +8,6 @@ import torch.fx
 from sympy import Integer
 from torch._decomp import get_decompositions
 
-from torchinductor import lowering
-
 from . import config
 from . import ir
 from .codegen.wrapper import WrapperCodeGen

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -8,6 +8,8 @@ import torch.fx
 from sympy import Integer
 from torch._decomp import get_decompositions
 
+from torchinductor import lowering
+
 from . import config
 from . import ir
 from .codegen.wrapper import WrapperCodeGen
@@ -22,7 +24,6 @@ from .lowering import lowerings
 from .lowering import make_fallback
 from .lowering import needs_realized_inputs
 from .sizevars import SizeVarAllocator
-from torchinductor import lowering
 
 log = logging.getLogger(__name__)
 
@@ -279,7 +280,7 @@ class GraphLowering(torch.fx.Interpreter):
 
             # TODO(jansel): introduce a store vs inline choice
             result.mark_reuse(len(n.users))
-        
+
         lowering.current_origin = None
         return result
 

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2898,7 +2898,6 @@ class StorageBox(MutableBox):
             ),
             data=self.data,
         )
-        print(self)
         # Move origin down a level - every StorageBox going through realization must already have origins
         for origin in self.origins:
             self.data.associate_origin(origin)

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -209,15 +209,12 @@ class IRNode(object):
     @staticmethod
     @contextlib.contextmanager
     def current_origins(origins: Set[torch.fx.Node]):
-        print("Enter origins", origins)
         old = IRNode._current_origins
         IRNode._current_origins = old | origins
         yield
         IRNode._current_origins = old
-        print("Exit origins")
 
     def __post_init__(self):
-        print("Init called")
         self.origins = set(self._current_origins)
 
     def common_repr(self):

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -202,7 +202,9 @@ def is_triton(device):
 
 class IRNode(object):
     def common_repr(self):
-        return [f"origins={self.origins}"] if hasattr(self, "origins") else ["no origins?"]
+        return (
+            [f"origins={self.origins}"] if hasattr(self, "origins") else ["no origins?"]
+        )
 
     def str_helper(self, lines):
         lines = lines + self.common_repr()
@@ -218,12 +220,13 @@ class IRNode(object):
     def associate_origin(self, node):
         if not hasattr(self, "origins"):
             self.origins = set()
-        
+
         self.origins.add(node)
-    
+
     @staticmethod
     def associate_origin_from_lowerings(x):
         from torchinductor import lowering
+
         if lowering.current_origin is not None:
             x.associate_origin(lowering.current_origin)
 
@@ -653,7 +656,6 @@ class BaseView(IRNode):
         loader = self.make_loader()
         loader = patch.object(ConstantBuffer, "override_device", device)(loader)
         return Pointwise(device, self.get_dtype(), loader, self.get_size())
-
 
     def associate_origin(self, node):
         super().associate_origin(node)
@@ -2123,8 +2125,12 @@ class ExternKernel(InputsKernel):
         return index, tuple(new_sizes)
 
     def __str__(self):
-        lines = [f"{field.name}={getattr(self, field.name)}" for field in dataclasses.fields(self)]
+        lines = [
+            f"{field.name}={getattr(self, field.name)}"
+            for field in dataclasses.fields(self)
+        ]
         return self.str_helper(lines)
+
 
 @dataclasses.dataclass
 class ExternKernelOut(ExternKernel):
@@ -2586,7 +2592,6 @@ class Convolution(ExternKernelAlloc):
         )
         if isinstance(self.layout, Layout):
             self.codegen_size_asserts(wrapper)
-
 
     @classmethod
     def create(

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -617,11 +617,11 @@ class BaseView(IRNode):
         return self.data.realize()
 
     def realize_hint(self):
-        print("Do I have origin?", self.origins)
         res = self.data.realize_hint()
-        for origin in self.origins:
-            res.associate_origin(origin)
-        return self.data.realize_hint()
+        if res is not None:
+            for origin in self.origins:
+                res.associate_origin(origin)
+        return res
 
     def get_storage_numel(self):
         return self.data.get_storage_numel()
@@ -2109,7 +2109,7 @@ class ExternKernel(InputsKernel):
         return index, tuple(new_sizes)
 
     def __str__(self):
-        lines = [f"{field.name}={getattr(self, field.name)!r}" for field in dataclasses.fields(self)]
+        lines = [f"{field.name}={getattr(self, field.name)}" for field in dataclasses.fields(self)]
         return self.str_helper(lines)
 
 @dataclasses.dataclass
@@ -2846,7 +2846,8 @@ class MutableBox(IRNode):
 
     def associate_origin(self, node):
         super().associate_origin(node)
-        self.data.associate_origin(node)
+        if self.data is not None:
+            self.data.associate_origin(node)
 
     __repr__ = __str__
 

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1423,7 +1423,7 @@ def index_put_(self, indices, values, accumulate=False):
         output_indexer=output_indexer,
         scatter_mode="atomic_add" if accumulate else None,
     )
-    buffer = ir.ComputedBuffer(
+    buffer = ir.ComputedBuffer.create(
         None,
         ir.MutationLayout(self),
         scatter,
@@ -1510,7 +1510,7 @@ def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = 
             output_indexer=output_indexer,
             scatter_mode=None,
         )
-        buffer = ir.ComputedBuffer(
+        buffer = ir.ComputedBuffer.create(
             None,
             ir.MutationLayout(self),
             zero_out,
@@ -1528,7 +1528,7 @@ def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = 
         output_indexer=output_indexer,
         scatter_mode=backend_reduce_str(reduce),
     )
-    buffer = ir.ComputedBuffer(
+    buffer = ir.ComputedBuffer.create(
         None,
         ir.MutationLayout(self),
         scatter,

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -30,6 +30,7 @@ needs_realized_inputs = set()
 
 current_origin = None
 
+
 def add_needs_realized_inputs(fn):
     if isinstance(fn, (list, tuple, set)):
         return [add_needs_realized_inputs(x) for x in fn]

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -28,8 +28,6 @@ aten = torch.ops.aten
 prims = torch.ops.prims
 needs_realized_inputs = set()
 
-current_origin = None
-
 
 def add_needs_realized_inputs(fn):
     if isinstance(fn, (list, tuple, set)):

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -28,6 +28,7 @@ aten = torch.ops.aten
 prims = torch.ops.prims
 needs_realized_inputs = set()
 
+current_origin = None
 
 def add_needs_realized_inputs(fn):
     if isinstance(fn, (list, tuple, set)):

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1424,7 +1424,7 @@ def index_put_(self, indices, values, accumulate=False):
         output_indexer=output_indexer,
         scatter_mode="atomic_add" if accumulate else None,
     )
-    buffer = ir.ComputedBuffer.create(
+    buffer = ir.ComputedBuffer(
         None,
         ir.MutationLayout(self),
         scatter,
@@ -1511,7 +1511,7 @@ def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = 
             output_indexer=output_indexer,
             scatter_mode=None,
         )
-        buffer = ir.ComputedBuffer.create(
+        buffer = ir.ComputedBuffer(
             None,
             ir.MutationLayout(self),
             zero_out,
@@ -1529,7 +1529,7 @@ def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = 
         output_indexer=output_indexer,
         scatter_mode=backend_reduce_str(reduce),
     )
-    buffer = ir.ComputedBuffer.create(
+    buffer = ir.ComputedBuffer(
         None,
         ir.MutationLayout(self),
         scatter,

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -818,6 +818,7 @@ class Scheduler:
         self.check_can_free = set()
         self.fusable_deps = set()
         for node in nodes:
+            assert(node.origins is not None), "All nodes passed to scheduling must have an origin"
             if node.is_no_op():
                 self.nodes.append(NopKernelSchedulerNode(self, node))
             elif isinstance(node, ir.ComputedBuffer):

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -818,7 +818,9 @@ class Scheduler:
         self.check_can_free = set()
         self.fusable_deps = set()
         for node in nodes:
-            assert(node.origins is not None), "All nodes passed to scheduling must have an origin"
+            assert (
+                node.origins is not None
+            ), "All nodes passed to scheduling must have an origin"
             if node.is_no_op():
                 self.nodes.append(NopKernelSchedulerNode(self, node))
             elif isinstance(node, ir.ComputedBuffer):

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -818,6 +818,7 @@ class Scheduler:
         self.check_can_free = set()
         self.fusable_deps = set()
         for node in nodes:
+            print("Node in scheduler", node)
             if node.is_no_op():
                 self.nodes.append(NopKernelSchedulerNode(self, node))
             elif isinstance(node, ir.ComputedBuffer):

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -818,7 +818,6 @@ class Scheduler:
         self.check_can_free = set()
         self.fusable_deps = set()
         for node in nodes:
-            print("Node in scheduler", node)
             if node.is_no_op():
                 self.nodes.append(NopKernelSchedulerNode(self, node))
             elif isinstance(node, ir.ComputedBuffer):


### PR DESCRIPTION
An example of what these IRNodes look like now, running `test_alexnet_prefix_cpu`

```
StorageBox(
  ComputedBuffer(name=None, layout=FlexibleLayout('cpu', torch.float32, size=[s3, 64, 55, 55], stride=[193600, 3025, 55, 1]), data=Pointwise(
    'cpu',
    torch.float32,
    relu(load(buf0, 193600*i0 + 3025*i1 + 55*i2 + i3, False) + load(primals_1, i1, False)),
    ranges=[s3, 64, 55, 55],
    origins={relu_default}
  ))
)
StorageBox(
  ComputedBuffer(name=None, layout=FlexibleLayout('cpu', torch.float32, size=[s3, 64, 27, 27], stride=[46656, 729, 27, 1]), data=Pointwise(
    'cpu',
    torch.float32,
    maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 112, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 111, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 110, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 57, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 56, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 55, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 2, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 1, False), load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3, False))))))))),
    ranges=[s3, 64, 27, 27],
    origins={max_pool2d_with_indices_default}
  ))
)
Convolution(
  name=buf0,
  layout=FixedLayout('cpu', torch.float32, size=[s3, 64, 55, 55], stride=[193600, 3025, 55, 1]),
  inputs=[InputBuffer(name='primals_3', layout=FixedLayout('cpu', torch.float32, size=[s3, s1, s4, s4], stride=[s1*s4**2, s4**2, s4, 1])), InputBuffer(name='primals_2', layout=FixedLayout('cpu', torch.float32, size=[s0, s1, s2, s2], stride=[s1*s2**2, s2**2, s2, 1]))],
  constant_args=(None, (4, 4), (2, 2), (1, 1), False, (0, 0), 1),
  output_view=None,
  origins={convolution_default}
)
ComputedBuffer(name='buf1', layout=FixedLayout('cpu', torch.float32, size=[s3, 64, 55, 55], stride=[193600, 3025, 55, 1]), data=Pointwise(
  'cpu',
  torch.float32,
  relu(load(buf0, 193600*i0 + 3025*i1 + 55*i2 + i3, False) + load(primals_1, i1, False)),
  ranges=[s3, 64, 55, 55],
  origins={relu_default}
))
ComputedBuffer(name='buf2', layout=FixedLayout('cpu', torch.float32, size=[s3, 64, 27, 27], stride=[46656, 729, 27, 1]), data=Pointwise(
  'cpu',
  torch.float32,
  maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 112, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 111, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 110, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 57, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 56, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 55, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 2, False), maximum(load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3 + 1, False), load(buf1, 193600*i0 + 3025*i1 + 110*i2 + 2*i3, False))))))))),
  ranges=[s3, 64, 27, 27],
  origins={max_pool2d_with_indices_default}
))
```