### PR TITLE
Make the graph break warning more compact.

### DIFF
--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -48,7 +48,6 @@ from .resume_execution import ContinueExecutionCache
 from .resume_execution import ReenterWith
 from .utils import counters
 from .utils import fake_tensors_available
-from .utils import filter_stack
 from .utils import istype
 from .variables.base import MutableLocal
 from .variables.base import VariableTracker

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -158,16 +158,14 @@ def break_graph_if_unsupported(*, push):
                     raise
                 user_stack = "".join(
                     traceback.format_list(
-                        filter_stack(traceback.extract_stack())
-                        + [self.frame_summary()]
-                        + list(reversed(exc.real_stack))
+                        [([self.frame_summary()] + list(reversed(exc.real_stack)))[-1]]
                     )
-                )
+                ).strip()
 
                 # torchdynamo.explain() formats this a little nicer, and presents a slightly
                 # more actionable user code pointer
                 if not explain:
-                    log.warning(f"Graph break: {exc} from user code at:\n {user_stack}")
+                    log.warning(f"Graph break: {exc} from user code at {user_stack}")
 
                 exc.remove_from_stats()
                 exc.add_to_stats("graph_break")


### PR DESCRIPTION
Partially addresses https://github.com/pytorch/torchdynamo/issues/943

It would be nice to also tell the user how to get a full stack
trace but it didn't seem like this was all that useful.

Before:

```
Torchdynamo: [WARNING] Graph break: numpy from user code at:
   File "benchmarks/torchbench.py", line 363, in <module>
    main(TorchBenchmarkRunner(), original_dir)
  File "/raid/ezyang/torchdynamo/benchmarks/common.py", line 1727, in main
    runner.run_one_model(
  File "/raid/ezyang/torchdynamo/benchmarks/common.py", line 1074, in run_one_model
    new_result = optimized_model_iter_fn(model, example_inputs)
  File "benchmarks/torchbench.py", line 347, in forward_and_backward_pass
    def forward_and_backward_pass(self, mod, inputs, collect_outputs=True):
  File "benchmarks/torchbench.py", line 347, in forward_and_backward_pass
    def forward_and_backward_pass(self, mod, inputs, collect_outputs=True):
  File "benchmarks/torchbench.py", line 351, in forward_and_backward_pass
    pred = mod(*cloned_inputs)
  File "/raid/ezyang/pytorch-scratch2/torch/nn/modules/module.py", line 1185, in _call_impl
    return forward_call(*input, **kwargs)
  File "/scratch/ezyang/pytorch-scratch2-env/lib/python3.8/site-packages/transformers/models/big_bird/modeling_big_bird.py", line 2385, in forw
ard
    @add_start_docstrings_to_model_forward(BIG_BIRD_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
  File "/raid/ezyang/pytorch-scratch2/torch/nn/modules/module.py", line 1185, in _call_impl
    return forward_call(*input, **kwargs)
  File "/scratch/ezyang/pytorch-scratch2-env/lib/python3.8/site-packages/transformers/models/big_bird/modeling_big_bird.py", line 1979, in forw
ard
    @add_start_docstrings_to_model_forward(BIG_BIRD_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
  ...
```

After:

```
Torchdynamo: [WARNING] Graph break: numpy from user code at File "/scratch/ezyang/pytorch-scratch2-env/lib/python3.8/site-packages/transformers
/models/big_bird/modeling_big_bird.py", line 1085, in _bigbird_block_rand_mask
    rand_attn = np.zeros((from_seq_length // from_block_size - 2, num_rand_blocks), dtype=np.int32)
```

It's still too chatty though: it seems to warn about the graph
break every single time through the code.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>
