### PR TITLE
[inductor] Relax a dim assertion in scatter_reduce

### DIFF
--- a/tests/test_torchinductor.py
+++ b/tests/test_torchinductor.py
@@ -2324,7 +2324,7 @@ class CommonTemplate:
             fn,
             [
                 torch.zeros(2, 3),
-                0,
+                -1,
                 torch.tensor([[0]]),
                 torch.ones(2, 3),
             ],

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1507,7 +1507,7 @@ def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = 
     assert reduce is None or reduce in {"sum"}
     assert isinstance(self, TensorBox)
     assert "int" in str(index.get_dtype())
-    assert 0 <= dim < len(self.get_size())
+    assert -len(self.get_size()) <= dim < len(self.get_size())
 
     self.realize()
     V.graph.realize_users_of(self.get_name())


### PR DESCRIPTION
Summary: For https://github.com/pytorch/torchdynamo/issues/633, dim is
allowed to be negative.