### PR TITLE
Preserve stack trace over normalize()

### DIFF
--- a/torchdynamo/optimizations/normalize.py
+++ b/torchdynamo/optimizations/normalize.py
@@ -391,7 +391,7 @@ class Functionalization(Transformer):
 def swap_node(graph, old_node, new_node):
     old_node.replace_all_uses_with(new_node)
     graph.erase_node(old_node)
-    assert new_node.meta is None, "New node must not have meta populated"
+    assert not new_node.meta, "New node must not have meta populated"
     new_node.meta = old_node.meta
 
 

--- a/torchdynamo/optimizations/normalize.py
+++ b/torchdynamo/optimizations/normalize.py
@@ -391,6 +391,8 @@ class Functionalization(Transformer):
 def swap_node(graph, old_node, new_node):
     old_node.replace_all_uses_with(new_node)
     graph.erase_node(old_node)
+    assert new_node.meta is None, "New node must not have meta populated"
+    new_node.meta = old_node.meta
 
 
 def normalize(gm: torch.fx.GraphModule):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #874

This is needed for preserving stacktrace over  call_module and call_method nodes, as normalize() pass creates new fx.nodes. 

Alternatively, we can rewrite normalize() pass using the fx.Transformer pattern.  