### PR TITLE
FakeTensor should be wrapped as TensorVariable

### DIFF
--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -182,9 +182,14 @@ def is_numpy_float_type(value):
 
 def istensor(obj):
     """Check of obj is a tensor"""
-    return istype(
-        obj, (torch.Tensor, torch.nn.Parameter, *config.traceable_tensor_subclasses)
+    tensor_list = (
+        torch.Tensor,
+        torch.nn.Parameter,
+        *config.traceable_tensor_subclasses,
     )
+    if fake_tensors_available:
+        tensor_list = tensor_list + (torch._subclasses.FakeTensor,)
+    return istype(obj, tensor_list)
 
 
 def is_lazy_module(mod):


### PR DESCRIPTION
This comes from the discussion with @anijain2305 on if ```tensor.grad``` should be a ```TensorVariable```, obviously the answer is YES. However, I found there are many places we wrap tensor as ```UserDefinedObjectVariable```. We dig into this together and found ```FakeTensor``` was not considered as tensor type and wrap as tensor, which should be fixed.