### PR TITLE
Add an option to divide benchmark suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
           command: |
             source .circleci/setup_env.sh
             python .circleci/check_csv.py -f aot_eager.csv
+
   inductor_torchbench_inference:
     machine:
       # https://circleci.com/docs/2.0/configuration-reference/#available-linux-gpu-images
@@ -114,9 +115,8 @@ jobs:
             source .circleci/setup_env.sh
             python .circleci/check_csv.py -f inductor_torchbench_inference.csv
 
-  inductor_torchbench_training:
+  inductor_torchbench_training_0:
     machine:
-      # https://circleci.com/docs/2.0/configuration-reference/#available-linux-gpu-images
       image: ubuntu-2004-cuda-11.4:202110-01
     resource_class: gpu.nvidia.large
     steps:
@@ -127,18 +127,43 @@ jobs:
           command: |
             source .circleci/setup_env.sh
             make develop
-            python benchmarks/torchbench.py --ci -d cuda --inductor --training --use-eval-mode --float32 \
-              --raise-on-assertion-error --raise-on-backend-error --quiet \
+            python benchmarks/torchbench.py --ci --quiet -d cuda --inductor --training --use-eval-mode --float32 \
+              --raise-on-assertion-error --raise-on-backend-error --total-partitions 2 --partition-id 0\
               -x Super_SloMo -x moco -x dlrm -x fambench_dlrm -x fastNLP_Bert -x hf_Reformer -x tacotron2 \
-              -x attention_is_all_you_need_pytorch -x hf_ -x mobilenet_ -x pytorch_struct -x timm_ -x vgg16 -x yolov3 \
-              --output=inductor_torchbench_training.csv
+              -x attention_is_all_you_need_pytorch -x mobilenet_ -x pytorch_struct -x vgg16 -x yolov3 \
+              --output=inductor_torchbench_training_0.csv
       - store_artifacts:
-          path: inductor_torchbench_training.csv
+          path: inductor_torchbench_training_0.csv
       - run:
           name: TorchBench training result check
           command: |
             source .circleci/setup_env.sh
-            python .circleci/check_csv.py -f inductor_torchbench_training.csv
+            python .circleci/check_csv.py -f inductor_torchbench_training_0.csv
+
+  inductor_torchbench_training_1:
+    machine:
+      image: ubuntu-2004-cuda-11.4:202110-01
+    resource_class: gpu.nvidia.large
+    steps:
+      - checkout
+      - install_deps
+      - run:
+          name: TorchBench training run
+          command: |
+            source .circleci/setup_env.sh
+            make develop
+            python benchmarks/torchbench.py --ci --quiet -d cuda --inductor --training --use-eval-mode --float32 \
+              --raise-on-assertion-error --raise-on-backend-error --total-partitions 2 --partition-id 1\
+              -x Super_SloMo -x moco -x dlrm -x fambench_dlrm -x fastNLP_Bert -x hf_Reformer -x tacotron2 \
+              -x attention_is_all_you_need_pytorch -x mobilenet_ -x pytorch_struct -x vgg16 -x yolov3 \
+              --output=inductor_torchbench_training_1.csv
+      - store_artifacts:
+          path: inductor_torchbench_training_1.csv
+      - run:
+          name: TorchBench training result check
+          command: |
+            source .circleci/setup_env.sh
+            python .circleci/check_csv.py -f inductor_torchbench_training_1.csv
 
 workflows:
   gpu:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ jobs:
               --raise-on-assertion-error --raise-on-backend-error --total-partitions 2 --partition-id 0\
               -x Super_SloMo -x moco -x dlrm -x fambench_dlrm -x fastNLP_Bert -x hf_Reformer -x tacotron2 \
               -x attention_is_all_you_need_pytorch -x mobilenet_ -x pytorch_struct -x vgg16 -x yolov3 \
+              -x hf_Albert -x hf_Bart -x hf_GPT2 \
               --output=inductor_torchbench_training_0.csv
       - store_artifacts:
           path: inductor_torchbench_training_0.csv
@@ -156,6 +157,7 @@ jobs:
               --raise-on-assertion-error --raise-on-backend-error --total-partitions 2 --partition-id 1\
               -x Super_SloMo -x moco -x dlrm -x fambench_dlrm -x fastNLP_Bert -x hf_Reformer -x tacotron2 \
               -x attention_is_all_you_need_pytorch -x mobilenet_ -x pytorch_struct -x vgg16 -x yolov3 \
+              -x hf_Albert -x hf_Bart -x hf_GPT2 \
               --output=inductor_torchbench_training_1.csv
       - store_artifacts:
           path: inductor_torchbench_training_1.csv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,4 +171,5 @@ workflows:
       - coverage
       - aot_eager
       - inductor_torchbench_inference
-      - inductor_torchbench_training
+      - inductor_torchbench_training_0
+      - inductor_torchbench_training_1

--- a/benchmarks/torchbench.py
+++ b/benchmarks/torchbench.py
@@ -303,7 +303,12 @@ class TorchBenchmarkRunner(BenchmarkRunner):
     def iter_model_names(self, args):
         from torchbenchmark import _list_model_paths
 
-        for model_path in _list_model_paths():
+        models = _list_model_paths()
+        start, end = self.get_benchmark_indices(len(models))
+        for index, model_path in enumerate(models):
+            if index < start or index >= end:
+                continue
+
             model_name = os.path.basename(model_path)
             if (
                 not re.search("|".join(args.filter), model_name, re.I)


### PR DESCRIPTION
Summary: By dividing a large benchmark suite into several smaller CI tasks, we can increase the coverage without increasing  CI turnaround time.

Only changing torchbench in this PR. hf and timm changes are coming in another one.