### PR TITLE
Reducing Torchscript Verbosity

### DIFF
--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -291,8 +291,6 @@ def torchscript(model, example_inputs, verbose=True):
     try:
         return torch.jit.trace(model, example_inputs)
     except Exception:
-        if verbose:
-            log.exception("jit error")
         try:
             return torch.jit.script(model)
         except Exception:


### PR DESCRIPTION
`torch.jit.trace` fails when we use AMP. This creates really large logs, amounting to 15 GB while running OSS models.

Reducing to the verbosity to cases where both `jit.script` and `jit.trace` fails.