### PR TITLE
allow_tff32=True for triton_ops.matmul

### DIFF
--- a/benchmarks/microbenchmarks/bench_mm_fusion.py
+++ b/benchmarks/microbenchmarks/bench_mm_fusion.py
@@ -10,6 +10,12 @@ torchinductor.config.triton.dense_indexing = True
 torch.manual_seed(0)
 
 
+# The flag below controls whether to allow TF32 on matmul. This flag defaults to True.
+torch.backends.cuda.matmul.allow_tf32 = True
+# The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
+torch.backends.cudnn.allow_tf32 = True
+
+
 class Func(object):
     # mm
     @torchdynamo.optimize("inductor")

--- a/benchmarks/microbenchmarks/inductor_mm.py
+++ b/benchmarks/microbenchmarks/inductor_mm.py
@@ -6,6 +6,11 @@ import torchdynamo
 import torchdynamo.config
 import torchinductor.config as config
 
+# The flag below controls whether to allow TF32 on matmul. This flag defaults to True.
+torch.backends.cuda.matmul.allow_tf32 = True
+# The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
+torch.backends.cudnn.allow_tf32 = True
+
 
 @torchdynamo.optimize("inductor", nopython=True)
 def inductor_aten_mm(a, b):

--- a/torchinductor/codegen/triton_mm.j2
+++ b/torchinductor/codegen/triton_mm.j2
@@ -59,7 +59,7 @@ def {{kernel_name}}(
         else:
             a = tl.load(A_ptrs, mask=rk[None, :] < k, other=0.0)
             b = tl.load(B_ptrs, mask=rk[:, None] < k, other=0.0)
-        acc += tl.dot(a, b, allow_tf32=False)
+        acc += tl.dot(a, b)
         A_ptrs += BLOCK_K * SPLIT_K * stride_ak
         B_ptrs += BLOCK_K * SPLIT_K * stride_bk
     acc = acc.to({{out_def}}.dtype.element_ty)

--- a/torchinductor/triton_ops/matmul.py
+++ b/torchinductor/triton_ops/matmul.py
@@ -58,7 +58,7 @@ def _kernel(
         else:
             a = tl.load(A, mask=rk[None, :] < k, other=0.0)
             b = tl.load(B, mask=rk[:, None] < k, other=0.0)
-        acc += tl.dot(a, b, allow_tf32=False)
+        acc += tl.dot(a, b)
         A += BLOCK_K * SPLIT_K * stride_ak
         B += BLOCK_K * SPLIT_K * stride_bk
     acc = acc.to(C.dtype.element_ty)


### PR DESCRIPTION
allow_tff32=True for triton_ops.matmul
Otherwise, triton_ops.mamul_out is way slower than aten.mm.out in torchinductor. Because in torchinductor, `
torch.backends.cuda.matmul.allow_tf32 = True
torch.backends.cudnn.allow_tf32 = True`