### PR TITLE
Add upsample nearest2d backward lowering

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -1188,7 +1188,7 @@ class CommonTemplate:
     def test_adaptive_avg_pool2d1(self):
         def fn(x):
             return aten._adaptive_avg_pool2d(x, (6, 6)), aten._adaptive_avg_pool2d(
-                x + 1, (4, 5)
+                x + 1, (2, 5)
             )
 
         self.common(

--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -1291,6 +1291,15 @@ class CommonTemplate:
             (-torch.arange(1 * 8 * 8, dtype=torch.float32).view(1, 1, 8, 8),),
         )
 
+    def test_avg_pool2d6(self):
+        def fn(x):
+            return aten.avg_pool2d(x, [3, 3], [2, 2], [1, 1], divisor_override=3)
+
+        self.common(
+            fn,
+            (-torch.arange(1 * 8 * 8, dtype=torch.float32).view(1, 1, 8, 8),),
+        )
+
     def test_alexnet_prefix(self):
         def forward(arg6, arg7, arg16):
             convolution = torch.ops.aten.convolution(
@@ -1946,6 +1955,30 @@ class CommonTemplate:
             )
 
         self.common(fn, (torch.randn([2, 4, 37, 38]),))
+
+    def test_upsample_nearest2d_backward(self):
+        func = torch.ops.aten.upsample_nearest2d_backward.vec
+
+        def fn(a):
+            return (
+                func(
+                    a, output_size=[6, 12], input_size=[3, 3, 3, 6], scale_factors=None
+                ),
+                func(
+                    a, output_size=[6, 12], input_size=[3, 3, 4, 5], scale_factors=None
+                ),
+                func(
+                    a, output_size=[6, 12], input_size=[3, 3, 2, 8], scale_factors=None
+                ),
+                func(
+                    a, output_size=[6, 12], input_size=[3, 3, 2, 8], scale_factors=None
+                ),
+                func(
+                    a, output_size=[6, 12], input_size=[3, 3, 4, 7], scale_factors=None
+                ),
+            )
+
+        self.common(fn, (torch.randn([3, 3, 6, 12]),))
 
     def test_upsample_bilinear2d_a(self):
         def fn(a):

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -202,6 +202,18 @@ class CleanDiv(IndexingDiv):
     pass
 
 
+class CeilDiv(sympy.Function):
+    """
+    Div used in indexing that rounds up.
+    """
+
+    def __new__(cls, base, divisor):
+        if sympy.gcd(base, divisor) == divisor:
+            return CleanDiv(base, divisor)
+        else:
+            return IndexingDiv(base + (divisor - 1), divisor)
+
+
 def is_triton(x):
     # TODO(jansel): a config check once we have multi-backend
     if getattr(x, "get_device", None):

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -888,7 +888,6 @@ make_fallback(aten.unfold_backward)
 make_fallback(aten.upsample_bicubic2d)
 make_fallback(aten.upsample_bicubic2d_backward)
 make_fallback(aten.upsample_bilinear2d_backward)
-make_fallback(aten.upsample_nearest2d_backward)
 
 
 @register_lowering(aten.convolution)
@@ -2187,6 +2186,36 @@ def pad_adaptive_loader(x):
     return load
 
 
+def _adaptive_pooling_idx_sum(kernel_maxes, start_index_fns, end_index_fns):
+    h_start_index_fn, w_start_index_fn = start_index_fns
+    h_end_index_fn, w_end_index_fn = end_index_fns
+
+    def fn_sum(idx, loader):
+        *prefix, bh, bw = idx
+
+        h_start_index = h_start_index_fn(bh)
+        h_end_index = h_end_index_fn(bh)
+
+        w_start_index = w_start_index_fn(bw)
+        w_end_index = w_end_index_fn(bw)
+
+        total = None
+        for ih, iw in itertools.product(range(kernel_maxes[0]), range(kernel_maxes[1])):
+            val = loader(
+                prefix,
+                [ih, iw],
+                [h_start_index, w_start_index],
+                [h_end_index, w_end_index],
+            )
+            if total is None:
+                total = val
+            else:
+                total = ops.add(val, total)
+        return total
+
+    return fn_sum
+
+
 @register_lowering(aten._adaptive_avg_pool2d)
 def _adaptive_avg_pool2d(x, output_size):
     assert isinstance(x, TensorBox)
@@ -2214,34 +2243,23 @@ def _adaptive_avg_pool2d(x, output_size):
     new_size = list(batch) + [h_out, w_out]
     dtype = x.get_dtype()
 
-    def fn_sum(idx, loader):
-        *prefix, bh, bw = idx
+    def start_index(index, out_dim, inp_dim):
+        return ir.IndexingDiv((index * inp_dim), out_dim)
 
-        def start_index(index, out_dim, inp_dim):
-            return ir.IndexingDiv((index * inp_dim), out_dim)
+    def end_index(index, out_dim, inp_dim):
+        return ir.IndexingDiv((index + 1) * inp_dim + out_dim - 1, out_dim)
 
-        def end_index(index, out_dim, inp_dim):
-            return ir.IndexingDiv((index + 1) * inp_dim + out_dim - 1, out_dim)
+    h_start_index = functools.partial(start_index, out_dim=h_out, inp_dim=h_in)
+    h_end_index = functools.partial(end_index, out_dim=h_out, inp_dim=h_in)
 
