### PR TITLE
Fix multi-level import issue

### DIFF
--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -12,6 +12,7 @@ from torch.nn import functional as F
 import torchdynamo.testing
 from torchdynamo.testing import requires_static_shapes
 
+tensor_for_import_testing = torch.ones(10, 10)
 d = torch.ones(10, 10)
 e = torch.nn.Linear(10, 10)
 flag = True

--- a/test/test_repros.py
+++ b/test/test_repros.py
@@ -45,15 +45,6 @@ def has_detectron2():
         return False
 
 
-def has_scipy():
-    try:
-        import scipy.sparse
-
-        return scipy.sparse.coo_matrix is not None
-    except ImportError:
-        return False
-
-
 def _do_paste_mask(masks, boxes, img_h: int, img_w: int, skip_empty: bool = True):
     # from detectron2 mask_ops.py
 
@@ -1499,12 +1490,11 @@ class ReproTests(torchdynamo.testing.TestCase):
 
         self.assertTrue((to_bitmasks(torch.zeros(10)) == torch.ones(10)).all())
 
-    @unittest.skipIf(not has_scipy(), "requires scipy")
-    def test_scipy_import(self):
+    def test_two_level_import(self):
         def fn():
-            import scipy.sparse
+            import torch.fx
 
-            print(scipy.sparse.coo_matrix)
+            print(torch.fx.symbolic_trace)
 
         opt_fn = torchdynamo.optimize("eager")(fn)
         opt_fn()

--- a/test/test_repros.py
+++ b/test/test_repros.py
@@ -1501,19 +1501,10 @@ class ReproTests(torchdynamo.testing.TestCase):
 
     @unittest.skipIf(not has_scipy(), "requires scipy")
     def test_scipy_import(self):
-        from torch.testing._internal.common_utils import random_sparse_pd_matrix
-
         def fn():
             import scipy.sparse
 
-            m = 500
-
-            A = random_sparse_pd_matrix(
-                m, density=2.0 / m, device="cpu", dtype=torch.float64
-            )
-            values = A.coalesce().values().cpu().numpy().copy()
-            indices = A.coalesce().indices().cpu().numpy().copy()
-            return scipy.sparse.coo_matrix((values, (indices[0], indices[1])), A.shape)
+            print(scipy.sparse.coo_matrix)
 
         opt_fn = torchdynamo.optimize("eager")(fn)
         opt_fn()

--- a/test/test_repros.py
+++ b/test/test_repros.py
@@ -1490,9 +1490,7 @@ class ReproTests(torchdynamo.testing.TestCase):
 
         self.assertTrue((to_bitmasks(torch.zeros(10)) == torch.ones(10)).all())
 
-    def test_two_level_import(self):
-        import logging
-
+    def test_multi_dot_import(self):
         def fn1(x):
             return torch.sin(x)
 
@@ -1509,22 +1507,31 @@ class ReproTests(torchdynamo.testing.TestCase):
         opt_fn(x)
         self.assertEqual(cnt.frame_count, 1)
 
-    # TODO - This test fails
-    # def test_two_level_relative_import(self):
-    #     import logging
-    #     def fn1(x):
-    #         return torch.sin(x)
+    def test_relative_import(self):
+        def fn(x):
+            from .test_functions import tensor_for_import_testing
 
-    #     def fn(x):
-    #         from . import test_functions
-    #         return x * 2
+            return x * 2 * tensor_for_import_testing
 
-    #     x = torch.randn(10)
-    #     fn(x)
-    #     cnt = torchdynamo.testing.CompileCounter()
-    #     opt_fn = torchdynamo.optimize(cnt)(fn)
-    #     opt_fn(x)
-    #     self.assertEqual(cnt.frame_count, 1)
+        x = torch.randn(10)
+        fn(x)
+        cnt = torchdynamo.testing.CompileCounter()
+        opt_fn = torchdynamo.optimize(cnt, nopython=True)(fn)
+        opt_fn(x)
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_relative_import_no_modulename(self):
+        def fn(x):
+            from . import test_functions
+
+            return x * 2 * test_functions.tensor_for_import_testing
+
+        x = torch.randn(10)
+        fn(x)
+        cnt = torchdynamo.testing.CompileCounter()
+        opt_fn = torchdynamo.optimize(cnt, nopython=True)(fn)
+        opt_fn(x)
+        self.assertEqual(cnt.frame_count, 1)
 
 
 if __name__ == "__main__":

