### PR TITLE
Adding eval mode for TIMM model training to check accuracy

### DIFF
--- a/benchmarks/timm_models.py
+++ b/benchmarks/timm_models.py
@@ -80,14 +80,7 @@ BATCH_SIZE_DIVISORS = {
     "xcit_large_24_p8_224": 4,
 }
 
-# https://github.com/pytorch/torchdynamo/issues/611
-REQUIRE_HIGHER_TOLERANCE = {
-    "adv_inception_v3",
-    "convmixer_768_32",
-    "convnext_base",
-    "gluon_inception_v3",
-    "inception_v3",
-}
+REQUIRE_HIGHER_TOLERANCE = set()
 
 
 def refresh_model_names():
@@ -245,6 +238,11 @@ class TimmRunnner(BenchmarkRunner):
         self.target = self._gen_target(batch_size, device)
 
         self.loss = torch.nn.CrossEntropyLoss().to(device)
+        if is_training and not use_eval_mode:
+            model.train()
+        else:
+            model.eval()
+
         return device, model_name, model, example_inputs, batch_size
 
     def iter_models(self, args):


### PR DESCRIPTION
This was exposed by the dashboard where the accuracy pass rate for `aot_nvfuser` suddenly tanked.

This also resolved one other issue about decompositions. Earlier, I incorrectly attributed the accuracy differences to decompositions, but it was just the model.eval was not switched on.

Ideal state would be to test accuracy with model.train() turned on. We will look into this next.