### PR TITLE
Add lru_cache to some hot spots related to sympy manipulation

### DIFF
--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -1,5 +1,6 @@
 import collections
 import contextlib
+import functools
 import itertools
 import logging
 import math
@@ -13,6 +14,7 @@ import sympy
 from sympy.printing.printer import Printer
 
 from .. import metrics
+from ..utils import freeze_inputs
 from ..utils import sympy_dot
 from ..utils import unique
 from ..virtualized import V
@@ -21,6 +23,8 @@ from ..virtualized import ops
 log = logging.getLogger(__name__)
 
 
+@freeze_inputs
+@functools.lru_cache(256)
 def _simplify_loops(index_vars, sizes, index_formulas):
     """
     Try to remove as many axis from loop iterations as possible, by:

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -663,12 +663,10 @@ class TritonKernel(Kernel):
         return index_str, " & ".join(mask)
 
     def var_ranges(self):
-        return (
-            dict(
-                itertools.chain.from_iterable(
-                    tree.var_ranges.items() for tree in self.range_trees
-                )
-            ),
+        return dict(
+            itertools.chain.from_iterable(
+                tree.var_ranges.items() for tree in self.range_trees
+            )
         )
 
     def codegen_indexing(self, expr: sympy.Expr):

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -10,6 +10,7 @@ from sympy import Expr
 from sympy import Integer
 from sympy import Symbol
 
+from .utils import freeze_inputs
 from .virtualized import V
 
 log = logging.getLogger(__name__)
@@ -60,6 +61,8 @@ class SizeVarAllocator(object):
     def simplify(self, expr):
         return sympy.expand(expr).subs(self.replacements)
 
+    @freeze_inputs
+    @functools.lru_cache(256)
     def simplify_with_ranges(self, expr, var_ranges):
         """
         Simplify indexing expression with knowledge of the ranges of

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -68,9 +68,6 @@ class SizeVarAllocator(object):
         from .ir import IndexingDiv
         from .ir import ModularIndexing
 
-        if isinstance(var_ranges, tuple):
-            assert len(var_ranges) == 1, var_ranges
-            var_ranges = var_ranges[0]
         expr = join_dimensions(self.simplify(expr))
         original_expr = expr
 
@@ -348,6 +345,7 @@ class SizeVarAllocator(object):
         return f"({', '.join(parts)})"
 
 
+@functools.lru_cache(256)
 def join_dimensions(expr: sympy.Expr) -> sympy.Expr:
     """
     ModularIndexing(i0, 1, 32) + 32 * ModularIndexing(i0, 32, 4)

--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -6,6 +6,8 @@ import numpy as np
 import sympy
 import torch
 from torch.cuda import synchronize
+from torch.fx.immutable_collections import immutable_dict
+from torch.fx.immutable_collections import immutable_list
 
 
 @functools.lru_cache(None)
@@ -75,3 +77,28 @@ def print_performance(fn, args=(), times=10, repeat=10, baseline=1.0):
     took = np.median(timings)
     print(f"{took/baseline:.6f}")
     return took
+
+
+immutable_dict.__hash__ = lambda self: hash(tuple(self.items()))
+immutable_list.__hash__ = lambda self: hash(tuple(self))
+
+
+def freeze_inputs(f):
+    """
+    Useful for wrapping lists in tuples for caching purposes
+    """
+
+    def freeze_value(x):
+        if isinstance(x, list):
+            return immutable_list(x)
+        if isinstance(x, dict):
+            return immutable_dict(x)
+        return x
+
+    @functools.wraps(f)
+    def wrapped(*args):
+        args = [freeze_value(x) for x in args]
+        return f(*args)
+
+    wrapped.cache_info = f.cache_info
+    return wrapped


### PR DESCRIPTION
Reduces compilation time (assuming no autotuning) by about 20-30%.

For ` time  ./benchmarks/torchbench.py -dcuda --inductor --float16 --training --only <model>`

Resnet18: 40s => 30s
densenet121: 2m32s => 2m
hf_Bert: 1m20 => 55s