### PR TITLE
add a few lowerings

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -1655,6 +1655,15 @@ class CommonTemplate:
             (torch.randn([64]),),
         )
 
+    def test_flip(self):
+        def fn(x):
+            return torch.flip(x, (-1,)), torch.flip(x, (0, 2)) - 2
+
+        self.common(
+            fn,
+            (torch.randn([1, 2, 6, 6]),),
+        )
+
     def test_log2(self):
         def fn(x):
             return torch.log2(x), torch.log2(x + 1) - 2

--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -187,6 +187,10 @@ class CppOverrides(OpOverrides):
         return f"std::sqrt({x})"
 
     @staticmethod
+    def rsqrt(x):
+        return f"1 / std::sqrt({x})"
+
+    @staticmethod
     def pow(a, b):
         return f"std::pow({a}, {b})"
 

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -160,6 +160,10 @@ class TritonOverrides(OpOverrides):
         return f"tl.randn({seed}, {offset})"
 
     @staticmethod
+    def rsqrt(x):
+        return f"tl.libdevice.rsqrt({x})"
+
+    @staticmethod
     def pow(a, b):
         return f"tl.libdevice.pow({a}, {b})"
 

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -82,6 +82,7 @@ decompositions = get_decompositions(
         aten.tanh_backward,
         aten.threshold_backward,
         aten.transpose.int,
+        aten.tril.default,
         aten.upsample_nearest2d_backward,
         aten.upsample_bilinear2d.vec,
     ]
@@ -123,11 +124,6 @@ def addmm(input, mat1, mat2):
 @register_decomposition([aten.tanh])
 def tanh(x):
     return 2.0 / (1.0 + torch.exp(-2.0 * x)) - 1.0
-
-
-@register_decomposition([aten.rsqrt])
-def rsqrt(x):
-    return torch.reciprocal(torch.sqrt(x))
 
 
 @register_decomposition([aten.log2])

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1857,6 +1857,28 @@ def reflection_pad2d_backward(grad_output, x, padding):
     )
 
 
+@register_lowering(prims.rev.default)
+def rev(x, dims):
+    # note - dims pre-canoncalized
+    x_loader = x.make_loader()
+    sizes = x.get_size()
+
+    def loader(idx):
+        idx = list(idx)
+        assert len(idx) == len(sizes)
+        for dim in dims:
+            idx[dim] = sizes[dim] - idx[dim]
+
+        return x_loader(idx)
+
+    return Pointwise.create(
+        device=x.get_device(),
+        dtype=x.get_dtype(),
+        inner_fn=loader,
+        ranges=sizes,
+    )
+
+
 @register_lowering(aten.constant_pad_nd, type_promote=False)
 def constant_pad_nd(x, padding, fill_value=0):
     assert (len(padding) % 2) == 0
@@ -2653,6 +2675,7 @@ register_pointwise(aten.neg)
 register_pointwise(aten.reciprocal)
 register_pointwise(aten.remainder)
 register_pointwise(aten.round)
+register_pointwise(aten.rsqrt)
 register_pointwise(aten.sign)
 register_pointwise(aten.silu)
 register_pointwise(aten.ceil)


### PR DESCRIPTION
- Add lowering for `prims.flip` (this gets lowered to from aten.flip.default which shows up a lot in huggingface)
- Enable `aten.tril.default` decomp 
- Remove `rsqrt` decomp to lower to intrinsic

aten.rsqrt.default (fp16) (20th/50th/80th percentile)
Before : [0.901 0.907, 0.966] / After : [0.966, 0.970, 0.975]

aten.flip.default  speedup:  [1.0219, 1.045, 1.068]

aten.tril.default speedup:  [1.116, 1.116, 1.116]




