### PR TITLE
Fix how torchbench is installed in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
           name: Generate date for cache key
           command: date +%F > .circleci-date
       - restore_cache:
-          key: env-v5-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}-{{ checksum "requirements.txt" }}
+          key: env-v6-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}-{{ checksum "requirements.txt" }}
       - run:
           name: Install libs
           command: |
@@ -16,7 +16,7 @@ commands:
       - run:
           name: Install TorchBenchmark
           command: |
-            FILE=torchbenchmark/env-v5.key
+            FILE=torchbenchmark/env-v6.key
             if test -f "$FILE"; then
               # If torchbenchmark is updated, we need to invalidate the cache by bumping up the key version number,
               # but this won't happen very often because we also update cache daily.
@@ -25,8 +25,8 @@ commands:
               source .circleci/setup_env.sh
               conda install -y -c conda-forge git-lfs
               git lfs install --skip-repo --skip-smudge
-              git clone --recursive --depth=1 --shallow-submodules git@github.com:pytorch/benchmark.git -b xz9/use-s3-download torchbenchmark
-              (cd torchbenchmark && python install.py && touch env-v5.key)
+              git clone --recursive --depth=1 --shallow-submodules git@github.com:pytorch/benchmark.git torchbenchmark
+              (cd torchbenchmark && python install.py && touch env-v6.key)
               pip install gym==0.25.2  # workaround issue in 0.26.0
             fi
       - run:
@@ -40,7 +40,7 @@ commands:
             source .circleci/setup_env.sh
             python -m pip install git+https://github.com/rwightman/pytorch-image-models
       - save_cache:
-          key: env-v5-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}-{{ checksum "requirements.txt" }}
+          key: env-v6-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}-{{ checksum "requirements.txt" }}
           paths:
             - conda
             - env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,8 @@ commands:
             else
               source .circleci/setup_env.sh
               conda install -y -c conda-forge git-lfs
-              git lfs install --skip-repo
-              # git clone --recursive --depth=1 --shallow-submodules git@github.com:pytorch/benchmark.git torchbenchmark
-              # above doesn't work due to git-lfs auth issues, workaround with a tarball:
-              wget -O torchbenchmark.tar.bz2 "https://github.com/jansel/benchmark/releases/download/snapshots/torchbenchmark.tar.bz2"
-              tar jxvf torchbenchmark.tar.bz2
+              git lfs install --skip-repo --skip-smudge
+              git clone --recursive --depth=1 --shallow-submodules git@github.com:pytorch/benchmark.git torchbenchmark
               (cd torchbenchmark && python install.py && touch env-v4.key)
               pip install gym==0.25.2  # workaround issue in 0.26.0
             fi
@@ -520,3 +517,4 @@ workflows:
       - inductor_timm_training_3
       - inductor_timm_training_4
       - inductor_timm_training_5
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
       - run:
           name: Install TorchBenchmark
           command: |
-            FILE=torchbenchmark/env-v5.key
+            FILE=torchbenchmark/env-v6.key
             if test -f "$FILE"; then
               # If torchbenchmark is updated, we need to invalidate the cache by bumping up the key version number,
               # but this won't happen often because we also update cache daily.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,7 @@ commands:
               source .circleci/setup_env.sh
               conda install -y -c conda-forge git-lfs
               git lfs install --skip-repo --skip-smudge
-              git clone --recursive --depth=1 --shallow-submodules git@github.com:pytorch/benchmark.git torchbenchmark
-              # Reinstate smudge
-              git lfs install --force
+              git clone --recursive --depth=1 --shallow-submodules git@github.com:pytorch/benchmark.git -b inductor torchbenchmark
               (cd torchbenchmark && python install.py && touch env-v4.key)
               pip install gym==0.25.2  # workaround issue in 0.26.0
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ commands:
       - run:
           name: Install TorchBenchmark
           command: |
-            FILE=torchbenchmark/env-v6.key
+            FILE=torchbenchmark/env-v5.key
             if test -f "$FILE"; then
               # If torchbenchmark is updated, we need to invalidate the cache by bumping up the key version number,
-              # but this won't happen often because we also update cache daily.
+              # but this won't happen very often because we also update cache daily.
               echo "$FILE exists means restore_cache has succeeded, so skip installing torchbenchmark."
             else
               source .circleci/setup_env.sh
@@ -68,7 +68,7 @@ jobs:
           name: TorchBench run
           command: |
             source .circleci/setup_env.sh
-            python benchmarks/torchbench.py --skip-fp64-check --coverage -d cuda --raise-on-assertion-error --raise-on-backend-error -x Super_SloMo -x moco
+            python benchmarks/torchbench.py --skip-fp64-check --coverage -d cuda --raise-on-assertion-error --raise-on-backend-error -x Super_SloMo -x moco -x pytorch_struct
       - store_artifacts:
           path: coverage.csv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ commands:
               conda install -y -c conda-forge git-lfs
               git lfs install --skip-repo --skip-smudge
               git clone --recursive --depth=1 --shallow-submodules git@github.com:pytorch/benchmark.git torchbenchmark
+              # Reinstate smudge
+              git lfs install --force
               (cd torchbenchmark && python install.py && touch env-v4.key)
               pip install gym==0.25.2  # workaround issue in 0.26.0
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
           name: Generate date for cache key
           command: date +%F > .circleci-date
       - restore_cache:
