### PR TITLE
Fix syntax error in guards

### DIFF
--- a/torchdynamo/guards.py
+++ b/torchdynamo/guards.py
@@ -152,9 +152,9 @@ def strip_function_call(name):
     """
     "___odict_getitem(a, 1)" => "a"
     """
-    m = re.search(r"[a-z0-9_]+\(([^(),]+)[^()]*\)", name)
-    if m:
-        return strip_function_call(m.group(1))
+    m = re.search(r"([a-z0-9_]+)\(([^(),]+)[^()]*\)", name)
+    if m and m.group(1) != "slice":
+        return strip_function_call(m.group(2))
     return strip_getattr_getitem(name)
 
 
@@ -192,7 +192,7 @@ class GuardBuilder:
             name = guard
         else:
             name = guard.name
-        base = strip_getattr_getitem(strip_function_call(strip_getattr_getitem(name)))
+        base = strip_getattr_getitem(strip_function_call(name))
         if base not in self.argnames:
             if re.match(r"^\d+$", base):
                 log.warning(f"invalid var name: {guard}")

--- a/torchdynamo/guards.py
+++ b/torchdynamo/guards.py
@@ -192,8 +192,10 @@ class GuardBuilder:
             name = guard
         else:
             name = guard.name
-        base = strip_getattr_getitem(strip_function_call(name))
+        base = strip_getattr_getitem(strip_function_call(strip_getattr_getitem(name)))
         if base not in self.argnames:
+            if re.match(r"^\d+$", base):
+                log.warning(f"invalid var name: {guard}")
             self.argnames.append(base)
 
         return name


### PR DESCRIPTION
In `detectron2_fcos_r_50_fpn` we were generating the guard:
```
lambda instance_lists,1,**___kwargs_ignored: ...
```

Due to name being: `instance_lists[slice(1, None, None)]`, and `strip_function_call` pulling out the wrong thing.