### PR TITLE
Add version comments to minifier for easier to reproduce repros

### DIFF
--- a/torchinductor/debug_utils.py
+++ b/torchinductor/debug_utils.py
@@ -11,7 +11,7 @@ from torchinductor.codecache import cache_dir
 
 def generate_repro_string(gm, args):
     model_str = textwrap.dedent(
-        f"""
+        """
         import torch
         from torch import tensor, device
         import torch.fx as fx

--- a/torchinductor/debug_utils.py
+++ b/torchinductor/debug_utils.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import textwrap
 import uuid
+
 import torch
 
 import torchdynamo
@@ -25,9 +26,11 @@ def generate_repro_string(gm, args):
     model_str += f"# torch cuda version: {torch.version.cuda}\n"
     model_str += f"# torch git version: {torch.version.git_version}\n\n\n"
     if torch.cuda.is_available():
-        cuda_version_out = subprocess.run(['nvcc', '--version'], stdout=subprocess.PIPE)
+        cuda_version_out = subprocess.run(["nvcc", "--version"], stdout=subprocess.PIPE)
         cuda_version_lines = cuda_version_out.stdout.decode().split("\n")
-        cuda_version_out = "".join([f"# {s} \n" for s in cuda_version_lines if s not in ['']])
+        cuda_version_out = "".join(
+            [f"# {s} \n" for s in cuda_version_lines if s not in [""]]
+        )
         model_str += f"{cuda_version_out}\n\n"
 
     model_str += "class Repro(torch.nn.Module):\n"

--- a/torchinductor/debug_utils.py
+++ b/torchinductor/debug_utils.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import textwrap
 import uuid
+from collections import Counter
 
 import torch
 
@@ -26,12 +27,29 @@ def generate_repro_string(gm, args):
     model_str += f"# torch cuda version: {torch.version.cuda}\n"
     model_str += f"# torch git version: {torch.version.git_version}\n\n\n"
     if torch.cuda.is_available():
+        model_str += "# CUDA Info: \n"
         cuda_version_out = subprocess.run(["nvcc", "--version"], stdout=subprocess.PIPE)
         cuda_version_lines = cuda_version_out.stdout.decode().split("\n")
         cuda_version_out = "".join(
             [f"# {s} \n" for s in cuda_version_lines if s not in [""]]
         )
-        model_str += f"{cuda_version_out}\n\n"
+        model_str += f"{cuda_version_out}\n"
+        gpu_names = subprocess.run(
+            ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv"],
+            stdout=subprocess.PIPE,
+        )
+        gpu_names = gpu_names.stdout.decode().split("\n")
+        gpu_names = [name for name in gpu_names if name not in ("", "name")]
+        gpu_names = Counter(gpu_names)
+
+        model_str += "# GPU Hardware Info: \n"
+        for name, count in gpu_names.items():
+            model_str += f"# {name} : {count} \n"
+        model_str += "\n"
+    else:
+        model_str += (
+            "torch.cuda.is_available() returned False - no GPU info collected \n"
+        )
 
     model_str += "class Repro(torch.nn.Module):\n"
     attrs = dir(gm)


### PR DESCRIPTION
Sample of what the top of the Repro file looks like now:

```
import torch
from torch import tensor, device
import torch.fx as fx
from torchdynamo.testing import rand_strided
from math import inf
from torchinductor.compile_fx import compile_fx_inner
from torch.fx.experimental.proxy_tensor import make_fx

# torch version: 1.13.0.dev20220807+cu116
# torch cuda version: 11.6
# torch git version: c50657628024720a25aa07ba3d2db1e6a8ba021b


# nvcc: NVIDIA (R) Cuda compiler driver 
# Copyright (c) 2005-2022 NVIDIA Corporation 
# Built on Thu_Feb_10_18:23:41_PST_2022 
# Cuda compilation tools, release 11.6, V11.6.112 
# Build cuda_11.6.r11.6/compiler.30978841_0 


class Repro(torch.nn.Module):
```