--- a/test/test_repros.py
+++ b/test/test_repros.py
@@ -47,9 +47,9 @@ def has_detectron2():
 
 def has_scipy():
     try:
-        import scipy
+        import scipy.sparse
 
-        return True
+        return scipy.sparse.coo_matrix is not None
     except ImportError:
         return False
 

--- a/test/test_repros.py
+++ b/test/test_repros.py
@@ -45,6 +45,15 @@ def has_detectron2():
         return False
 
 
+def has_scipy():
+    try:
+        import scipy
+
+        return True
+    except ImportError:
+        return False
+
+
 def _do_paste_mask(masks, boxes, img_h: int, img_w: int, skip_empty: bool = True):
     # from detectron2 mask_ops.py
 
@@ -1489,6 +1498,16 @@ class ReproTests(torchdynamo.testing.TestCase):
                 return boxes + 1
 
         self.assertTrue((to_bitmasks(torch.zeros(10)) == torch.ones(10)).all())
+
+    @unittest.skipIf(not has_scipy(), "requires scipy")
+    def test_scipy_import(self):
+        def fn(device="cpu", dtype=torch.float64):
+            import scipy.sparse
+
+            print(scipy.sparse.coo_matrix)
+
+        opt_fn = torchdynamo.optimize("eager")(fn)
+        opt_fn()
 
 
 if __name__ == "__main__":

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -450,7 +450,12 @@ class InstructionTranslatorBase(object):
             fromlist=fromlist.as_python_constant(),
             level=level.as_python_constant(),
         )
-        source = self.import_source(module_name)
+        # __import__ returns the top level package name, so the source has to be
+        # set correctly.
+        if fromlist.as_python_constant() is None and hasattr(value, "__name__"):
+            source = self.import_source(getattr(value, "__name__"))
+        else:
+            source = self.import_source(module_name)
 
         if is_allowed(value):
             self.push(TorchVariable(value, source=source))

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -458,8 +458,9 @@ class InstructionTranslatorBase(object):
         # returned, not the module named by module_name. However, when a
         # non-empty fromlist argument is given, the module named by name is
         # returned. Therefore, we set the source correctly here.
-        if fromlist is None and hasattr(value, "__name__"):
-            source = self.import_source(getattr(value, "__name__"))
+        if not fromlist:
+            top_level_module_name = module_name.partition(".")[0]
+            source = self.import_source(top_level_module_name)
         else:
             source = self.import_source(module_name)
 

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -446,6 +446,7 @@ class InstructionTranslatorBase(object):
         """
         Copied from the Cpython implementation of __import__
         Resolve a relative module name to an absolute one.
+        https://github.com/python/cpython/blob/5a094f0255eea1db58fb2cf14c200971e64ec36e/Lib/importlib/_bootstrap.py#L902
         """
         bits = package.rsplit(".", level - 1)
         if len(bits) < level:
@@ -456,6 +457,7 @@ class InstructionTranslatorBase(object):
     def calc_package(self):
         """
         Copied from the Cpython implementation of __import__
+        https://github.com/python/cpython/blob/5a094f0255eea1db58fb2cf14c200971e64ec36e/Lib/importlib/_bootstrap.py#L1090
         """
         package = self.f_globals.get("__package__")
         spec = self.f_globals.get("__spec__")


### PR DESCRIPTION
`__import__` brings in the top level module when fromlist is empty. For example, `__import__` of `scipy.sparse` brings just `scipy`. More details at - https://docs.python.org/3/library/functions.html#import__

However, our handling of `IMPORT_NAME` bytecode did not handle it correctly, and the source was still pointing to `scipy.sparse`.

This should fix one issue in https://github.com/pytorch/pytorch/pull/83575

cc @ezyang 
