### PR TITLE
Add dynamo.explain() to help explain and fix graph breaks

### DIFF
--- a/torchdynamo/__init__.py
+++ b/torchdynamo/__init__.py
@@ -3,6 +3,7 @@ from . import convert_frame
 from . import eval_frame
 from . import resume_execution
 from .eval_frame import disable
+from .eval_frame import explain
 from .eval_frame import export
 from .eval_frame import optimize
 from .eval_frame import optimize_assert
@@ -16,6 +17,7 @@ __all__ = [
     "optimize",
     "optimize_assert",
     "export",
+    "explain",
     "run",
     "disable",
     "reset",

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -289,7 +289,7 @@ def get_compiler_fn(compiler_fn):
     return compiler_fn
 
 
-def optimize(backend, nopython=False):
+def optimize(backend, nopython=False, guard_export_fn=None):
     """
     The main entrypoint of TorchDynamo.  Do graph capture and call
     backend() to optimize extracted graphs.
@@ -323,10 +323,57 @@ def optimize(backend, nopython=False):
     backend_ctx_ctor = getattr(backend, "backend_ctx_ctor", null_context)
 
     if nopython:
-        return optimize_assert(backend, guard_export_fn=None)
+        return optimize_assert(backend, guard_export_fn=guard_export_fn)
     return _optimize_catch_errors(
-        convert_frame.convert_frame(backend, guard_export_fn=None), backend_ctx_ctor
+        convert_frame.convert_frame(backend, guard_export_fn=guard_export_fn),
+        backend_ctx_ctor,
     )
+
+
+def explain(f, *args, **kwargs):
+    out_guards = []
+    graphs = []
+    ops_per_graph = []
+    op_count = 0
+    break_reasons = []
+
+    def dynamo_graph_accumulating_compiler(gm: torch.fx.GraphModule, example_inputs):
+        nonlocal graphs
+        nonlocal op_count
+        nonlocal ops_per_graph
+
+        graphs.append(gm)
+        ops = []
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                ops.append(node.target)
+
+        op_count += len(ops)
+        ops_per_graph.append(ops)
+        if gm.compile_subgraph_reason is not None:
+            break_reasons.append(gm.compile_subgraph_reason)
+        return gm.forward
+
+    def guard_export_print(guards):
+        nonlocal out_guards
+        out_guards.append(guards)
+
+    with patch(f"{__name__}.most_recent_backend", None), optimize(
+        dynamo_graph_accumulating_compiler,
+        nopython=False,
+        guard_export_fn=guard_export_print,
+    ):
+        # TODO(voz): We may have instances of `f` that mutate inputs, we should track sideffects and reject.
+        f(*args, **kwargs)
+
+    graph_count = len(graphs)
+
+    formatted_list = ""
+    for idx in range(0, len(break_reasons)):
+        formatted_list += f"{idx + 1}. {break_reasons[idx]} \n"
+
+    explanation = f"Dynamo produced {graph_count} graphs, with {graph_count - 1} graph break and {op_count} ops. \n Break reasons: \n\n{formatted_list}"
+    return explanation, out_guards, graphs, ops_per_graph
 
 
 def export(f, *args, **kwargs):

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import torch
 import torch.utils._pytree as pytree
 
+import torchdynamo
 from torchdynamo.utils import checkpoint_params
 from torchdynamo.utils import clone_inputs
 from torchdynamo.utils import same
@@ -329,10 +330,10 @@ def optimize(backend, nopython=False, guard_export_fn=None):
     )
 
 
+@patch("torchdynamo.symbolic_convert.explain", True)
 def explain(f, *args, **kwargs):
-    import torchdynamo.symbolic_convert as symbolic_convert
-
-    symbolic_convert.explain = True
+    # TODO(voz): Do we want a decorator for this?
+    torchdynamo.reset()
 
     out_guards = []
     graphs = []
@@ -378,7 +379,9 @@ def explain(f, *args, **kwargs):
     explanation = f"Dynamo produced {graph_count} graphs"
     explanation += f"with {graph_count - 1} graph break and {op_count} ops"
     explanation += f"\n Break reasons: \n\n{formatted_list}"
-    symbolic_convert.explain = False
+
+    # TODO(voz): Do we want a decorator for this?
+    torchdynamo.reset()
     return explanation, out_guards, graphs, ops_per_graph
 
 

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -331,6 +331,7 @@ def optimize(backend, nopython=False, guard_export_fn=None):
 
 def explain(f, *args, **kwargs):
     import torchdynamo.symbolic_convert as symbolic_convert
+
     symbolic_convert.explain = True
 
     out_guards = []
@@ -374,7 +375,7 @@ def explain(f, *args, **kwargs):
     for idx in range(0, len(break_reasons)):
         formatted_list += f"{idx + 1}. {break_reasons[idx]} \n"
 
-    explanation = f"Dynamo produced {graph_count} graphs" 
+    explanation = f"Dynamo produced {graph_count} graphs"
     explanation += f"with {graph_count - 1} graph break and {op_count} ops"
     explanation += f"\n Break reasons: \n\n{formatted_list}"
     symbolic_convert.explain = False

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -330,6 +330,9 @@ def optimize(backend, nopython=False, guard_export_fn=None):
 
 
 def explain(f, *args, **kwargs):
+    import torchdynamo.symbolic_convert as symbolic_convert
+    symbolic_convert.explain = True
+
     out_guards = []
     graphs = []
     ops_per_graph = []
@@ -371,7 +374,10 @@ def explain(f, *args, **kwargs):
     for idx in range(0, len(break_reasons)):
         formatted_list += f"{idx + 1}. {break_reasons[idx]} \n"
 
-    explanation = f"Dynamo produced {graph_count} graphs, with {graph_count - 1} graph break and {op_count} ops. \n Break reasons: \n\n{formatted_list}"
+    explanation = f"Dynamo produced {graph_count} graphs" 
+    explanation += f"with {graph_count - 1} graph break and {op_count} ops"
+    explanation += f"\n Break reasons: \n\n{formatted_list}"
+    symbolic_convert.explain = False
     return explanation, out_guards, graphs, ops_per_graph
 
 

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -218,12 +218,17 @@ class OutputGraph(fx.Tracer):
 
         assert False
 
-    def compile_subgraph(self, tx, partial_convert=False):
+    def compile_subgraph(self, tx, partial_convert=False, msg=None):
         """
         Generate a subgraph to continue execution on user code.
         Automatically restore live variables.
         """
         self.partial_convert = partial_convert
+        if msg is not None:
+            stack = tx.frame_summary()
+            msgs = reversed(traceback.StackSummary.from_list([stack]).format())
+            msg = f"{msg} \n {''.join(msgs)}"
+        self.compile_subgraph_reason = msg
 
         if not all(block.can_restore() for block in tx.block_stack):
             unimplemented("compile_subgraph with block_depth != 0")
@@ -345,6 +350,7 @@ class OutputGraph(fx.Tracer):
 
         gm = fx.GraphModule(root, self.graph)
         gm.recompile()
+        gm.compile_subgraph_reason = self.compile_subgraph_reason
         name = unique_id("__compiled_fn")
         compiled_fn = self.call_user_compiler(gm)
         compiled_fn = torchdynamo.disable(compiled_fn)

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -118,7 +118,6 @@ def generic_jump(truth_fn: typing.Callable, push: bool):
         elif isinstance(value, TensorVariable) and self.should_compile_partial_graph():
             # compile a partial subgraph prefix then jump into user code
             self.push(value)
-            # This is a rare compile_subgraph that bypasses unimplemented
             self.output.compile_subgraph(self, msg="generic_jump")
             self.pop()
 

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -143,6 +143,8 @@ def generic_jump(truth_fn: typing.Callable, push: bool):
 
 
 explain = False
+
+
 def break_graph_if_unsupported(*, push):
     def decorator(inner_fn):
         @functools.wraps(inner_fn)
@@ -161,8 +163,8 @@ def break_graph_if_unsupported(*, push):
                         + list(reversed(exc.real_stack))
                     )
                 )
-                
-                # torchdynamo.explain() formats this a little nicer, and presents a slightly 
+
+                # torchdynamo.explain() formats this a little nicer, and presents a slightly
                 # more actionable user code pointer
                 if not explain:
                     log.warning(f"Graph break: {exc} from user code at:\n {user_stack}")

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -142,6 +142,7 @@ def generic_jump(truth_fn: typing.Callable, push: bool):
     return inner
 
 
+explain = False
 def break_graph_if_unsupported(*, push):
     def decorator(inner_fn):
         @functools.wraps(inner_fn)
@@ -160,8 +161,11 @@ def break_graph_if_unsupported(*, push):
                         + list(reversed(exc.real_stack))
                     )
                 )
-
-                log.warning(f"Graph break: {exc} from user code at:\n {user_stack}")
+                
+                # torchdynamo.explain() formats this a little nicer, and presents a slightly 
+                # more actionable user code pointer
+                if not explain:
+                    log.warning(f"Graph break: {exc} from user code at:\n {user_stack}")
 
                 exc.remove_from_stats()
                 exc.add_to_stats("graph_break")

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -328,21 +328,7 @@ class InstructionTranslatorBase(object):
                 and self.step()
             ):
                 pass
-        except (
-            exc.BackendCompilerFailed,
-            exc.RestartAnalysis,
-            exc.SkipFrame,
-            exc.TorchRuntimeError,
-            exc.Unsupported,
-        ) as e:
-            raise
-        except Exception as e:
-            if config.debug or config.trace or config.print_internal_exceptions:
-                sys.stderr.write(
-                    f"ERROR FROM offset={self.current_instruction.offset} "
-                    f"filename {self.code_options.get('co_filename')} "
-                    f"{self.lineno} {typestr(e)}\n"
-                )
+        except Exception:
             raise
         finally:
             # Cleanup the outputGraph to delete the held tensors. We perform the


### PR DESCRIPTION
```py
from typing import List

import torch

import torchdynamo


def my_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
    print("my_compiler() called with FX graph:")
    gm.graph.print_tabular()
    return gm.forward  # return a python callable


def toy_example(a, b):
    x = a / (torch.abs(a) + 1)
    print("woo")
    if b.sum() < 0:
        b = b * -1
    return x * b

explained = torchdynamo.explain(toy_example, torch.randn(10), torch.randn(10))
print(explained[0])

"""
Dynamo produced 3 graphs, with 2 graph break and 6 ops. 
 Break reasons: 

1. call_function BuiltinVariable(print) [ConstantVariable(str)] {} 
   File "t2.py", line 16, in toy_example
    print("woo")
 
2. generic_jump 
   File "t2.py", line 17, in toy_example
    if b.sum() < 0:
 """
 ```