### PR TITLE
Add utility for timing dynamo compilation

### DIFF
--- a/torchdynamo/__init__.py
+++ b/torchdynamo/__init__.py
@@ -13,6 +13,7 @@ from .eval_frame import optimize_assert
 from .eval_frame import reset_code
 from .eval_frame import run
 from .eval_frame import skip
+from .utils import compilation_metrics
 from .utils import guard_failures
 from .utils import orig_code_map
 
@@ -43,6 +44,7 @@ def reset():
     guard_failures.clear()
     resume_execution.ContinueExecutionCache.cache.clear()
     eval_frame.most_recent_backend = None
+    compilation_metrics.clear()
 
 
 def list_backends():

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -32,6 +32,7 @@ from .guards import GuardedCode
 from .symbolic_convert import InstructionTranslator
 from .utils import CleanupManager
 from .utils import counters
+from .utils import dynamo_timed
 from .utils import filter_stack
 from .utils import format_bytecode
 from .utils import guard_failures
@@ -214,6 +215,7 @@ def format_error_msg(exc, frame):
     return msg
 
 
+@dynamo_timed
 def convert_frame_assert(compiler_fn: Callable, guard_export_fn=None, one_graph=True):
     """Fully convert a frame into an FX graph"""
     init_logging()
@@ -375,7 +377,8 @@ def convert_frame(compiler_fn: typing.Callable, guard_export_fn=None):
         except BackendCompilerFailed:
             raise
         except Exception:
-            pass
+            raise
+            # pass
         return None
 
     _convert_frame._torchdynamo_orig_callable = compiler_fn

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -215,13 +215,13 @@ def format_error_msg(exc, frame):
     return msg
 
 
-@dynamo_timed
 def convert_frame_assert(compiler_fn: Callable, guard_export_fn=None, one_graph=True):
     """Fully convert a frame into an FX graph"""
     init_logging()
 
     compiler_fn = wrap_compiler_fn(compiler_fn)
 
+    @dynamo_timed
     def _convert_frame_assert(frame: types.FrameType, cache_size: int):
         code = frame.f_code
         input_codes.add(code)

--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -377,8 +377,7 @@ def convert_frame(compiler_fn: typing.Callable, guard_export_fn=None):
         except BackendCompilerFailed:
             raise
         except Exception:
-            raise
-            # pass
+            pass
         return None
 
     _convert_frame._torchdynamo_orig_callable = compiler_fn

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -15,6 +15,7 @@ import torch.utils._pytree as pytree
 import torchdynamo
 from torchdynamo.utils import checkpoint_params
 from torchdynamo.utils import clone_inputs
+from torchdynamo.utils import compile_times
 from torchdynamo.utils import same
 
 from . import config
@@ -387,6 +388,8 @@ def explain(f, *args, **kwargs):
     explanation = f"Dynamo produced {graph_count} graphs"
     explanation += f"with {graph_count - 1} graph break and {op_count} ops"
     explanation += f"\n Break reasons: \n\n{formatted_list}"
