### PR TITLE
Allow ConcatKernel realize_into to try to produce a reinterpret view rather than fail

### DIFF
--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1990,6 +1990,13 @@ class ConcatKernel(NopKernel):
 
     @classmethod
     def realize_into(cls, src, dst):
+        # Attempt to turn this into a ReinterpretView rather than assert.
+        # This has concessions around layout, as as_storage_and_layout
+        # can cause us to go from flexible to fixed layout.
+        if not isinstance(dst, ReinterpretView):
+            if is_storage_and_layout(dst):
+                storage, layout = as_storage_and_layout(dst)
+                dst = ReinterpretView(storage, layout)
         assert isinstance(dst, ReinterpretView), dst
         if isinstance(src, TensorBox):
             # unwrap a TensorBox


### PR DESCRIPTION
There's probably a more optimal impl where we don't drop into slice at all, but rather skip both slice and a lot of the concat kernel (cc @ngimel), but this gets us past some model failures for now.