### PR TITLE
Support lowering symbolic shapes from tracer.

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -3046,6 +3046,21 @@ class CommonTemplate:
         args = [rand_strided(shape, stride, dtype) for shape, stride, dtype in args]
         self.common(forward, args)
 
+    def test_symbolic(self):
+        def f(x):
+            x = x.cos()
+            x = x.view(x.shape[0] * 2, -1)
+            return (x,)
+
+        traced = make_fx(f, tracing_mode="symbolic")(torch.randn(8, 4))
+        compiled = compile_fx_inner(traced, [torch.randn(8, 4)])
+
+        out = compiled(torch.randn(8, 4))
+        self.assertEqual(out[0].shape, (16, 2))
+
+        out = compiled(torch.randn(12, 4))
+        self.assertEqual(out[0].shape, (24, 2))
+
 
 if HAS_CPU:
 

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -4,17 +4,11 @@ debug = False
 # dead code elimination
 dce = False
 
-# assume there will be no backwards
-forward_only = False
-
 # assume input tensors are dynamic
 dynamic_shapes = True
 
 # assume weight tensors are fixed size
 static_weight_shapes = True
-
-# enable some approximation algorithms
-approximations = False
 
 # put correctness assertions in generated code
 size_asserts = True

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -213,12 +213,6 @@ class GraphLowering(torch.fx.Interpreter):
         if target is operator.getitem and isinstance(args[0], (list, tuple)):
             return super().call_function(target, args, kwargs)
 
-        print(target)
-        if target == torch.ops.aten.size:
-            return args[0].get_size()[args[1]]
-        if target == torch.ops.math.mul:
-            return args[0] * args[1]
-
         if target not in lowerings:
             if get_decompositions([target]):
                 # There isn't a good way to dynamically patch this in

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -214,10 +214,8 @@ class GraphLowering(torch.fx.Interpreter):
             return super().call_function(target, args, kwargs)
 
         print(target)
-        if target == torch.ops.math.size:
+        if target == torch.ops.aten.size:
             return args[0].get_size()[args[1]]
-        if target == torch.ops.math.stride:
-            return args[0].get_stride()[args[1]]
         if target == torch.ops.math.mul:
             return args[0] * args[1]
 

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -213,6 +213,14 @@ class GraphLowering(torch.fx.Interpreter):
         if target is operator.getitem and isinstance(args[0], (list, tuple)):
             return super().call_function(target, args, kwargs)
 
+        print(target)
+        if target == torch.ops.math.size:
+            return args[0].get_size()[args[1]]
+        if target == torch.ops.math.stride:
+            return args[0].get_stride()[args[1]]
+        if target == torch.ops.math.mul:
+            return args[0] * args[1]
+
         if target not in lowerings:
             if get_decompositions([target]):
                 # There isn't a good way to dynamically patch this in
@@ -248,6 +256,9 @@ class GraphLowering(torch.fx.Interpreter):
         return self.add_tensor_constant(value)
 
     def call_module(self, target, args, kwargs):
+        assert False
+
+    def call_method(self, target, args, kwargs):
         assert False
 
     def output(self, target, args, kwargs):

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1,6 +1,7 @@
 import functools
 import itertools
 import logging
+import operator
 from collections.abc import Iterable
 from typing import List
 
@@ -2906,18 +2907,11 @@ register_inplace(aten.relu_, relu)
 register_inplace(aten.sigmoid_, sigmoid)
 
 
-@register_lowering(aten.size)
-def size(a, dim):
+@register_lowering(aten.sym_size)
+def sym_size(a, dim):
     return a.get_size()[dim]
 
 
-try:
-    math = torch.ops.math
-
-    @register_lowering(math.mul)
-    def mul(a, b):
-        return a * b
-
-
-except:
-    pass
+@register_lowering(operator.mul)
+def op_mul(a, b):
+    return a * b


### PR DESCRIPTION
Relies on https://github.com/pytorch/pytorch/pull/83719

POC.

```
import torchinductor
torchinductor.config.debug = True
torchinductor.config.dynamic_shapes = True

def f(x):
    a = torch.ones(1)
    b = a.expand(x.shape).cos()
    return (b,)

inp = [torch.randn(4, 5)]
res = make_fx(f, tracing_mode="symbolic")(*inp)
res.graph.eliminate_dead_code()
res.recompile()
print(res.code)
compiled = compile_fx_inner(res, inp)

import time
begin = time.time()
for i in range(1, 10):
    out = compiled(torch.ones(i, i))
    print(out)

print(time.time()-begin)
```