### PR TITLE
Have clone return a tensor which is not a view

### DIFF
--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -278,13 +278,13 @@ def clone_input(x):
             (shape - 1) * stride for shape, stride in zip(x.size(), x.stride())
         )
         if x.is_quantized:
-            buffer = torch.empty_quantized((needed_size + 32,), x)
+            result = torch.empty_quantized((needed_size + 32,), x)
         else:
-            buffer = torch.empty(needed_size + 32, dtype=x.dtype, device=x.device)
+            result = torch.empty(needed_size + 32, dtype=x.dtype, device=x.device)
         cache_line_offset = (
-            (x.data_ptr() - buffer.data_ptr()) % 32
+            (x.data_ptr() - result.data_ptr()) % 32
         ) // x.element_size()
-        result = torch.as_strided(buffer, x.size(), x.stride(), cache_line_offset)
+        result.as_strided_(x.size(), x.stride(), cache_line_offset)
         try:
             result.copy_(x.clone())
             result.requires_grad_(x.requires_grad)
@@ -292,7 +292,9 @@ def clone_input(x):
             # RuntimeError: unsupported operation: more than one element of the written-to
             # tensor refers to a single memory location. Please clone() the tensor before
             # performing the operation.
-            return torch.clone(x)
+            y = torch.clone(x)
+            y.requires_grad_(x.requires_grad)
+            return y
         return result
 
 


### PR DESCRIPTION
Currently clone_input returns a view, which causes strange error messages if the original tensor is a tensor with grad and it's used in an inplace operation.

For example:
`RuntimeError: A view was created in no_grad mode and is being modified inplace with grad mode enabled. Given that this use case is ambiguous and error-prone, it is forbidden. You can clarify your code by moving both the view and the inplace either both inside the no_grad block (if you don't want the inplace to be tracked) or both outside (if you want the inplace to be tracked).`

After the change:
`RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.`

Related to #945 