### PR TITLE
Fix prefuse scheduler dependency issue

### DIFF
--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -508,13 +508,19 @@ class BlockedNodes:
             self.dep_to_nodes[dep] = [x for x in self.dep_to_nodes[dep] if x]
             for box in self.dep_to_nodes[dep]:
                 if (
-                    len(box.peek().unmet_dependencies - deps) == 0
+                    box.peek()
+                    and len(box.peek().unmet_dependencies - deps) == 0
                     and box.peek().group == group
                 ):
                     out = box.pop()
                     if isinstance(out, FusedSchedulerNode):
                         for x in out.snodes:
-                            result.append(x)
+                            if len(x.unmet_dependencies) == 0:
+                                result.append(x)
+                            else:
+                                self.add(x)
+                        # in case there are dependencies inside pre fused nodes
+                        result.extend(self.pop_fusable(deps, group))
                     else:
                         result.append(out)
         return result

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -503,6 +503,7 @@ class BlockedNodes:
 
     def pop_fusable(self, deps, group):
         assert isinstance(deps, set)
+        unpacked_something = False
         result = []
         for dep in deps:
             self.dep_to_nodes[dep] = [x for x in self.dep_to_nodes[dep] if x]
@@ -519,10 +520,12 @@ class BlockedNodes:
                                 result.append(x)
                             else:
                                 self.add(x)
-                        # in case there are dependencies inside pre fused nodes
-                        result.extend(self.pop_fusable(deps, group))
+                            unpacked_something = True
                     else:
                         result.append(out)
+        if unpacked_something:
+            # in case there are dependencies inside pre fused nodes
+            result.extend(self.pop_fusable(deps, group))
         return result
 
 


### PR DESCRIPTION
add pre fused nodes to blocked_nodes in case there are dependencies inside prefused nodes
For example, buf1-buf2 are in prefused group. buf1 depends on buf0, buf2 depends on buf1.  `pop_fusable` only checks the depdency of the whole group, which is buf0. Once buf0 depdency is met, both buf1 and buf2 are in the available node list. When codegen pop_group(), buf1 is popped out first. But it may be possible that buf1 could not be fused in the current kernel and we put it back into reschedule list. Later, buf2 is popped out without knowing that its dependency is not met anymore.
The PR will fix such issue by adding both buf1 and buf2 to blocked nodes before they really get popped out

Fixes #810