### PR TITLE
Fix calling isinstance on torch.nn.Parameter

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -2075,6 +2075,20 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertTrue(same(b_grad, torch.tensor([0.0, 0.0])))
         self.assertEqual(cnts.frame_count, 2)
 
+    def test_torch_nn_parameter_isinstance(self):
+        def fn(x):
+            a = torch.nn.Parameter(torch.rand(2, 3))
+            if isinstance(a, torch.Tensor):
+                return x + 1
+            else:
+                return x - 1
+
+        x = torch.tensor([2.5])
+        ref = fn(x)
+        opt_fn = torchdynamo.optimize("eager")(fn)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+
     def test_change_backends(self):
         @torchdynamo.optimize("eager", nopython=True)
         def fn1():

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -311,7 +311,10 @@ class TensorVariable(VariableTracker):
 
         def check_type(ty):
             if ty not in tensortype_to_dtype:
-                return self.python_type() is ty
+                if self.python_type() is torch.nn.Parameter and ty is torch.Tensor:
+                    return True
+                else:
+                    return self.python_type() is ty
 
             dtypes = tensortype_to_dtype[ty]
             return self.dtype in dtypes

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -311,10 +311,7 @@ class TensorVariable(VariableTracker):
 
         def check_type(ty):
             if ty not in tensortype_to_dtype:
-                if self.python_type() is torch.nn.Parameter and ty is torch.Tensor:
-                    return True
-                else:
-                    return self.python_type() is ty
+                return issubclass(self.python_type(), ty)
 
             dtypes = tensortype_to_dtype[ty]
             return self.dtype in dtypes


### PR DESCRIPTION
Fix this bug:
```
def fn(x):
    a = torch.nn.Parameter(torch.rand(2, 3))
    if isinstance(a, torch.Tensor):
        return x + 1
    else:
        return x - 1

x = torch.tensor([2.5])
print(fn(x))

with torchdynamo.optimize("eager"):
    print(fn(x))
```
Pytorch output: ```[3.5]```
TorchDynamo output: ```[1.5]```