### PR TITLE
Correctly pre-initialize FakeTensorMode before using it, so restore works

### DIFF
--- a/tests/test_repros.py
+++ b/tests/test_repros.py
@@ -1488,3 +1488,7 @@ class ReproTests(torchdynamo.testing.TestCase):
                 return boxes + 1
 
         self.assertTrue((to_bitmasks(torch.zeros(10)) == torch.ones(10)).all())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_repros.py
+++ b/tests/test_repros.py
@@ -1490,5 +1490,5 @@ class ReproTests(torchdynamo.testing.TestCase):
         self.assertTrue((to_bitmasks(torch.zeros(10)) == torch.ones(10)).all())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/torchdynamo/optimizations/analysis.py
+++ b/torchdynamo/optimizations/analysis.py
@@ -116,11 +116,12 @@ def has_mutation(gm, example_inputs, inputs_only=False):
     # TODO - moco gives bad accuracy with Aliasing. gm is getting mutated in a bad way.
 
     if fake_tensors_available and config.fake_tensor_propagation:
-        fake_mode = FakeTensorMode()
+        with FakeTensorMode() as fake_mode:
+            pass
         fake_wrapper = functools.partial(wrap_to_fake_tensor, fake_mode=fake_mode)
         example_inputs = tree_map(fake_wrapper, example_inputs)
         new_gm = deepcopy_to_fake_tensor(gm, fake_mode)
-        with fake_mode:
+        with fake_mode.restore():
             ShapeAliasingAndMutationProp(new_gm).run(*example_inputs)
     else:
         new_gm = copy.deepcopy(gm)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1192,7 +1192,9 @@ class InstructionTranslatorBase(object):
         self.f_code: types.CodeType = f_code
 
         if fake_tensors_available:
-            self._fake_mode = torch._subclasses.FakeTensorMode(inner=None)
+            with torch._subclasses.FakeTensorMode() as fake_mode:
+                pass
+            self._fake_mode = fake_mode
 
         self.checkpoint = None
         self.random_calls: List[tuple] = []


### PR DESCRIPTION
Needed for https://github.com/pytorch/pytorch/pull/83496