### PR TITLE
Automatically resolve DynamicShapeVariable to TensorVariable when calling torch.clamp

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -2079,6 +2079,15 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertRaises(torchdynamo.exc.ResetRequired, fn3)
         fn2()
 
+    def test_dynamo_min_operator_with_shape(self):
+        with torchdynamo.optimize("eager", nopython=True):
+
+            def f(x, a):
+                return min(x.shape[0], a)
+
+            result = f(torch.ones(6), 3)
+            self.assertEqual(result, 3)
+
 
 class TestTracer(JitTestCase):
     def test_jit_save(self):

--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -362,9 +362,9 @@ class BuiltinVariable(VariableTracker):
                 a, b = b, a
             assert isinstance(a, variables.TensorVariable)
 
-            # result of an item call is a scalar
-            # convert to a tensor
-            if isinstance(a, FakeItemVariable):
+            # 1. result of an item call is a scalar convert to a tensor
+            # 2. dynamic shape should be resolved to tensor
+            if isinstance(a, (FakeItemVariable, DynamicShapeVariable)):
                 a = variables.TorchVariable(torch.tensor).call_function(tx, [a], {})
 
             # convert min/max to torch ops


### PR DESCRIPTION
Fixes: https://github.com/pytorch/torchdynamo/issues/911