### PR TITLE
don't turn AliasedLayout into fixed for extern kernels

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -1622,6 +1622,25 @@ class CommonTemplate:
             (torch.randn([8, 16]),),
         )
 
+    def test_cat_extern_kernel(self):
+        def fn(x1, x2, x3, x4):
+            x = torch.mm(x2, x3)
+            s = torch.narrow(x, 1, 0, 100)
+            x = torch.mm(s, x4)
+            c = torch.cat((x, x1), 1)
+            return (c,)
+
+        self.common(
+            fn,
+            (
+                torch.randn(256, 256),
+                torch.randn(256, 1024),
+                torch.randn(1024, 1600),
+                torch.randn(100, 256),
+            ),
+            check_lowp=False,  # accuracy issues with relatively large matmuls
+        )
+
     def test_stack(self):
         def fn(a, b):
             return torch.stack(

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -2026,7 +2026,7 @@ class ExternKernel(InputsKernel):
     def decide_layout(self):
         if isinstance(self.layout, FlexibleLayout):
             self.apply_constraint()
-        self.freeze_layout()
+            self.freeze_layout()
 
     def codegen(self, wrapper):
         raise NotImplementedError


### PR DESCRIPTION
When one of the inputs to `cat` was extern kernel, AliasedLayout was replaced with Fixed, and thus the extern kernel output wasn't written to cat output. 
I don't like this fix very much, because extern kernels can't always produce output in the layout needed for Concat, and Pointwise in Concat doesn't seem to be doing what it's supposed to, but at least some testcase is fixed. 