### PR TITLE
[inductor] Make less consts by relaxing matching

### DIFF
--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -151,7 +151,11 @@ class GraphLowering(torch.fx.Interpreter):
     def add_tensor_constant(self, data):
         def allocate():
             for name, value in self.constants.items():
-                if data.size() == value.size() and torch.allclose(data, value):
+                if (data.size() == value.size() and 
+                    data.stride() == value.stride() and
+                    data.dtype == value.dtype and
+                    data.device == value.device and
+                    torch.eq(data, value).all()):
                     return name
             name = f"constant{len(self.constants)}"
             self.constants[name] = data

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -151,11 +151,13 @@ class GraphLowering(torch.fx.Interpreter):
     def add_tensor_constant(self, data):
         def allocate():
             for name, value in self.constants.items():
-                if (data.size() == value.size() and 
-                    data.stride() == value.stride() and
-                    data.dtype == value.dtype and
-                    data.device == value.device and
-                    torch.eq(data, value).all()):
+                if (
+                    data.size() == value.size()
+                    and data.stride() == value.stride()
+                    and data.dtype == value.dtype
+                    and data.device == value.device
+                    and torch.eq(data, value).all()
+                ):
                     return name
             name = f"constant{len(self.constants)}"
             self.constants[name] = data

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -170,14 +170,11 @@ class GraphLowering(torch.fx.Interpreter):
         If device_override doesn't match the constant's device, then
         copy it and return a different name.
         """
-        # import pdb
-        # pdb.set_trace()
         if self.constants[name].device == device_override or device_override is None:
             return name
         alt_name = f"{name}_{device_override.type}{device_override.index or 0}"
         if alt_name not in self.constants:
             self.constants[alt_name] = self.constants[name].to(device_override)
-        print("ALT CONSTANT NAME", name, alt_name)
         return alt_name
 
     def placeholder(self, target, args, kwargs):
@@ -300,7 +297,6 @@ class GraphLowering(torch.fx.Interpreter):
         mod = PyCodeCache.load(code)
 
         for name, value in self.constants.items():
-            print("GOT A CONSTANT", name)
             setattr(mod, name, value)
 
         return mod.call


### PR DESCRIPTION
`./benchmarks/torchbench.py --inductor --training --no-skip --only Super_SloMo` 

Down to 6 graph constants, from 100, at the time the scheduler is created