### PR TITLE
Only copy grad and requires grad for leaf tensors

### DIFF
--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -287,16 +287,18 @@ def clone_input(x):
         result.as_strided_(x.size(), x.stride(), cache_line_offset)
         try:
             result.copy_(x.clone())
-            result.requires_grad_(x.requires_grad)
-            if x.grad is not None:
+            if x.is_leaf:
+                result.requires_grad_(x.requires_grad)
+            if x.is_leaf and x.grad is not None:
                 result.grad = clone_input(x.grad)
         except RuntimeError:
             # RuntimeError: unsupported operation: more than one element of the written-to
             # tensor refers to a single memory location. Please clone() the tensor before
             # performing the operation.
             y = torch.clone(x)
-            y.requires_grad_(x.requires_grad)
-            if x.grad is not None:
+            if x.is_leaf:
+                y.requires_grad_(x.requires_grad)
+            if x.is_leaf and x.grad is not None:
                 y.grad = clone_input(x.grad)
             return y
         return result


### PR DESCRIPTION
Previously we would copy grad and requires_grad for non-leaf tensors. This could result in errors when running in-place ops like batchnorm, because some non-leaf tensors would have requires_grad set by pytorch core, and after copying, the copied tensor now has `is_leaf == True`. So putting this through an in-place op would throw "leaf tensor with grad being used in inplace op"

Because other parts of the stack will generate grad_fn and set requires_grad, it's okay to not populate them for non-leaf tensors in dynamo.

With help from @anijain2305 