-          key: env-v4-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}-{{ checksum "requirements.txt" }}
+          key: env-v5-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}-{{ checksum "requirements.txt" }}
       - run:
           name: Install libs
           command: |
@@ -16,16 +16,17 @@ commands:
       - run:
           name: Install TorchBenchmark
           command: |
-            FILE=torchbenchmark/env-v4.key
+            FILE=torchbenchmark/env-v5.key
             if test -f "$FILE"; then
-              # If torchbenchmark.tar.bz2 is updated, we need to invalidate the cache by bumping up the key version number
+              # If torchbenchmark is updated, we need to invalidate the cache by bumping up the key version number,
+              # but this won't happen often because we also update cache daily.
               echo "$FILE exists means restore_cache has succeeded, so skip installing torchbenchmark."
             else
               source .circleci/setup_env.sh
               conda install -y -c conda-forge git-lfs
               git lfs install --skip-repo --skip-smudge
-              git clone --recursive --depth=1 --shallow-submodules git@github.com:pytorch/benchmark.git -b inductor torchbenchmark
-              (cd torchbenchmark && python install.py && touch env-v4.key)
+              git clone --recursive --depth=1 --shallow-submodules git@github.com:pytorch/benchmark.git -b xz9/use-s3-download torchbenchmark
+              (cd torchbenchmark && python install.py && touch env-v5.key)
               pip install gym==0.25.2  # workaround issue in 0.26.0
             fi
       - run:
@@ -39,7 +40,7 @@ commands:
             source .circleci/setup_env.sh
             python -m pip install git+https://github.com/rwightman/pytorch-image-models
       - save_cache:
-          key: env-v4-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}-{{ checksum "requirements.txt" }}
+          key: env-v5-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}-{{ checksum "requirements.txt" }}
           paths:
             - conda
             - env

--- a/.circleci/expected_coverage.csv
+++ b/.circleci/expected_coverage.csv
@@ -30,7 +30,6 @@ cuda,pyhpc_isoneutral_mixing,1,1,1546,1546,1.0000,0.9992
 cuda,pyhpc_turbulent_kinetic_energy,1,1,1569,1569,1.0000,0.9989
 cuda,pytorch_CycleGAN_and_pix2pix,1,1,92,92,1.0000,0.9984
 cuda,pytorch_stargan,1,1,57,57,1.0000,0.9987
-cuda,pytorch_struct,1,1,42,42,1.0000,0.9921
 cuda,pytorch_unet,1,1,72,72,1.0000,0.9979
 cuda,resnet18,1,1,70,70,1.0000,0.9981
 cuda,resnet50,1,1,176,176,1.0000,0.9990

--- a/.circleci/expected_coverage.csv
+++ b/.circleci/expected_coverage.csv
@@ -41,7 +41,7 @@ cuda,speech_transformer,9,10,854,1209,0.7064,0.8849
 cuda,squeezenet1_1,1,1,67,67,1.0000,0.9978
 cuda,tacotron2,88,3449,26847,31376,0.8557,0.9139
 cuda,timm_efficientnet,1,1,240,240,1.0000,0.9992
-cuda,timm_regnet,1,1,447,447,1.0000,0.9995
+cuda,timm_regnet,1,1,319,319,1.0000,0.9995
 cuda,timm_resnest,1,1,128,129,0.9922,0.9986
 cuda,timm_vision_transformer,1,1,289,289,1.0000,0.9989
 cuda,timm_vovnet,1,1,130,130,1.0000,0.9987

--- a/.circleci/setup_env.sh
+++ b/.circleci/setup_env.sh
@@ -18,6 +18,7 @@ if [ ! -d "${conda_dir}" ]; then
     bash ./miniconda.sh -b -f -p "${conda_dir}"
 fi
 eval "$(${conda_dir}/bin/conda shell.bash hook)"
+export GIT_LFS_SKIP_SMUDGE=1
 
 if [ ! -d "${env_dir}" ]; then
     printf "* Creating a test environment at ${env_dir}\n"

--- a/.circleci/setup_env.sh
+++ b/.circleci/setup_env.sh
@@ -18,7 +18,6 @@ if [ ! -d "${conda_dir}" ]; then
     bash ./miniconda.sh -b -f -p "${conda_dir}"
 fi
 eval "$(${conda_dir}/bin/conda shell.bash hook)"
-export GIT_LFS_SKIP_SMUDGE=1
 
 if [ ! -d "${env_dir}" ]; then
     printf "* Creating a test environment at ${env_dir}\n"

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -56,6 +56,7 @@ output_filename = None
 
 CI_SKIP_INFERENCE = [
     # TorchBench
+    "detectron2",
     "dlrm",
     "fambench_dlrm",
     "fastNLP_Bert",

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -105,6 +105,7 @@ CI_SKIP_TRAINING = [
     "hf_GPT2",
     "mobilenet_",
     "pytorch_struct",
+    "timm_regnet",
     "vgg16",
     "Background_Matting",  # from functionalization
     "mobilenet_v2_quantized_qat",  # from functionalization


### PR DESCRIPTION
Summary: leverage https://github.com/pytorch/benchmark/pull/1158 to use read torchbench data from S3 instead of using git lfs