### PR TITLE
Remove context manager - 2/n; support nn.Modules, run

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ has warmed up.  For example, if you are serving production traffic in a
 latency critical application.  For this, TorchDynamo provides an alternate
 mode where prior compiled graphs are used, but no new ones are generated:
 ```py
-with torchdynamo.run():
-    toy_example(torch.randn(10), torch.randn(10))
+frozen_toy_example = torchdynamo.run(toy_example)
+frozen_toy_example(torch.randn(10), torch.randn(10))
 ```
 
 ## Single Whole-Program Graph Mode

--- a/benchmarks/huggingface.py
+++ b/benchmarks/huggingface.py
@@ -412,11 +412,9 @@ class HuggingfaceRunner(BenchmarkRunner):
     def compute_loss(self, pred):
         return pred[0]
 
-    @torchdynamo.skip
     def forward_pass(self, mod, inputs, collect_outputs=True):
         return mod(**inputs)
 
-    @torchdynamo.skip
     def forward_and_backward_pass(self, mod, inputs, collect_outputs=True):
         cloned_inputs = clone_inputs(inputs)
         mod.zero_grad(True)

--- a/benchmarks/huggingface.py
+++ b/benchmarks/huggingface.py
@@ -11,7 +11,6 @@ import torch
 from common import BenchmarkRunner
 from common import main
 
-import torchdynamo
 from torchdynamo.testing import collect_results
 from torchdynamo.utils import clone_inputs
 

--- a/benchmarks/timm_models.py
+++ b/benchmarks/timm_models.py
@@ -277,11 +277,9 @@ class TimmRunnner(BenchmarkRunner):
     def compute_loss(self, pred):
         return self.loss(pred, self.target)
 
-    @torchdynamo.skip
     def forward_pass(self, mod, inputs, collect_outputs=True):
         return mod(*inputs)
 
-    @torchdynamo.skip
     def forward_and_backward_pass(self, mod, inputs, collect_outputs=True):
         cloned_inputs = clone_inputs(inputs)
         mod.zero_grad(True)

--- a/benchmarks/timm_models.py
+++ b/benchmarks/timm_models.py
@@ -11,7 +11,6 @@ import torch
 from common import BenchmarkRunner
 from common import main
 
-import torchdynamo
 from torchdynamo.testing import collect_results
 from torchdynamo.utils import clone_inputs
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1050,11 +1050,11 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 4)
 
-        fn(torch.randn(5))
+        fn(torch.randn(4, 4))
         self.assertEqual(cnts.frame_count, 2)
 
         fn = torchdynamo.run(fn)
-        fn(torch.randn(6))
+        fn(torch.randn(4, 4, 4))
         self.assertEqual(cnts.frame_count, 2)
 
     def test_nested_disable_decorator(self):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1039,6 +1039,24 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertEqual(cnts3.frame_count, 1)
         self.assertEqual(cnts3.op_count, 4)
 
+    def test_nested_optimize_run(self):
+        cnts = torchdynamo.testing.CompileCounter()
+
+        @torchdynamo.optimize(cnts, nopython=True)
+        def fn(x):
+            return torch.relu(torch.cos(x) + torch.sin(x))
+
+        fn(torch.randn(4))
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(cnts.op_count, 4)
+
+        fn(torch.randn(5))
+        self.assertEqual(cnts.frame_count, 2)
+
+        fn = torchdynamo.run(fn)
+        fn(torch.randn(6))
+        self.assertEqual(cnts.frame_count, 2)
+
     def test_nested_disable_decorator(self):
         cnts = torchdynamo.testing.CompileCounter()
 

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -388,7 +388,11 @@ def run(fn=None):
     """Don't do any dynamic compiles, just use prior optimizations"""
     if fn is not None:
         assert callable(fn)
-        return RunOnlyContext()(fn)
+        callable_fn = fn
+        # Check if the function is a result of torchdynamo.optimize decorator.
+        if inspect.getattr_static(fn, "_torchdynamo_inline", False):
+            callable_fn = fn._torchdynamo_inline
+        return RunOnlyContext()(callable_fn)
     return RunOnlyContext()
 
 

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -98,7 +98,13 @@ class _TorchDynamoContext:
             mod = fn
             optimized_forward = self(mod.forward)
 
-            class Wrapper:
+            class TorchDynamoNNModuleWrapper:
+                """
+                A wrapper that redirects the forward call to the optimized
+                forward, while for rest it redirects the calls to the original
+                module.
+                """
+
                 def __getattr__(self, name):
                     return getattr(mod, name)
 
@@ -108,7 +114,7 @@ class _TorchDynamoContext:
                 def __call__(self, *args, **kwargs):
                     return self.forward(*args, **kwargs)
 
-            new_mod = Wrapper()
+            new_mod = TorchDynamoNNModuleWrapper()
             # Save the function pointer to find the original callable while nesting
             # of decorators.
             new_mod._torchdynamo_orig_callable = mod


### PR DESCRIPTION
* Adds support for nn.Module objects
* In case of nesting of torchdynamo.optimize/run/disable etc, we recursively find the innnermost fn and apply the outermost Dynamo call on it.

