### PR TITLE
add allow_tf32 option in torchinductor.triton_ops.matmul

### DIFF
--- a/benchmarks/microbenchmarks/bench_mm_fusion.py
+++ b/benchmarks/microbenchmarks/bench_mm_fusion.py
@@ -10,6 +10,12 @@ torchinductor.config.triton.dense_indexing = True
 torch.manual_seed(0)
 
 
+# The flag below controls whether to allow TF32 on matmul. This flag defaults to True.
+torch.backends.cuda.matmul.allow_tf32 = True
+# The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
+torch.backends.cudnn.allow_tf32 = True
+
+
 class Func(object):
     # mm
     @torchdynamo.optimize("inductor")

--- a/benchmarks/microbenchmarks/bench_mm_fusion.py
+++ b/benchmarks/microbenchmarks/bench_mm_fusion.py
@@ -10,10 +10,8 @@ torchinductor.config.triton.dense_indexing = True
 torch.manual_seed(0)
 
 
-# The flag below controls whether to allow TF32 on matmul. This flag defaults to True.
+# The flag below controls whether to allow TF32 on matmul.
 torch.backends.cuda.matmul.allow_tf32 = True
-# The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
-torch.backends.cudnn.allow_tf32 = True
 
 
 class Func(object):

--- a/benchmarks/microbenchmarks/inductor_mm.py
+++ b/benchmarks/microbenchmarks/inductor_mm.py
@@ -6,6 +6,11 @@ import torchdynamo
 import torchdynamo.config
 import torchinductor.config as config
 
+# The flag below controls whether to allow TF32 on matmul. This flag defaults to True.
+torch.backends.cuda.matmul.allow_tf32 = True
+# The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
+torch.backends.cudnn.allow_tf32 = True
+
 
 @torchdynamo.optimize("inductor", nopython=True)
 def inductor_aten_mm(a, b):

