### PR TITLE
Autotune best layout for conv

### DIFF
--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -44,6 +44,9 @@ implicit_fallbacks = True
 # Enables a fusion pass that groups nodes together before the scheduler
 prefuse_nodes = True
 
+# do bench to decide best layout, currently only for aten.conv
+tune_layout = False
+
 
 # config specific to codegen/cpp.pp
 class cpp:

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2613,7 +2613,6 @@ class Convolution(ExternKernelAlloc):
             assert config_conv == "autotune"
             from .codegen.autotuner import tuned_conv
 
-            # kernel = "tuned_conv"
             kernel = tuned_conv(
                 x.get_size(),
                 weight.get_size(),
@@ -2631,11 +2630,31 @@ class Convolution(ExternKernelAlloc):
 
         # for conv2d or conv3d, prefer channels last format
         if kernel == "triton_ops.conv":
+            output_layout = "torch.channels_last"
+        elif config.tune_layout:
+            from .codegen.autotuner import tuned_conv_layout
+
+            output_layout = tuned_conv_layout(
+                kernel,
+                x.get_size(),
+                weight.get_size(),
+                stride,
+                padding,
+                dilation,
+                transposed,
+                output_padding,
+                groups,
+                x.get_device(),
+                x.get_dtype(),
+            )
+        else:
+            output_layout = "torch.contiguous_format"
+
+        if output_layout == "torch.channels_last":
             stride_order = [0] + list(reversed(range(1, len(kernel_size) + 1)))
             if len(stride_order) < len(output_size):
                 # add batch dim if it exists
                 stride_order = [len(stride_order)] + stride_order
-        # for conv1d, output layout is not preserved with inputs
         else:
             stride_order = list(reversed(range(len(output_size))))
 


### PR DESCRIPTION
For most of the models, channel-last layout is way faster than contiguous layout, overall ~10% speedup in fp16 torchinductor inference. To avoid slow down in a few models, add a autotuner to choose the best layout given the input shapes/ layer parameters

<img width="542" alt="image" src="https://user-images.githubusercontent.com/17924210/184461061-fd32fb95-a0eb-4945-9655-17936e8a7bc9.png">
