### PR TITLE
Record nn_module stack while parsing

### DIFF
--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -472,6 +472,11 @@ class OutputGraph(fx.Tracer):
 
         # append stack trace to fx node
         tx = current_tx if current_tx else self.root_tx
+
+        nn_module_stack = getattr(tx, "nn_module_stack")
+        if nn_module_stack:
+           rv.node.meta["nn_module_stack"] = nn_module_stack.copy()
+
         frame_summaries: List[traceback.FrameSummary] = []
         while tx:
             frame_summaries.append(tx.frame_summary())

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -475,7 +475,7 @@ class OutputGraph(fx.Tracer):
 
         nn_module_stack = getattr(tx, "nn_module_stack")
         if nn_module_stack:
-           rv.node.meta["nn_module_stack"] = nn_module_stack.copy()
+            rv.node.meta["nn_module_stack"] = nn_module_stack.copy()
 
         frame_summaries: List[traceback.FrameSummary] = []
         while tx:
@@ -483,5 +483,9 @@ class OutputGraph(fx.Tracer):
             tx = getattr(tx, "parent", None)
 
         msgs = traceback.StackSummary.from_list(frame_summaries).format()
-        rv.node.stack_trace = "".join(msgs)
+
+        # Carry module_stack along with node.stack_trace for reusing stacktrace propagation infra
+        nn_module_stack_str = f"Module stack: {nn_module_stack}\n"
+        rv.node.stack_trace = nn_module_stack_str + "".join(msgs)
+
         return rv

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1197,6 +1197,9 @@ class InstructionTranslatorBase(object):
         self.code_options: Dict[str, Any] = code_options
         self.f_code: types.CodeType = f_code
 
+        # Stack of module being parsed, current nn.module is at the end of ordered dict
+        self.nn_module_stack: Dict[str, str] = {}
+
         if fake_tensors_available:
             with torch._subclasses.FakeTensorMode() as fake_mode:
                 pass
@@ -1448,6 +1451,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         self.parent = parent
         self.symbolic_result = None
         self.closure_cells = closure_cells
+        self.nn_module_stack = parent.nn_module_stack.copy()
 
     @property
     def fake_mode(self):

--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import functools
 import inspect
 import itertools
@@ -154,58 +155,68 @@ class NNModuleVariable(VariableTracker):
     ) -> "VariableTracker":
         options = VariableTracker.propagate(self, args, kwargs.values())
         mod = tx.output.get_submodule(self.module_key)
-        is_lazy = is_lazy_module(mod)
-        if (
-            isinstance(mod, torch.nn.Sequential)
-            and mod.__class__.forward is torch.nn.Sequential.forward
-        ):
-            # unroll Sequential()
-            assert not kwargs
-            (arg,) = args
-            for idx, submod in enumerate(mod):
-                tx.call_function(
-                    tx.output.add_submodule(
-                        submod,
+
+        @contextmanager
+        def record_nn_module_stack():
+            try:
+                tx.nn_module_stack[self.module_key] = mod.__class__.__name__
+                yield
+            finally:
+                del tx.nn_module_stack[self.module_key]
+
+        with record_nn_module_stack():
+            is_lazy = is_lazy_module(mod)
+            if (
+                isinstance(mod, torch.nn.Sequential)
+                and mod.__class__.forward is torch.nn.Sequential.forward
+            ):
+                # unroll Sequential()
+                assert not kwargs
+                (arg,) = args
+                for idx, submod in enumerate(mod):
+                    tx.call_function(
+                        tx.output.add_submodule(
+                            submod,
+                            self.module_key,
+                            idx,
+                            source=NNModuleSource(GetItemSource(self.source, idx)),
+                            **options,
+                        ),
+                        [arg],
+                        {},
+                    )
+                    arg = tx.pop()
+                return arg
+            elif is_allowed(mod.__class__):
+                # The module type will change after it is called
+                if is_lazy:
+                    self.module_type = mod.cls_to_become
+
+                return variables.TensorVariable.create(
+                    tx=tx,
+                    proxy=tx.output.create_proxy(
+                        "call_module",
                         self.module_key,
-                        idx,
-                        source=NNModuleSource(GetItemSource(self.source, idx)),
-                        **options,
+                        *proxy_args_kwargs(args, kwargs),
+                        current_tx=tx,
                     ),
-                    [arg],
-                    {},
+                    nnmodule=mod,
+                    **options,
                 )
-                arg = tx.pop()
-            return arg
-        elif is_allowed(mod.__class__):
-            # The module type will change after it is called
-            if is_lazy:
-                self.module_type = mod.cls_to_become
-
-            return variables.TensorVariable.create(
-                tx=tx,
-                proxy=tx.output.create_proxy(
-                    "call_module",
-                    self.module_key,
-                    *proxy_args_kwargs(args, kwargs),
-                    current_tx=tx,
-                ),
-                nnmodule=mod,
-                **options,
-            )
-        else:
-            # for lazy modules, run the pre-hooks which will update the type
-            # TODO mlazos: we don't fully support all of the hooks that exist,
-            # so restrict using __call__ only to lazy modules for now
-            if is_lazy:
-                fn = mod.__class__.__call__
             else:
-                fn = mod.__class__.forward
+                # for lazy modules, run the pre-hooks which will update the type
+                # TODO mlazos: we don't fully support all of the hooks that exist,
+                # so restrict using __call__ only to lazy modules for now
+                if is_lazy:
+                    fn = mod.__class__.__call__
+                else:
+                    fn = mod.__class__.forward
 
-            return tx.inline_user_function_return(
-                variables.UserFunctionVariable(fn, **options),
-                [self] + args,
-                kwargs,
-            )
+                return tx.inline_user_function_return(
+                    variables.UserFunctionVariable(fn, **options),
+                    [self] + args,
+                    kwargs,
+                )
 
     def call_method(
         self,

--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -1,9 +1,9 @@
-from contextlib import contextmanager
 import functools
 import inspect
 import itertools
 import re
 import types
+from contextlib import contextmanager
 from typing import Dict
 from typing import List
 


### PR DESCRIPTION
As title. 

FX node.meta now have an "nn_module_stack" field, which is a dictionary for the current module hierarchy , e.g. 
{'self_layer3': 'Sequential', 
'self_layer3_0': 'BasicBlock', 
'self_layer3_0__downsample': 'Sequential', 
'self_layer3_0__downsample_1': 'BatchNorm2d'}

For more examples, see https://gist.github.com/SherlockNoMad/03988cafbd08f3ca66e230d8e5543539 