### PR TITLE
Fix stack summary order to comply with fx's stack trace order

### DIFF
--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -457,7 +457,7 @@ class OutputGraph(fx.Tracer):
             frame_summaries.append(tx.frame_summary())
             tx = getattr(tx, "parent", None)
 
-        msgs = reversed(traceback.StackSummary.from_list(frame_summaries).format())
+        msgs = traceback.StackSummary.from_list(frame_summaries).format()
         rv.node.stack_trace = "".join(msgs)
 
         return rv


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #899

This is needed for https://github.com/pytorch/pytorch/pull/83706