### PR TITLE
[Not for land]specialize for OUT_H=OUT_W=1 conv

### DIFF
--- a/benchmarks/microbenchmarks/model.py
+++ b/benchmarks/microbenchmarks/model.py
@@ -24,3 +24,9 @@ alexnet_layers = (
     # IN_H, IN_W, IN_C, KERNEL_H, KERNEL_W, KERNEL_N, stride, padding
     (224, 224, 3, 11, 11, 64, (4, 4), (2, 2)),
 )
+
+
+test_layers = (
+    # IN_H, IN_W, IN_C, KERNEL_H, KERNEL_W, KERNEL_N, stride, padding
+    (2, 2, 256, 3, 3, 256, (2, 2), (1, 1)),
+)


### PR DESCRIPTION
Specialize for convolution where IN_H <= KERNEL_H and IN_W <= KERNEL_W, OUT_H=OUT_W=1
in such case, we should assume loading inputs contiguously, and precompute ptr updates for kernel. So that we could make fully use of the loading bandwidth when IN_H < KERNEL_H and  IN_W < KERNEL_W;
However, I have to add `delta_w_ptrs = tl.multiple_of(delta_w_ptrs, 1)` to force triton not to vectorize, otherwise it will throw map::at error. Although it is still much slower than aten.convolution, but is faster than the previous triton conv 
For layer IN_H, IN_W, IN_C, KERNEL_H, KERNEL_W, KERNEL_N, stride, padding = 2, 2, 256, 3, 3, 256, (2, 2), (1, 1)
The TFLOPS are
| layout   | cuBLAS   | specialized  conv | old conv  |
| ------- | ---------| -------------| ------------|
nchw  | 0.877714 | 0.472615  |   0.142884
nhwc  | 0.921600 | 0.472615  |  0.142884
