### PR TITLE
[inductor] Make factory ops create tensor on the same device as graph inputs

### DIFF
--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -44,6 +44,9 @@ implicit_fallbacks = True
 # Enables a fusion pass that groups nodes together before the scheduler
 prefuse_nodes = True
 
+# Use the graph inputs' device (should be unique) as factory ops' output device
+use_graph_device_for_factory_ops = True
+
 
 # config specific to codegen/cpp.pp
 class cpp:

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -89,6 +89,10 @@ def decode_dtype(dtype: int):
 
 
 def decode_device(device):
+    if config.use_graph_device_for_factory_ops and len(V.graph.device_types) == 1:
+        # If this optimization is on, we make all factory ops generate
+        # tensors on the same unique device as the graph inputs.
+        return torch.device(list(V.graph.device_types)[0])
     if device is None:
         return torch.tensor(0.0).device  # default device
     if isinstance(device, str):


### PR DESCRIPTION
Summary: To solve the "skipping cudagraphs due to multple devices"
issue, see https://github.com/pytorch/torchdynamo/issues/748