### PR TITLE
avoid value dependent output shape slicing

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1844,28 +1844,6 @@ class MiscTests(torchdynamo.testing.TestCase):
         self.assertEqual(y, 11)
         self.assertEqual(z, 61)
 
-    def test_slicing_dynamic_shape(self):
-        def fn(y):
-            x = torch.ones(8)
-            idx = y[0]
-            out = x[idx:]
-            return (out + 3) * 5
-
-        counter = torchdynamo.testing.CompileCounter()
-        opt_fn = torchdynamo.optimize(counter)(fn)
-        out = opt_fn(torch.ones(10, dtype=torch.long))
-        # idx should be 1 -> slicing off [1:] of 8 elem tensor
-        self.assertEqual(list(out.shape), [7])
-
-        dyn = torchdynamo.config.dynamic_shapes
-        expected_ops = 5 if dyn else 4
-        expected_frame = 1 if dyn else 2
-
-        self.assertEqual(expected_ops, expected_ops)
-        self.assertEqual(expected_frame, expected_frame)
-
-        self.assertEqual(list(opt_fn(torch.tensor([4])).shape), [4])
-
     def test_cross_entropy_loss_fancy_ctor(self):
         output = None
         rand_5 = torch.randn(5)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1856,8 +1856,12 @@ class MiscTests(torchdynamo.testing.TestCase):
         out = opt_fn(torch.ones(10, dtype=torch.long))
         # idx should be 1 -> slicing off [1:] of 8 elem tensor
         self.assertEqual(list(out.shape), [7])
+
         # graph break on slice
-        self.assertEqual(counter.op_count, 3)
+        self.assertEqual(counter.op_count, 5)
+        self.assertEqual(counter.frame_count, 1)
+
+        self.assertEqual(list(opt_fn(torch.tensor([4])).shape), [4])
 
     def test_cross_entropy_loss_fancy_ctor(self):
         output = None

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1857,9 +1857,12 @@ class MiscTests(torchdynamo.testing.TestCase):
         # idx should be 1 -> slicing off [1:] of 8 elem tensor
         self.assertEqual(list(out.shape), [7])
 
-        # graph break on slice
-        self.assertEqual(counter.op_count, 5)
-        self.assertEqual(counter.frame_count, 1)
+        dyn = torchdynamo.config.dynamic_shapes
+        expected_ops = 5 if dyn else 4
+        expected_frame = 1 if dyn else 2
+
+        self.assertEqual(expected_ops, expected_ops)
+        self.assertEqual(expected_frame, expected_frame)
 
         self.assertEqual(list(opt_fn(torch.tensor([4])).shape), [4])
 

--- a/test/test_repros.py
+++ b/test/test_repros.py
@@ -892,7 +892,6 @@ class ReproTests(torchdynamo.testing.TestCase):
         # idx should be 1 -> slicing off [1:] of 8 elem tensor
         self.assertEqual(list(out.shape), [7])
 
-        dyn = torchdynamo.config.dynamic_shapes
         expected_ops = ifdyn(5, 4)
         expected_frame = ifdyn(1, 2)
 

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -154,7 +154,12 @@ class TensorVariable(VariableTracker):
         # fake tensors, and which would determine the output shape of the slice.
         # It is a workaround until https://github.com/pytorch/pytorch/pull/83567
         # is landed and there is more complete support for breaking on data dependent operators.
-        if proxy.node.target == operator.getitem and use_fake_tensors:
+        if (
+            proxy.node.target == operator.getitem
+            and use_fake_tensors
+            and args is not None
+            and config.dynamic_shapes
+        ):
             if (
                 isinstance(args[0], FakeTensor)
                 and isinstance(args[1], slice)
@@ -163,9 +168,7 @@ class TensorVariable(VariableTracker):
                     for e in (args[1].start, args[1].stop, args[1].step)
                 )
             ):
-                raise torch._subclasses.fake_tensor.DynamicOutputShapeException(
-                    torch.ops.aten.slice.Tensor
-                )
+                unimplemented("dynamic shape slicing")
 
         if isinstance(example_value, torch.Tensor):
             is_parameter = isinstance(example_value, torch.nn.Parameter)

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -154,11 +154,12 @@ class TensorVariable(VariableTracker):
         # fake tensors, and which would determine the output shape of the slice.
         # It is a workaround until https://github.com/pytorch/pytorch/pull/83567
         # is landed and there is more complete support for breaking on data dependent operators.
+
         if (
             proxy.node.target == operator.getitem
             and use_fake_tensors
             and args is not None
-            and config.dynamic_shapes
+            and not config.dynamic_shapes
         ):
             if (
                 isinstance(args[0], FakeTensor)

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -148,6 +148,23 @@ class TensorVariable(VariableTracker):
                 if use_fake_tensors:
                     example_value = fake_wrapper(example_value)
 
+        # Avoids a .item() call in the tensor slice that would attempt to get a value out
+        # fake tensors, and which would determine the output shape of the slice.
+        # It is a workaround until https://github.com/pytorch/pytorch/pull/83567
+        # is landed and there is more complete support for breaking on data dependent operators.
+        if proxy.node.target == operator.getitem and use_fake_tensors:
+            if (
+                isinstance(args[0], FakeTensor)
+                and isinstance(args[1], slice)
+                and any(
+                    isinstance(e, FakeTensor)
+                    for e in (args[1].start, args[1].stop, args[1].step)
+                )
+            ):
+                raise torch._subclasses.fake_tensor.DynamicOutputShapeException(
+                    torch.ops.aten.slice.Tensor
+                )
+
         if isinstance(example_value, torch.Tensor):
             is_parameter = isinstance(example_value, torch.nn.Parameter)
             parameter_value = initial_example_value if is_parameter else None

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -113,7 +113,9 @@ class TensorVariable(VariableTracker):
             def wrap_fake_exception(func):
                 return func()
 
+        args = kwargs = None
         initial_example_value = example_value
+
         with preserve_rng_state():
             if example_value is None:
                 op = proxy.node.op


### PR DESCRIPTION
From code comment:
Avoid a .item() call in the tensor slice that would attempt to get a value out
fake tensors, and which would determine the output shape of the slice.
It is a workaround until https://github.com/pytorch/pytorch/pull/83567
is landed and there is more complete support for breaking on data dependent operators.

I'm deferring on landing 83567 because there are a bunch of spurious `.item()` calls that get invoked for 0-element tensors and im worried about regressing perf with a bunch of graph breaks. To avoid that im adding handling for constant tensor tracking but that's a bit of a ways off and this issue with slicing is blocking correctness/some other models.