+
+    explanation += compile_times()
 
     # TODO(voz): Do we want a decorator for this?
     torchdynamo.reset()

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -37,6 +37,31 @@ troubleshooting_url = (
 
 log = logging.getLogger(__name__)
 
+# profiling compilation time
+compilation_metrics = collections.OrderedDict()
+
+
+def dynamo_timed(func):
+    def time_wrapper(*args, **kwargs):
+        t0 = time.time()
+        r = func(*args, **kwargs)
+        key = func.__qualname__
+        if key not in compilation_metrics:
+            compilation_metrics[key] = []
+        compilation_metrics[key].append(time.time() - t0)
+        return r
+
+    return time_wrapper
+
+
+def print_compile_times():
+    rows = [
+        (k, list(map(lambda f: f"{f:.4f}", compilation_metrics[k])))
+        for k in compilation_metrics
+    ]
+    print(tabulate.tabulate(rows, headers=("Function", "Runtimes (s)")))
+
+
 LOGGING_CONFIG = {
     "version": 1,
     "formatters": {

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -54,12 +54,14 @@ def dynamo_timed(func):
     return time_wrapper
 
 
-def print_compile_times():
+def compile_times():
     rows = [
         (k, list(map(lambda f: f"{f:.4f}", compilation_metrics[k])))
         for k in compilation_metrics
     ]
-    print(tabulate.tabulate(rows, headers=("Function", "Runtimes (s)")))
+    out = "TorchDynamo compilation metrics:\n"
+    out += tabulate.tabulate(rows, headers=("Function", "Runtimes (s)"))
+    return out
 
 
 LOGGING_CONFIG = {

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -6,6 +6,8 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from torchdynamo.utils import dynamo_timed
+
 from .. import codecache
 from .. import config
 from .. import ir
@@ -292,6 +294,7 @@ class WrapperCodeGen(CodeGen):
         self.allocated.add(output_buffer.get_name())
         self.writeline(ReuseLine(input_buffer, output_buffer))
 
+    @dynamo_timed
     def generate(self):
         result = IndentedBuffer()
         result.splice(self.header)

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -10,6 +10,8 @@ from sympy import Integer
 from torch._decomp import get_decompositions
 from torch.utils._mode_utils import no_dispatch
 
+from torchdynamo.utils import dynamo_timed
+
 from . import config
 from . import ir
 from .codegen.wrapper import WrapperCodeGen
@@ -131,6 +133,7 @@ class GraphLowering(torch.fx.Interpreter):
         self.randomness_offset = offset + numel
         return offset
 
+    @dynamo_timed
     def run(self, *args):
         if self.num_dynamic_inputs is None:
             self.num_dynamic_inputs = len(args)
@@ -310,6 +313,7 @@ class GraphLowering(torch.fx.Interpreter):
         self.scheduler.codegen()
         return self.wrapper_code.generate()
 
+    @dynamo_timed
     def compile_to_module(self):
         from .codecache import PyCodeCache
 

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -573,7 +573,6 @@ class Scheduler:
             for node in self.nodes:
                 node.log_details()
 
-    @dynamo_timed
     def compute_dependencies(self):
         """
         Create dependency edges between nodes, handling aliasing and
@@ -737,7 +736,6 @@ class Scheduler:
             if len(self.nodes) == old_len:
                 break
 
-    @dynamo_timed
     def fuse_nodes_once(self):
         """
         Mutates self.nodes to combine nodes into FusedSchedulerNodes.

--- a/torchinductor/scheduler.py
+++ b/torchinductor/scheduler.py
@@ -16,6 +16,8 @@ import numpy as np
 import sympy
 import torch
 
+from torchdynamo.utils import dynamo_timed
+
 from . import config
 from . import dependencies
 from . import ir
@@ -497,6 +499,7 @@ class NodeUser:
 
 
 class Scheduler:
+    @dynamo_timed
     def __init__(self, nodes):
         super(Scheduler, self).__init__()
         self.backends = {}
@@ -570,6 +573,7 @@ class Scheduler:
             for node in self.nodes:
                 node.log_details()
 
+    @dynamo_timed
     def compute_dependencies(self):
         """
         Create dependency edges between nodes, handling aliasing and
@@ -733,6 +737,7 @@ class Scheduler:
             if len(self.nodes) == old_len:
                 break
 
+    @dynamo_timed
     def fuse_nodes_once(self):
         """
         Mutates self.nodes to combine nodes into FusedSchedulerNodes.
@@ -984,6 +989,7 @@ class Scheduler:
             self.backends[device] = self.create_backend(device)
         return self.backends[device]
 
+    @dynamo_timed
     def codegen(self):
         for node in self.nodes:
             self.buffer_names_no_longer_needed.update(node.last_usage)


### PR DESCRIPTION
usage:
```
from .utils import print_compilation_metrics
print_compilation_metrics()
```

instrumentation:
```
from .utils import dynamo_timed
@dynamo_timed
my_function()
```

sample output:
```
Function                         Runtimes (s)
-------------------------------  --------------------
convert_frame_assert             ['0.0005']
GraphLowering.run                ['0.0637', '0.0204']
Scheduler.compute_dependencies   ['0.0001', '0.0001']
Scheduler.fuse_nodes_once        ['0.0001', '0.0002']
Scheduler.__init__               ['0.0417', '0.0597']
Scheduler.codegen                ['0.0223', '0.0225']
WrapperCodeGen.generate          ['0.0055', '0.0141']
GraphLowering.compile_to_fn      ['0.1230', '0.0988']
compile_fx_inner                 ['0.1881', '0.1217']
compile_fx.<locals>.fw_compiler  ['0.1881']
compile_fx.<locals>.bw_compiler  ['0.1218']
```