### PR TITLE
[inductor] Fix argmax/argmin return type bug

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -2785,8 +2785,6 @@ class CommonTemplate:
             [
                 torch.randn([8, 256, 256]),
             ],
-            exact_dtype=False,  # FIXME
-            check_lowp=False,  # FIXME
         )
 
     def test_argmax_argmin2(self):
@@ -2803,8 +2801,26 @@ class CommonTemplate:
             [
                 torch.randn([144, 144]),
             ],
-            exact_dtype=False,  # FIXME
-            check_lowp=False,  # FIXME
+        )
+
+    @unittest.skip(
+        """
+        FIXME: In the case of having equally max/min elements, our implementation returns
+        the last index instead of the first one
+        """
+    )
+    def test_argmax_argmin3(self):
+        def fn(x):
+            return (
+                aten.argmax(x, 0),
+                aten.argmin(x, 0),
+                aten.argmax(x, -1),
+                aten.argmin(x, -1),
+            )
+
+        self.common(
+            fn,
+            [torch.randint(0, 5, [10, 10])],
         )
 
     def test_vdd_clamp(self):

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -567,7 +567,7 @@ class Kernel(CodeGen):
     def store(self, name, index, value, mode=None):
         raise NotImplementedError()
 
-    def reduction(self, name, dtype, reduction_type, index, value):
+    def reduction(self, name, dtype, src_dtype, reduction_type, index, value):
         raise NotImplementedError()
 
     def __enter__(self):
@@ -608,8 +608,10 @@ class Kernel(CodeGen):
                     return self.store(name, index, value, mode=mode)
 
             @staticmethod
-            def reduction(name, dtype, reduction_type, index, value):
-                return self.reduction(name, dtype, reduction_type, index, value)
+            def reduction(name, dtype, src_dtype, reduction_type, index, value):
+                return self.reduction(
+                    name, dtype, src_dtype, reduction_type, index, value
+                )
 
         super().__enter__()
         parent_handler = self.overrides(V.get_ops_handler())

--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -57,14 +57,14 @@ def reduction_combine(reduction_type, var, next_value):
 index_value_name_counter = 1
 
 
-def argmax_argmin_prefix(reduction_type, dtype, tmpvar):
+def argmax_argmin_prefix(reduction_type, src_dtype, tmpvar):
     global index_value_name_counter
     struct_name = f"IndexValue_{index_value_name_counter}"
     index_value_name_counter += 1
 
     prefix = [
-        f"struct {struct_name} {{size_t index; {DTYPE_TO_CPP[dtype]} value;}};",
-        f"{struct_name} {tmpvar}(0, {reduction_init(reduction_type, dtype)});",
+        f"struct {struct_name} {{long index; {DTYPE_TO_CPP[src_dtype]} value;}};",
+        f"{struct_name} {tmpvar}(0, {reduction_init(reduction_type, src_dtype)});",
     ]
     if reduction_type == "argmax":
         prefix.extend(
@@ -72,7 +72,7 @@ def argmax_argmin_prefix(reduction_type, dtype, tmpvar):
                 f"#pragma omp declare reduction(argmax : struct {struct_name} :\\",
                 "    omp_out.value = omp_in.value < omp_out.value ? omp_out.value : omp_in.value,\\",
                 "    omp_out.index = omp_in.value < omp_out.value ? omp_out.index : omp_in.index)\\",
-                f"\tinitializer(omp_priv = {{0, {reduction_init(reduction_type, dtype)}}})",
+                f"\tinitializer(omp_priv = {{0, {reduction_init(reduction_type, src_dtype)}}})",
             ]
         )
     elif reduction_type == "argmin":
@@ -81,7 +81,7 @@ def argmax_argmin_prefix(reduction_type, dtype, tmpvar):
                 f"#pragma omp declare reduction(argmin : struct {struct_name} :\\",
                 "    omp_out.value = omp_in.value > omp_out.value ? omp_out.value : omp_in.value,\\",
                 "    omp_out.index = omp_in.value > omp_out.value ? omp_out.index : omp_in.index)\\",
-                f"\tinitializer(omp_priv = {{0, {reduction_init(reduction_type, dtype)}}})",
+                f"\tinitializer(omp_priv = {{0, {reduction_init(reduction_type, src_dtype)}}})",
             ]
         )
     return prefix
@@ -321,7 +321,7 @@ class CppKernel(Kernel):
             raise NotImplementedError(f"store mode={mode}")
         self.stores.writeline(name, line)
 
