### PR TITLE
[Reland #899]Fix stack summary order to comply with fx's stack trace order

### DIFF
--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -457,7 +457,6 @@ class OutputGraph(fx.Tracer):
             frame_summaries.append(tx.frame_summary())
             tx = getattr(tx, "parent", None)
 
-        msgs = reversed(traceback.StackSummary.from_list(frame_summaries).format())
+        msgs = traceback.StackSummary.from_list(frame_summaries).format()
         rv.node.stack_trace = "".join(msgs)
-
         return rv


### PR DESCRIPTION
Previous PR created by ghstack didn't have the target merge branch setup properly.

ghstack-source-id: 829991f27b0d0347d1ff2705932c82ad50336c97
Pull Request resolved: https://github.com/pytorch/torchdynamo/pull/899