### PR TITLE
Add model training loss convergence benchmark

### DIFF
--- a/benchmarks/training_loss.py
+++ b/benchmarks/training_loss.py
@@ -1,0 +1,100 @@
+import os
+
+import torch
+from datasets import load_dataset
+from datasets import load_metric
+from torch.optim import SGD
+from torch.utils.data import DataLoader
+from transformers import AutoModelForSequenceClassification
+from transformers import AutoTokenizer
+
+import torchdynamo
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+num_samples = 10000
+num_epochs = 3
+
+
+def data_processing(num_samples):
+    dataset = load_dataset("yelp_review_full")
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+
+    def tokenize_function(examples):
+        return tokenizer(examples["text"], padding="max_length", truncation=True)
+
+    tokenized_datasets = dataset.map(tokenize_function, batched=True)
+
+    tokenized_datasets = tokenized_datasets.remove_columns(["text"])
+    tokenized_datasets = tokenized_datasets.rename_column("label", "labels")
+    tokenized_datasets.set_format("torch")
+
+    small_train_dataset = (
+        tokenized_datasets["train"].shuffle(seed=42).select(range(num_samples))
+    )
+    small_eval_dataset = (
+        tokenized_datasets["test"].shuffle(seed=42).select(range(num_samples))
+    )
+
+    train_dataloader = DataLoader(small_train_dataset, shuffle=True, batch_size=8)
+    eval_dataloader = DataLoader(small_eval_dataset, batch_size=8)
+
+    return train_dataloader, eval_dataloader
+
+
+@torchdynamo.optimize("eager")
+def training_iter_fn(batch, model, optimizer):
+    batch = {k: v.to(device) for k, v in batch.items()}
+    outputs = model(**batch)
+    loss = outputs.loss
+    loss.backward()
+    optimizer.step()
+    optimizer.zero_grad()
+    return loss
+
+
+@torchdynamo.optimize("eager")
+def eval_iter_fn(batch):
+    return model(**batch)
+
+
+def model_training_evaluation(
+    train_dataloader, eval_dataloader, model, optimizer, num_epochs
+):
+    model.to(device)
+    model.train()
+    loss_history = []
+    for epoch in range(num_epochs):
+        running_loss = 0.0
+        for i, batch in enumerate(train_dataloader, 0):
+            loss = training_iter_fn(batch, model, optimizer)
+            running_loss += loss.item()
+            if i % 100 == 99:
+                loss_history.append(running_loss / 100)
+                running_loss = 0.0
+
+    metric = load_metric("accuracy")
+    model.eval()
+    for batch in eval_dataloader:
+        batch = {k: v.to(device) for k, v in batch.items()}
+        with torch.no_grad():
+            outputs = eval_iter_fn(batch)
+
+        logits = outputs.logits
+        predictions = torch.argmax(logits, dim=-1)
+        metric.add_batch(predictions=predictions, references=batch["labels"])
+
+    return loss_history, metric.compute()
+
+
+if __name__ == "__main__":
+    train_dataloader, eval_dataloader = data_processing(num_samples)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        "bert-base-cased", num_labels=5
+    )
+    optimizer = SGD(model.parameters(), lr=5e-5, momentum=0.9)
+    loss_history, accuracy = model_training_evaluation(
+        train_dataloader, eval_dataloader, model, optimizer, num_epochs
+    )
+    print("Loss history : " + str(loss_history))
+    print("Accuracy : " + str(accuracy))

--- a/benchmarks/training_loss.py
+++ b/benchmarks/training_loss.py
@@ -11,7 +11,7 @@ from transformers import AutoTokenizer
 
 import torchdynamo
 
-# torchdynamo.config.fake_tensor_propagation = False
+torchdynamo.config.fake_tensor_propagation = False
 
 # You will download around 84G dataset if you run this end to end training/evaluation example.
 


### PR DESCRIPTION
This example follows how users write their own end to end model training/evaluation pipeline using _huggingface_. The loss function is in convergence w/o Dynamo:
```
Loss history : [1.638656200170517, 1.6167153787612916, 1.591713446378708, 1.5690117526054381, 1.5178297901153563, 1.4247627103328704, 1.325632695555687, 1.23151354432106, 1.2123524838685988, 1.1726598739624023, 1.0923227965831757, 1.1367704308032989, 1.0908222246170043, 1.1158152759075164, 1.0315754282474519, 1.06554756462574, 1.0479815247654916, 1.0996541720628739, 1.0450058096647263, 1.0318933933973313, 1.0339357393980027, 1.0286797326803208, 1.052253406047821, 1.0163359659910203, 0.9940995579957962, 0.988142160475254, 0.9932016897201538, 0.9409900230169296, 0.9778001809120178, 1.0251611429452896, 0.9572644853591918, 1.013562046289444, 0.9348490306735039, 0.9323300030827523, 1.0125887167453766, 0.9674993979930878]
```  
There are several bugs if we enable Dynamo, I'm working on fixing them now. Posting it before bug-free is to collect feedback on if this framework is what users usually does and then we can optimize Dynamo to provide the best performance and experience with least onboarding cost.

cc @anijain2305 