-    def reduction(self, name, dtype, reduction_type, index, value):
+    def reduction(self, name, dtype, src_dtype, reduction_type, index, value):
         argmax_or_argmin = reduction_type in {"argmax", "argmin"}
         tmpvar = self.cse.generate(
             self.loads, f"reduction {name} {cexpr(index)}", write=False
@@ -330,7 +330,7 @@ class CppKernel(Kernel):
         self.reduction_vars[tmpvar] = reduction_type
         if argmax_or_argmin:
             self.reduction_prefix.writelines(
-                argmax_argmin_prefix(reduction_type, dtype, tmpvar)
+                argmax_argmin_prefix(reduction_type, src_dtype, tmpvar)
             )
             compare_op = "<" if reduction_type == "argmax" else ">"
             self.stores.writelines(

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -730,9 +730,9 @@ class TritonKernel(Kernel):
         if not self.inside_reduction:
             self.outside_loop_vars.add(value)
 
-    def reduction(self, name, dtype, reduction_type, index, value):
+    def reduction(self, name, dtype, src_dtype, reduction_type, index, value):
         assert self.inside_reduction
-        default = triton_constant(ir.Reduction.default_value(reduction_type, dtype))
+        default = triton_constant(ir.Reduction.default_value(reduction_type, src_dtype))
         masks = [f"{tree.prefix}mask" for tree in self.range_trees]
         if self._load_mask:
             masks.append(self._load_mask)
@@ -747,17 +747,17 @@ class TritonKernel(Kernel):
 
         dim = len(self.range_trees) - 1
         result_var = self.cse.newvar()
-        if (dtype, reduction_type, value) not in self.cse.reduction_cache:
-            self.cse.reduction_cache[(dtype, reduction_type, value)] = result_var
+        if (src_dtype, reduction_type, value) not in self.cse.reduction_cache:
+            self.cse.reduction_cache[(src_dtype, reduction_type, value)] = result_var
             accumulator = f"_{result_var}"
             self.body.writeline(
-                f"{accumulator} = tl.zeros({self.dense_size_str()}, {triton_compute_type(dtype)}) + {default}"
+                f"{accumulator} = tl.zeros({self.dense_size_str()}, {triton_compute_type(src_dtype)}) + {default}"
             )
             accumulator_index = None
             if reduction_type in {"argmax", "argmin"}:
                 accumulator_index = f"_{result_var}_index"
                 self.body.writeline(
-                    f"{accumulator_index} = tl.zeros({self.dense_size_str()}, tl.int32)"
+                    f"{accumulator_index} = tl.zeros({self.dense_size_str()}, tl.int64)"
                 )
 
             updated = value
@@ -798,7 +798,7 @@ class TritonKernel(Kernel):
                     f"{result_var} = tl.reshape(tl.{reduction_type}({accumulator}, {dim}), [{', '.join(sizes)}])"
                 )
         else:
-            var_name = self.cse.reduction_cache[(dtype, reduction_type, value)]
+            var_name = self.cse.reduction_cache[(src_dtype, reduction_type, value)]
             self.suffix.writeline(f"{result_var} = {var_name}")
         self.inside_reduction = False
         index, mask = self.indexing(index, result_var)

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -161,7 +161,7 @@ class RecordLoadStore(V.MockHandler):
         self._writes.add(MemoryDep(name, canonicalized_index, canonicalized_size))
         return f"store({name}, {index}, {value}, {mode})"
 
-    def reduction(self, name, dtype, reduction_type, index, value):
+    def reduction(self, name, dtype, src_dtype, reduction_type, index, value):
         return self.store(name, index, f"reduce_{reduction_type})({value})")
 
     def index_expr(self, index, dtype):

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -2505,6 +2505,7 @@ def make_reduction(reduction_type: str, override_dtype=None):
         result = Reduction.create(
             device=x.get_device(),
             dtype=override_dtype or x.get_dtype(),
+            src_dtype=x.get_dtype(),
             inner_fn=loader,
             ranges=new_size,
             reduction_ranges=reduced_sizes,
@@ -2711,8 +2712,8 @@ register_lowering(aten.min)(make_reduction("min"))
 register_lowering(aten.amax)(make_reduction("amax"))
 register_lowering(aten.amin)(make_reduction("amin"))
 register_lowering(aten.any)(make_reduction("any", override_dtype=torch.bool))
-register_lowering(aten.argmax)(make_reduction("argmax"))
-register_lowering(aten.argmin)(make_reduction("argmin"))
+register_lowering(aten.argmax)(make_reduction("argmax", override_dtype=torch.int64))
+register_lowering(aten.argmin)(make_reduction("argmin", override_dtype=torch.int64))
 
 add = register_pointwise(aten.add)
 exp = register_pointwise(aten.exp)

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -2504,7 +2504,7 @@ def make_reduction(reduction_type: str, override_dtype=None):
         inner_loader = x.make_loader()
         result = Reduction.create(
             device=x.get_device(),
-            dtype=override_dtype or x.get_dtype(),
+            dst_dtype=override_dtype or x.get_dtype(),
             src_dtype=x.get_dtype(),
             inner_fn=loader,
             ranges=new_size,
@@ -2703,7 +2703,7 @@ def sum_(x, axis=None, keepdims=False, *, dtype=None):
         is_integer_dtype(x.get_dtype()) or is_boolean_dtype(x.get_dtype())
     ) and dtype is None:
         dtype = torch.int64
-    fn = make_reduction("sum")
+    fn = make_reduction("sum", override_dtype=dtype)
     return fn(x, axis, keepdims, dtype=dtype)
 
 

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -425,9 +425,11 @@ class SimplifyIndexing(V.WrapperHandler):
         index = V.graph.sizevars.simplify_with_ranges(index, self._var_ranges)
         return self._inner.store(name, index, value, mode=mode)
 
-    def reduction(self, name, dtype, reduction_type, index, value):
+    def reduction(self, name, dtype, src_dtype, reduction_type, index, value):
         index = V.graph.sizevars.simplify_with_ranges(index, self._var_ranges)
-        return self._inner.reduction(name, dtype, reduction_type, index, value)
+        return self._inner.reduction(
+            name, dtype, src_dtype, reduction_type, index, value
+        )
 
     def index_expr(self, index, dtype):
         index = V.graph.sizevars.simplify_with_ranges(index, self._var_ranges)


### PR DESCRIPTION
Summary: Fix by tracking both the src dtype and the result dtype.
There is one remaining issue, https://github.com/pytorch/torchdynamo/issues/859