### PR TITLE
Simplify as we're computing gcd

### DIFF
--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -186,7 +186,9 @@ class IndexingDiv(sympy.Function):
                     return IndexingDiv(base - a, divisor) + a / gcd
         gcd = sympy.gcd(base, divisor)
         if gcd != 1:
-            return IndexingDiv(base / gcd, divisor / gcd)
+            return IndexingDiv(
+                sympy.simplify(base / gcd), sympy.simplify(divisor / gcd)
+            )
 
 
 class CleanDiv(IndexingDiv):


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchdynamo/issues/870

```
s12 = sympy.symbols('s12', integer=True)
base = 3287040 - 256*s12
gcd = s12 - 12840
print(base/gcd)
>>> (3287040 - 256*s12)/(s12 - 12840)
```