### PR TITLE
Expunge jansel/benchmark from documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
               source .circleci/setup_env.sh
               conda install -y -c conda-forge git-lfs
               git lfs install --skip-repo
-              # git clone --recursive --depth=1 --shallow-submodules git@github.com:jansel/benchmark.git torchbenchmark
+              # git clone --recursive --depth=1 --shallow-submodules git@github.com:pytorch/benchmark.git torchbenchmark
               # above doesn't work due to git-lfs auth issues, workaround with a tarball:
               wget -O torchbenchmark.tar.bz2 "https://drive.google.com/u/0/uc?id=1KvYsqipsvvv3pnNkJzME0iTemDZe0buC&export=download&confirm=t"
               tar jxvf torchbenchmark.tar.bz2

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ clone-deps:
 		&& (test -e torchtext || git clone --recursive https://github.com/pytorch/text torchtext) \
 		&& (test -e torchaudio || git clone --recursive https://github.com/pytorch/audio torchaudio) \
 		&& (test -e detectron2 || git clone --recursive https://github.com/facebookresearch/detectron2) \
-		&& (test -e torchbenchmark || git clone --recursive https://github.com/jansel/benchmark torchbenchmark) \
+		&& (test -e torchbenchmark || git clone --recursive https://github.com/pytorch/benchmark torchbenchmark) \
 		&& (test -e triton || git clone --recursive https://github.com/openai/triton.git) \
 	)
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,6 @@ nightly builds.
 
 [PyTorch from source]: https://github.com/pytorch/pytorch#from-source
 
-For reproducing the experiments in the posts above, use the TorchBenchmark
-[fork found here].  This fork contains a few minor fixes that have not
-yet been merged upstream.
-
-[fork found here]: https://github.com/jansel/benchmark
-
 Other development requirements can be installed with:
 ```shell
 pip install -r requirements.txt
@@ -278,7 +272,7 @@ def toy_example(a, b):
 ```
 
 [optimize_for_inference]: https://pytorch.org/docs/stable/generated/torch.jit.optimize_for_inference.html
-[backends.py]: https://github.com/jansel/torchdynamo/blob/main/torchdynamo/optimizations/backends.py
+[backends.py]: https://github.com/pytorch/torchdynamo/blob/main/torchdynamo/optimizations/backends.py
 
 ## Guards
 
@@ -484,7 +478,7 @@ testing:
 cd ..  # if still in torchdynamo/
 
 # download everything
-git clone git@github.com:jansel/benchmark.git torchbenchmark
+git clone git@github.com:pytorch/benchmark.git torchbenchmark
 cd torchbenchmark
 python install.py
 


### PR DESCRIPTION
The real repo is usable now.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>