--- a/torchinductor/codegen/triton_mm.j2
+++ b/torchinductor/codegen/triton_mm.j2
@@ -23,6 +23,7 @@ def {{kernel_name}}(
     {% for i in extra_argdefs %}
     {{i}},
     {% endfor %}
+    allow_tf32: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -59,7 +60,7 @@ def {{kernel_name}}(
         else:
             a = tl.load(A_ptrs, mask=rk[None, :] < k, other=0.0)
             b = tl.load(B_ptrs, mask=rk[:, None] < k, other=0.0)
-        acc += tl.dot(a, b)
+        acc += tl.dot(a, b, allow_tf32=allow_tf32)
         A_ptrs += BLOCK_K * SPLIT_K * stride_ak
         B_ptrs += BLOCK_K * SPLIT_K * stride_bk
     acc = acc.to({{out_def}}.dtype.element_ty)

--- a/torchinductor/codegen/triton_mm.j2
+++ b/torchinductor/codegen/triton_mm.j2
@@ -59,7 +59,7 @@ def {{kernel_name}}(
         else:
             a = tl.load(A_ptrs, mask=rk[None, :] < k, other=0.0)
             b = tl.load(B_ptrs, mask=rk[:, None] < k, other=0.0)
-        acc += tl.dot(a, b, allow_tf32=False)
+        acc += tl.dot(a, b)
         A_ptrs += BLOCK_K * SPLIT_K * stride_ak
         B_ptrs += BLOCK_K * SPLIT_K * stride_bk
     acc = acc.to({{out_def}}.dtype.element_ty)

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2069,7 +2069,7 @@ class ExternKernel(InputsKernel):
         sizevars = V.graph.sizevars
         sizes = self.get_size()
         strides = self.get_stride()
-        strides = [sizevars.guard_static_shape(x) for x in strides]
+        strides = [sizevars.size_hint(x) for x in strides]
         index_vars = [sympy.Symbol(f"d{i}") for i in range(len(sizes))]
         # reorder index vars according to stride
         index_order = sorted(range(len(strides)), key=strides.__getitem__, reverse=True)

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2256,6 +2256,7 @@ class MatrixMultiply(ExternKernelOut):
             [
                 ("GROUP_M", "8"),
                 ("ACC_TYPE", ACC_TYPE),
+                ("allow_tf32", f"{torch.backends.cuda.matmul.allow_tf32}"),
             ]
         )
 

--- a/torchinductor/triton_ops/matmul.py
+++ b/torchinductor/triton_ops/matmul.py
@@ -58,7 +58,7 @@ def _kernel(
         else:
             a = tl.load(A, mask=rk[None, :] < k, other=0.0)
             b = tl.load(B, mask=rk[:, None] < k, other=0.0)
-        acc += tl.dot(a, b, allow_tf32=False)
+        acc += tl.dot(a, b)
         A += BLOCK_K * SPLIT_K * stride_ak
         B += BLOCK_K * SPLIT_K * stride_bk
     acc = acc.to(C.dtype.element_ty)

--- a/torchinductor/triton_ops/matmul.py
+++ b/torchinductor/triton_ops/matmul.py
@@ -128,7 +128,7 @@ class _matmul_out:
         )
 
     @staticmethod
-    def forward(a, b, out, allow_tf32=torch.backends.cuda.matmul.allow_tf32):
+    def forward(a, b, out, allow_tf32=True):
         return _matmul_out._call(a, b, out, allow_tf32)
 
 

--- a/torchinductor/triton_ops/matmul.py
+++ b/torchinductor/triton_ops/matmul.py
@@ -22,6 +22,7 @@ def _kernel(
     stride_bn,
     stride_cm,
     stride_cn,
+    allow_tf32: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -58,7 +59,7 @@ def _kernel(
         else:
             a = tl.load(A, mask=rk[None, :] < k, other=0.0)
             b = tl.load(B, mask=rk[:, None] < k, other=0.0)
-        acc += tl.dot(a, b)
+        acc += tl.dot(a, b, allow_tf32=allow_tf32)
         A += BLOCK_K * SPLIT_K * stride_ak
         B += BLOCK_K * SPLIT_K * stride_bk
     acc = acc.to(C.dtype.element_ty)
@@ -78,7 +79,7 @@ class _matmul_out:
     kernel = _kernel
 
     @staticmethod
-    def _call(a, b, out):
+    def _call(a, b, out, allow_tf32=True):
         # handle non-contiguous inputs if necessary
         if a.stride(0) > 1 and a.stride(1) > 1:
             a = a.contiguous()
@@ -121,13 +122,14 @@ class _matmul_out:
             b.stride(1),
             c.stride(0),
             c.stride(1),
+            allow_tf32=allow_tf32,
             GROUP_M=8,
             ACC_TYPE=ACC_TYPE,
         )
 
     @staticmethod
-    def forward(a, b, out):
-        return _matmul_out._call(a, b, out)
+    def forward(a, b, out, allow_tf32=torch.backends.cuda.matmul.allow_tf32):
+        return _matmul_out._call(a, b, out, allow_tf32)
 
 
 matmul_out = _matmul_out.forward

--- a/torchinductor/triton_ops/tests/test_mm_fusion.py
+++ b/torchinductor/triton_ops/tests/test_mm_fusion.py
@@ -8,6 +8,9 @@ from torchdynamo.testing import rand_strided
 torchinductor.config.triton.dense_indexing = True
 torch.manual_seed(0)
 
+# The flag below controls whether to allow TF32 on matmul.
+torch.backends.cuda.matmul.allow_tf32 = True
+
 class Func(object):
     @torchdynamo.optimize("inductor")
     def mm(x, w, bias):


### PR DESCRIPTION
add allow_tf32 option in torchinductor.triton_ops.matmul, allow_tf=torch.backends.cuda.matmul.allow_tf32
Do not guard_static_shape in strides otherwise canonicalize of ExternKernel buffer Dependency won't match the following fusable nodes