### PR TITLE
Added another level to minifier that always prints minifier code (useful for segfaults).

### DIFF
--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -106,6 +106,8 @@ def compile_fx_inner(
     if cudagraphs is None:
         cudagraphs = config.triton.cudagraphs
 
+    if config.repro_level == 3:
+        dump_to_minify(gm, example_inputs)
     try:
         graph = GraphLowering(gm, num_dynamic_inputs=len(example_inputs))
         with V.set_graph_handler(graph):

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -53,6 +53,7 @@ tune_layout = False
 # 0: Nothing printed out when compilation fails
 # 1: Dump the graph out to repro.py if compilation fails
 # 2: Dumps the graph out to minify_repro.py with a minifier if compilation fails
+# 3: Always dumps the last graph ran out to minify_repro.py, useful for segfaults/irrecoverable errors
 repro_level = int(os.environ.get("INDUCTOR_REPRO_LEVEL", 0))
 
 

--- a/torchinductor/debug_utils.py
+++ b/torchinductor/debug_utils.py
@@ -103,7 +103,7 @@ def inductor_fails(fx_g, args, check_str=None):
         compile_mod = compile_fx_inner(fx_g, args)
         compile_mod = compile_mod(*args)
     except Exception as e:
-        if check_str is not None and check_str in repr(e):
+        if check_str is not None and check_str not in repr(e):
             return False
         print(repr(e))
         return True


### PR DESCRIPTION
For errors like this( https://github.com/pytorch/torchdynamo/issues/815), we can't catch compilation errors as the compilation segfaults (crashing the process). Instead, we just always dump out the minify code, and the last one that we can compile works :)