### PR TITLE
Always use isolate in benchmarking script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           name: TorchBench AotAutograd Eager run
           command: |
             source .circleci/setup_env.sh
-            python benchmarks/torchbench.py --training --accuracy-aot-nop -d cuda -x Super_SloMo -x moco -x dlrm -x fambench_dlrm -x fastNLP_Bert -x hf_Reformer -x tacotron2 --isolate --use-eval-mode --output=aot_eager.csv
+            python benchmarks/torchbench.py --training --accuracy-aot-nop -d cuda -x Super_SloMo -x moco -x dlrm -x fambench_dlrm -x fastNLP_Bert -x hf_Reformer -x tacotron2 --use-eval-mode --output=aot_eager.csv
       - store_artifacts:
           path: aot_eager.csv
       - run:

--- a/Makefile
+++ b/Makefile
@@ -139,19 +139,19 @@ fixed2-gpu: develop
 
 baseline-cpu: develop
 	 rm -f baseline_*.csv
-	 python benchmarks/torchbench.py --isolate -n50 --overhead
-	 python benchmarks/torchbench.py --isolate -n50 --speedup-ts
-	 python benchmarks/torchbench.py --isolate -n50 --speedup-sr
-	 python benchmarks/torchbench.py --isolate -n50 --speedup-onnx
+	 python benchmarks/torchbench.py -n50 --overhead
+	 python benchmarks/torchbench.py -n50 --speedup-ts
+	 python benchmarks/torchbench.py -n50 --speedup-sr
+	 python benchmarks/torchbench.py -n50 --speedup-onnx
 	 paste -d, baseline_ts.csv baseline_sr.csv baseline_onnx.csv > baseline_all.csv
 
 baseline-gpu: develop
 	 rm -f baseline_*.csv
-	 python benchmarks/torchbench.py -dcuda --isolate -n100 --overhead
-	 python benchmarks/torchbench.py -dcuda --isolate -n100 --speedup-ts && mv baseline_ts.csv baseline_nnc.csv
-	 python benchmarks/torchbench.py -dcuda --isolate -n100 --speedup-ts --nvfuser && mv baseline_ts.csv baseline_nvfuser.csv
-	 python benchmarks/torchbench.py -dcuda --isolate -n100 --speedup-trt
-	 python benchmarks/torchbench.py -dcuda --isolate -n100 --speedup-onnx
+	 python benchmarks/torchbench.py -dcuda -n100 --overhead
+	 python benchmarks/torchbench.py -dcuda -n100 --speedup-ts && mv baseline_ts.csv baseline_nnc.csv
+	 python benchmarks/torchbench.py -dcuda -n100 --speedup-ts --nvfuser && mv baseline_ts.csv baseline_nvfuser.csv
+	 python benchmarks/torchbench.py -dcuda -n100 --speedup-trt
+	 python benchmarks/torchbench.py -dcuda -n100 --speedup-onnx
 	 paste -d, baseline_nnc.csv baseline_nvfuser.csv baseline_trt.csv baseline_onnx.csv > baseline_all.csv
 
 gpu-inductor-cudagraphs-fp32: develop

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -40,11 +40,11 @@ Running runner.py generates a file named `run.sh`. This file contains the actual
 One could directly call torchbench.py, huggingface.py or timm_models.py with the necessary flags. There are a lot of flags in the benchmarks runner. Some of the examples are as follows. These are subject to change.
 
 **Inference Commands**
-* TorchScript NVFuser Inference - `python benchmarks/torchbench.py -dcuda --isolate -n100 --speedup-ts`
+* TorchScript NVFuser Inference - `python benchmarks/torchbench.py -dcuda -n100 --speedup-ts`
 * TorchInductor CUDA Graphs Inference - `python benchmarks/torchbench.py -dcuda --inductor-settings --float32 -n50 --inductor`
 
 **Training Commands**
-* Torchscript (with TorchDynamo capture) NVFuser Training - `python benchmarks/torchbench.py --float32 -dcuda --training --nvfuser --speedup-dynamo-ts --use-eval-mode --isolate`
-* AOTAutograd Torchscript NVFuser Training - `python benchmarks/torchbench.py --float32 -dcuda --training --nvfuser --accuracy-aot-ts-mincut --use-eval-mode --isolate`
+* Torchscript (with TorchDynamo capture) NVFuser Training - `python benchmarks/torchbench.py --float32 -dcuda --training --nvfuser --speedup-dynamo-ts --use-eval-mode`
+* AOTAutograd Torchscript NVFuser Training - `python benchmarks/torchbench.py --float32 -dcuda --training --nvfuser --accuracy-aot-ts-mincut --use-eval-mode`
 
 Above commands are for torchbench models. You can simply replace `torchbench.py` with `huggingface.py` for HF models, and `timm_model.py` for TIMM models.

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -47,23 +47,23 @@ DEFAULT_OUTPUT_DIR = "benchmark_logs"
 
 TABLE = {
     "training": {
-        "ts_nnc": "--training --speedup-ts --use-eval-mode --isolate",
-        "ts_nvfuser": "--training --nvfuser --speedup-dynamo-ts --use-eval-mode --isolate",
-        "aot_eager": "--training --accuracy-aot-nop --generate-aot-autograd-stats --use-eval-mode --isolate",
-        "aot_nnc": "--training --accuracy-aot-ts-mincut --use-eval-mode --isolate",
-        "aot_nvfuser": "--training --nvfuser --accuracy-aot-ts-mincut --use-eval-mode --isolate",
-        "inductor_cudagraphs": "--training --inductor --use-eval-mode --isolate",
+        "ts_nnc": "--training --speedup-ts --use-eval-mode ",
+        "ts_nvfuser": "--training --nvfuser --speedup-dynamo-ts --use-eval-mode ",
+        "aot_eager": "--training --accuracy-aot-nop --generate-aot-autograd-stats --use-eval-mode ",
+        "aot_nnc": "--training --accuracy-aot-ts-mincut --use-eval-mode ",
+        "aot_nvfuser": "--training --nvfuser --accuracy-aot-ts-mincut --use-eval-mode ",
+        "inductor_cudagraphs": "--training --inductor --use-eval-mode",
     },
     "inference": {
-        "ts_nnc": "--isolate --speedup-ts",
-        "ts_nvfuser": "--isolate -n100 --speedup-ts --nvfuser",
-        "trt": "--isolate -n100 --speedup-trt",
+        "ts_nnc": "--speedup-ts",
+        "ts_nvfuser": "-n100 --speedup-ts --nvfuser",
+        "trt": "-n100 --speedup-trt",
         "eager_cudagraphs": "--inductor-settings --float32 -n50 --backend=cudagraphs",
         "nnc_cudagraphs": "--inductor-settings --float32 -n50 --backend=cudagraphs_ts --nvfuser",
         "ts_nvfuser_cudagraphs": "--inductor-settings --float32 -n50 --backend=cudagraphs_ts",
         "inductor_cudagraphs": "--inductor-settings --float32 -n50 --inductor",
     },
-    "coverage": {"dynamo_eager": "--isolate --coverage"},
+    "coverage": {"dynamo_eager": "--coverage"},
 }
 
 INFERENCE_COMPILERS = tuple(TABLE["inference"].keys())


### PR DESCRIPTION
Removes `isolate` option from benchmarking script.