### PR TITLE
Fix sth like torch.LongTensor(list(np.int64, np.int64, ...))

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -2506,6 +2506,19 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.torch.float16)
 
+    def test_generate_tensor_from_list_of_numpy_primitive_type(self):
+        # Test sth like torch.LongTensor(list(np.int64, np.int64, ...))
+        def fn():
+            x = np.array([1, 2, 3, 4, 5, 6], dtype=np.int64)
+            y = list((x[0], x[2], x[4]))
+            z = torch.LongTensor(y)
+            return z
+
+        ref = fn()
+        opt_fn = torchdynamo.optimize("eager")(fn)
+        res = opt_fn()
+        self.assertTrue(same(ref, res))
+
 
 class TestTracer(JitTestCase):
     def test_jit_save(self):

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -183,6 +183,20 @@ LOGGING_CONFIG = {
 }
 
 
+tensortype_to_dtype = {
+    torch.FloatTensor: (torch.float32, torch.float),
+    torch.DoubleTensor: (torch.float64, torch.double),
+    torch.HalfTensor: (torch.float16, torch.half),
+    torch.BFloat16Tensor: (torch.bfloat16,),
+    torch.ByteTensor: (torch.uint8,),
+    torch.CharTensor: (torch.int8,),
+    torch.LongTensor: (torch.int64, torch.long),
+    torch.IntTensor: (torch.int32, torch.int),
+    torch.ShortTensor: (torch.int16, torch.short),
+    torch.BoolTensor: (torch.bool,),
+}
+
+
 # initialize torchdynamo loggers
 def init_logging():
     if "PYTEST_CURRENT_TEST" not in os.environ:

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -38,6 +38,7 @@ from ..utils import istype
 from ..utils import preserve_rng_state
 from ..utils import product
 from ..utils import proxy_args_kwargs
+from ..utils import tensortype_to_dtype
 from .base import MutableLocal
 from .base import VariableTracker
 from .base import typestr
@@ -303,19 +304,6 @@ class TensorVariable(VariableTracker):
         return self.class_type
 
     def call_isinstance(self, tensor_type):
-        tensortype_to_dtype = {
-            torch.FloatTensor: (torch.float32, torch.float),
-            torch.DoubleTensor: (torch.float64, torch.double),
-            torch.HalfTensor: (torch.float16, torch.half),
-            torch.BFloat16Tensor: (torch.bfloat16,),
-            torch.ByteTensor: (torch.uint8,),
-            torch.CharTensor: (torch.int8,),
-            torch.LongTensor: (torch.int64, torch.long),
-            torch.IntTensor: (torch.int32, torch.int),
-            torch.ShortTensor: (torch.int16, torch.short),
-            torch.BoolTensor: (torch.bool,),
-        }
-
         def check_type(ty):
             if ty not in tensortype_to_dtype:
                 return issubclass(self.python_type(), ty)

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -29,6 +29,7 @@ from ..utils import tensortype_to_dtype
 from .base import VariableTracker
 from .tensor import TensorWithTFOverrideVariable
 
+
 log = logging.getLogger(__name__)
 
 

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -29,7 +29,6 @@ from ..utils import tensortype_to_dtype
 from .base import VariableTracker
 from .tensor import TensorWithTFOverrideVariable
 
-
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This was reported by @anijain2305 when running torchbench:
```
python benchmarks/torchbench.py --training --accuracy-aot-nop -d cuda --isolate --use-eval-mode --only=fastNLP_Bert
```

The root cause is FX doesn't support numpy int/float as [base type](https://github.com/pytorch/pytorch/blob/master/torch/fx/proxy.py#L154), so throw ```NotImplementedError``` error when there is numpy int/float in ```fx.node.args```.

The fast fix is to add numpy int/float as base types in torch.fx, but we think the goal of torch.fx is not to capture every base type after discussing with @anijain2305 .
So we fix this issue at Dynamo side by converting numpy int/float to python int/float before passing them to ```fx.node.args```. 