### PR TITLE
don't tile broadcasted tensors, those tiles are not needed

### DIFF
--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -1118,6 +1118,11 @@ class TritonScheduling:
                 split = strides.index(1) + 1
                 if split == len(ranges):
                     continue
+                if all(s == 0 for s in strides[split:]):
+                    # if this is a broadcasted tensor and all dimensions after split are broadcast,
+                    # this is not a real split
+                    continue
+
             except ValueError:
                 continue
             tiled_groups = (


### PR DESCRIPTION
Currently a lot of pw kernels are getting codegened with tiling and are subsequently autotuned, when that's not necessary