### PR TITLE
Enable verbosity config for errors

### DIFF
--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -20,6 +20,9 @@ except ImportError:
 # ERROR print exceptions (and what user code was being processed when it occurred)
 log_level = logging.WARNING
 
+# Verbose will print full stack traces on warnings and errors
+verbose = False
+
 # verify the correctness of optimized backend
 verify_correctness = False
 

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -34,6 +34,7 @@ from .symbolic_convert import InstructionTranslator
 from .utils import CleanupManager
 from .utils import counters
 from .utils import filter_stack
+from .utils import format_bytecode
 from .utils import guard_failures
 from .utils import init_logging
 from .utils import is_namedtuple
@@ -182,25 +183,34 @@ def has_tensor_in_frame(frame):
     return False
 
 
-def format_exception(exc, frame):
+def format_error_msg(exc, frame):
     msg = os.linesep * 2
-    msg += "=" * 10 + " TorchDynamo Stack Trace " + "=" * 10 + "\n"
-    msg += traceback.format_exc()
-    if hasattr(exc, "real_stack"):
-        msg += (
-            "\n"
-            + "=" * 10
-            + " The above exception occurred while processing the following code "
-            + "=" * 10
-            + "\n\n"
-        )
-        msg += "".join(
-            traceback.format_list(
-                filter_stack(traceback.extract_stack(frame))
-                + list(reversed(exc.real_stack))
+    if config.verbose:
+        msg = format_bytecode("WON'T CONVERT", frame, frame.f_code)
+        msg += "=" * 10 + " TorchDynamo Stack Trace " + "=" * 10 + "\n"
+        msg += traceback.format_exc()
+        if hasattr(exc, "real_stack"):
+            msg += (
+                "\n"
+                + "=" * 10
+                + " The above exception occurred while processing the following code "
+                + "=" * 10
+                + "\n\n"
             )
-        )
+            msg += "".join(
+                traceback.format_list(
+                    filter_stack(traceback.extract_stack(frame))
+                    + list(reversed(exc.real_stack))
+                )
+            )
+    else:
+        msg = f"WON'T CONVERT {frame.f_code.co_name} {frame.f_code.co_filename}\
+ line {frame.f_code.co_firstlineno} \ndue to: \n{traceback.format_exc(limit=-1)}"
 
+        if hasattr(exc, "real_stack"):
+            msg += f"from user code:\n {''.join(traceback.format_list([exc.real_stack[-1]]))}"
+
+        msg += "\nSet torchdynamo.config.verbose=True for more information\n"
     msg += "=" * 10
     return msg
 
@@ -293,10 +303,6 @@ def convert_frame_assert(compiler_fn: Callable, guard_export_fn=None, one_graph=
             if config.dead_code_elimination:
                 instructions[:] = remove_pointless_jumps(remove_dead_code(instructions))
 
-        def format_bytecode(prefix, bytecode):
-            return f"{prefix} {code.co_name} {code.co_filename} \
-                {code.co_firstlineno} \n{dis.Bytecode(bytecode).dis()}\n "
-
         try:
             for attempt in itertools.count():
                 try:
@@ -317,8 +323,8 @@ def convert_frame_assert(compiler_fn: Callable, guard_export_fn=None, one_graph=
                     return None
             output_codes.add(code)
 
-            log.info(format_bytecode("ORIGINAL BYTECODE", frame.f_code))
-            log.info(format_bytecode("MODIFIED BYTECODE", code))
+            log.info(format_bytecode("ORIGINAL BYTECODE", frame, frame.f_code))
+            log.info(format_bytecode("MODIFIED BYTECODE", frame, code))
 
             assert output.guards is not None
             CleanupManager.instance[code] = output.cleanups
@@ -344,16 +350,10 @@ def convert_frame_assert(compiler_fn: Callable, guard_export_fn=None, one_graph=
             BackendCompilerFailed,
             AssertionError,
         ) as e:
-            log.error(
-                format_bytecode("WONT CONVERT", frame.f_code)
-                + format_exception(e, frame)
-            )
+            log.error(format_error_msg(e, frame))
             raise
         except Exception as e:
-            log.error(
-                format_bytecode("WONT CONVERT", frame.f_code)
-                + format_exception(e, frame)
-            )
+            log.error(format_error_msg(e, frame))
             raise InternalTorchDynamoError()
 
     _convert_frame_assert._torchdynamo_orig_callable = compiler_fn

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -1,4 +1,3 @@
-import dis
 import functools
 import itertools
 import logging

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -208,7 +208,7 @@ def format_error_msg(exc, frame):
  line {frame.f_code.co_firstlineno} \ndue to: \n{traceback.format_exc(limit=-1)}"
 
         if hasattr(exc, "real_stack"):
-            msg += f"from user code:\n {''.join(traceback.format_list([exc.real_stack[-1]]))}"
+            msg += f"\nfrom user code:\n {''.join(traceback.format_list([exc.real_stack[-1]]))}"
 
         msg += "\nSet torchdynamo.config.verbose=True for more information\n"
     msg += "=" * 10

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -2,6 +2,7 @@ import collections
 import contextlib
 import copy
 import dataclasses
+import dis
 import functools
 import gc
 import inspect
@@ -95,6 +96,11 @@ def format_graph_tabular(graph):
 
     node_specs = [[n.op, n.name, n.target, n.args, n.kwargs] for n in graph.nodes]
     return tabulate(node_specs, headers=["opcode", "name", "target", "args", "kwargs"])
+
+
+def format_bytecode(prefix, frame, code):
+    return f"{prefix} {frame.f_code.co_name} {frame.f_code.co_filename}\
+ line {frame.f_code.co_firstlineno} \n{dis.Bytecode(code).dis()}\n "
 
 
 def count_calls(g: fx.Graph):


### PR DESCRIPTION
`config.verbose = False`:

```
Torchdynamo: [ERROR] WON'T CONVERT test_assertion_error /scratch/mlazos/torchdynamo/../test/script.py line 50 
due to: 
Traceback (most recent call last):
  File "/scratch/mlazos/torchdynamo/torchdynamo/symbolic_convert.py", line 777, in BUILD_MAP
    assert isinstance(k, ConstantVariable) or (
AssertionError

from user code:
   File "/scratch/mlazos/torchdynamo/../test/script.py", line 55, in test_assertion_error
    z = {y: 5}

Set torchdynamo.config.verbose=True for more information
```

`config.verbose = True`:

```
Torchdynamo: [ERROR] WON'T CONVERT test_assertion_error /scratch/mlazos/torchdynamo/../test/script.py line 50 
 52           0 LOAD_GLOBAL              0 (torch)
              2 LOAD_ATTR                1 (ones)
              4 LOAD_CONST               1 (10000)
              6 LOAD_CONST               1 (10000)
              8 LOAD_GLOBAL              2 (cuda)
             10 LOAD_CONST               2 (('device',))
             12 CALL_FUNCTION_KW         3
             14 STORE_FAST               0 (x)

 53          16 LOAD_GLOBAL              0 (torch)
             18 LOAD_ATTR                1 (ones)
             20 LOAD_CONST               1 (10000)
             22 LOAD_CONST               1 (10000)
             24 LOAD_GLOBAL              2 (cuda)
             26 LOAD_CONST               2 (('device',))
             28 CALL_FUNCTION_KW         3
             30 STORE_FAST               1 (y)

 54          32 LOAD_GLOBAL              0 (torch)
             34 LOAD_ATTR                1 (ones)
             36 LOAD_CONST               1 (10000)
             38 LOAD_CONST               1 (10000)
             40 LOAD_GLOBAL              2 (cuda)
             42 LOAD_CONST               2 (('device',))
             44 CALL_FUNCTION_KW         3
             46 STORE_FAST               2 (w)

 55          48 LOAD_FAST                1 (y)
             50 LOAD_CONST               3 (5)
             52 BUILD_MAP                1
             54 STORE_FAST               3 (z)

 56          56 LOAD_FAST                3 (z)
             58 LOAD_GLOBAL              0 (torch)
             60 LOAD_METHOD              3 (zeros)
             62 LOAD_CONST               1 (10000)
             64 LOAD_CONST               1 (10000)
             66 CALL_METHOD              2
             68 BINARY_MULTIPLY
             70 LOAD_FAST                1 (y)
             72 BINARY_MULTIPLY
             74 LOAD_FAST                2 (w)
             76 BINARY_MULTIPLY
             78 RETURN_VALUE

 ========== TorchDynamo Stack Trace ==========
Traceback (most recent call last):
  File "/scratch/mlazos/torchdynamo/torchdynamo/convert_frame.py", line 309, in _convert_frame_assert
    code = transform_code_object(frame.f_code, transform)
  File "/scratch/mlazos/torchdynamo/torchdynamo/bytecode_transformation.py", line 338, in transform_code_object
    transformations(instructions, code_options)
  File "/scratch/mlazos/torchdynamo/torchdynamo/convert_frame.py", line 297, in transform
    tracer.run()
  File "/scratch/mlazos/torchdynamo/torchdynamo/symbolic_convert.py", line 331, in run
    and self.step()
  File "/scratch/mlazos/torchdynamo/torchdynamo/symbolic_convert.py", line 304, in step
    getattr(self, inst.opname)(inst)
  File "/scratch/mlazos/torchdynamo/torchdynamo/symbolic_convert.py", line 777, in BUILD_MAP
    assert isinstance(k, ConstantVariable) or (
AssertionError

========== The above exception occurred while processing the following code ==========

  File "/scratch/mlazos/torchdynamo/../test/script.py", line 87, in <module>
    test_assertion_error()
  File "/scratch/mlazos/torchdynamo/../test/script.py", line 55, in test_assertion_error
    z = {y: 5}
==========```