-        h_start_index = start_index(bh, h_out, h_in)
-        h_end_index = end_index(bh, h_out, h_in)
+    w_start_index = functools.partial(start_index, out_dim=w_out, inp_dim=w_in)
+    w_end_index = functools.partial(end_index, out_dim=w_out, inp_dim=w_in)
 
-        w_start_index = start_index(bw, w_out, w_in)
-        w_end_index = end_index(bw, w_out, w_in)
-
-        total = None
-        for ih, iw in itertools.product(range(h_kernel_max), range(w_kernel_max)):
-            val = loader(
-                prefix,
-                [ih, iw],
-                [h_start_index, w_start_index],
-                [h_end_index, w_end_index],
-            )
-            if total is None:
-                total = val
-            else:
-                total = ops.add(val, total)
-        return total
+    fn_sum = _adaptive_pooling_idx_sum(
+        [h_kernel_max, w_kernel_max],
+        [h_start_index, w_start_index],
+        [h_end_index, w_end_index],
+    )
 
     ones_loader = pad_adaptive_loader(ones_like(x))
 
@@ -2258,6 +2276,59 @@ def _adaptive_avg_pool2d(x, output_size):
     return rv
 
 
+@register_lowering(aten.upsample_nearest2d_backward.vec)
+def upsample_nearest2d_backward(
+    x, output_size=None, input_size=None, scale_factors=None
+):
+    x.realize_hint()
+
+    *batch, inp_h, inp_w = x.get_size()
+    inp_h = V.graph.sizevars.guard_static_shape(inp_h)
+    inp_w = V.graph.sizevars.guard_static_shape(inp_w)
+
+    *batch, out_h, out_w = input_size
+
+    if inp_h % out_h == 0 and inp_w % out_w == 0:
+        return avg_pool2d(x, [inp_h // out_h, inp_w // out_w], divisor_override=1)
+
+    h_kernel_max = math.ceil(inp_h / out_h)
+    w_kernel_max = math.ceil(inp_w / out_w)
+
+    def start_index(index, out_dim, inp_dim):
+        if inp_dim % out_dim == 0:
+            return ir.CleanDiv(index * inp_dim, out_dim)
+        else:
+            # adding (out_dim -1) to numerator equivalent to taking ceil
+            return ir.IndexingDiv((index * inp_dim + (out_dim - 1)), out_dim)
+
+    def end_index(index, out_dim, inp_dim):
+        return start_index((index + 1), out_dim, inp_dim)
+
+    h_start_index = functools.partial(start_index, out_dim=out_h, inp_dim=inp_h)
+    h_end_index = functools.partial(end_index, out_dim=out_h, inp_dim=inp_h)
+
+    w_start_index = functools.partial(start_index, out_dim=out_w, inp_dim=inp_w)
+    w_end_index = functools.partial(end_index, out_dim=out_w, inp_dim=inp_w)
+
+    fn_sum = _adaptive_pooling_idx_sum(
+        [h_kernel_max, w_kernel_max],
+        [h_start_index, w_start_index],
+        [h_end_index, w_end_index],
+    )
+
+    def fn(idx):
+        return fn_sum(idx, pad_adaptive_loader(x))
+
+    rv = Pointwise.create(
+        device=x.get_device(),
+        dtype=x.get_dtype(),
+        inner_fn=fn,
+        ranges=list(input_size),
+    )
+
+    return rv
+
+
 @register_lowering(aten.avg_pool2d, type_promote=False)
 def avg_pool2d(
     x,
@@ -2268,7 +2339,6 @@ def avg_pool2d(
     count_include_pad=True,
     divisor_override=None,
 ):
-    assert not divisor_override
     if not stride:
         stride = kernel_size
     if not padding:
@@ -2309,8 +2379,11 @@ def avg_pool2d(
                 total = ops.add(val, total)
         return total
 
-    if count_include_pad or not had_padding:
-        scale = 1.0 / (kernel_size[0] * kernel_size[1])
+    if count_include_pad or not had_padding or divisor_override:
+        if divisor_override:
+            scale = 1 / divisor_override
+        else:
+            scale = 1.0 / (kernel_size[0] * kernel_size[1])
 
         def fn(idx):
             return ops.mul(fn_sum(idx, x_loader), ops.constant(scale, dtype))

--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -61,6 +61,11 @@ def unique(it):
     return {id(x): x for x in it}.values()
 
 
+def ceildiv(numer: int, denom: int):
+    assert isinstance(numer, int) and isinstance(denom, int)
+    return (numer + (denom - 1)) // denom
+
+
 def timed(model, example_inputs, times=1):
     synchronize()
     torch.manual_seed(1337)


### PR DESCRIPTION
Add lowering for upsample nearest 2d backward. The operator is extremely similar to adaptive average pooling, but with slightly different ways of calculating the start and end index. 

For the TIMM models, this provides a nice speedup (20th/50th/80th percentile) `[3.8709676965080684, 4.561997954885475, 4.736363681462547]`. Whereas for torchbench, it's about at parity `[1.0240000087311494, 1.0714285296660602, 1.1018803331990505]`. 

All of the backwards I saw lowered into avg_pool2d, but I also tested with the lowering to avg_pool2d disabled and perf was very similar but a tad slower:
TIMM: `[3.4285712503847163, 3.9383956989819255, 4.5775858235245375]`
TB: `[1.0136363681462546, 1.0647482775085906, 1.0714285296660602]`