### PR TITLE
[inductor] TORCHINDUCTOR_TRACE=1 debug mode

### DIFF
--- a/torchdynamo/debug_utils.py
+++ b/torchdynamo/debug_utils.py
@@ -96,18 +96,22 @@ def dump_state(gm, args, compiler_name):
     file_name = os.path.join(subdir, f"{len(gm.graph.nodes)}.py")
     print(f"Writing checkpoint with {len(gm.graph.nodes)} nodes to {file_name}")
     with open(file_name, "w") as fd:
-        fd.write(generate_repro_string(gm, args))
-        fd.write(COMPILER_REPRO_OPTIONS[compiler_name][0])
-        fd.write(
-            textwrap.dedent(
-                f"""
-                compiled = {COMPILER_REPRO_OPTIONS[compiler_name][1]}(mod, args)
-                compiled(*args)
-                """
-            )
-        )
+        save_graph_repro(fd, gm, args, compiler_name)
     repro_path = os.path.join(torchdynamo.config.base_dir, "repro.py")
     shutil.copyfile(file_name, repro_path)
+
+
+def save_graph_repro(fd, gm, args, compiler_name):
+    fd.write(generate_repro_string(gm, args))
+    fd.write(COMPILER_REPRO_OPTIONS[compiler_name][0])
+    fd.write(
+        textwrap.dedent(
+            f"""
+            compiled = {COMPILER_REPRO_OPTIONS[compiler_name][1]}(mod, args)
+            compiled(*args)
+            """
+        )
+    )
 
 
 def isolate_fails(fx_g, args, compiler_name: str, env=None):

--- a/torchinductor/codecache.py
+++ b/torchinductor/codecache.py
@@ -156,11 +156,10 @@ class PyCodeCache:
             with open(path) as f:
                 code = compile(f.read(), path, "exec")
                 mod = types.ModuleType(f"{__name__}.{key}")
+                mod.__file__ = path
                 exec(code, mod.__dict__, mod.__dict__)
                 cls.cache[key] = mod
                 cls.cache[key].key = key
-        if config.debug:
-            print(f"PyCodeCache {path}")
         return cls.cache[key]
 
 

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -1,25 +1,21 @@
 import dataclasses
 import functools
 import logging
-import operator
 from typing import List
 
 import torch.fx
 from functorch.compile import min_cut_rematerialization_partition
 
-from torchdynamo.debug_utils import wrap_debug
 from torchdynamo.optimizations.backends import aot_autograd
 from torchdynamo.optimizations.normalize import normalize_ir
-from torchdynamo.testing import same
 from torchdynamo.utils import identity
-from torchdynamo.utils import init_logging
 
 from . import config
 from . import overrides
+from .debug import DebugContext
 from .decomposition import select_decomp_table
 from .graph import GraphLowering
 from .utils import ceildiv
-from .utils import gen_gm_and_inputs
 from .virtualized import V
 
 log = logging.getLogger(__name__)
@@ -40,36 +36,17 @@ class BoxedBool:
         return False
 
 
-class CheckEachNode(torch.fx.Interpreter):
-    def call_function(self, target, args, kwargs):
-        expected = target(*args, **kwargs)
-        if target in (operator.getitem,):
-            return expected
-
-        gm, gm_inps = gen_gm_and_inputs(target, args, kwargs)
-        graph = GraphLowering(gm)
-        with V.set_graph_handler(graph):
-            graph.run(*args, **kwargs)
-            actual = graph.compile_to_fn()(*gm_inps)
-
-        if isinstance(expected, torch.Tensor):
-            actual = actual[0]
-
-        print(target, same(expected, actual))
-        assert same(expected, actual)
-
-        return expected
-
-
-@functools.partial(wrap_debug, compiler_name="inductor")
+@DebugContext.wrap
 def compile_fx_inner(
     gm: torch.fx.GraphModule,
     example_inputs: List[torch.Tensor],
     wrap=identity,
     cudagraphs=None,
     num_fixed=0,
+    is_backward=False,
 ):
-    init_logging()
+    log.info("Compiling %s graph", "BACKWARDS" if is_backward else "FORWARDS")
+    V.debug.fx_graph(gm, example_inputs)
 
     if cudagraphs is None:
         cudagraphs = config.triton.cudagraphs
@@ -182,10 +159,6 @@ def count_tangents(fx_g: torch.fx.GraphModule):
 
 def compile_fx(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]):
     """Main entrypoint to a compile given FX graph"""
-    logging.getLogger("torchinductor").setLevel(
-        logging.DEBUG if config.debug else logging.WARNING
-    )
-
     with overrides.patch_functions():
         model_ = normalize_ir(model_, example_inputs_)
         model_ = overrides.replace_fx(model_)
@@ -193,21 +166,19 @@ def compile_fx(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]
     cudagraphs = BoxedBool(config.triton.cudagraphs)
 
     def fw_compiler(model: torch.fx.GraphModule, example_inputs):
-        if config.debug:
-            print("FORWARD GRAPH:")
-            model.graph.print_tabular()
         fixed = len(example_inputs) - num_example_inputs
         return compile_fx_inner(
             model, example_inputs, num_fixed=fixed, cudagraphs=cudagraphs
         )
 
     def bw_compiler(model: torch.fx.GraphModule, example_inputs):
-        if config.debug:
-            print("BACKWARD GRAPH:")
-            model.graph.print_tabular()
         fixed = count_tangents(model)
         return compile_fx_inner(
-            model, example_inputs, num_fixed=fixed, cudagraphs=cudagraphs
+            model,
+            example_inputs,
+            num_fixed=fixed,
+            cudagraphs=cudagraphs,
+            is_backward=True,
         )
 
     with overrides.patch_functions():

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -1,3 +1,5 @@
+import os
+
 # add some debug printouts
 debug = False
 
@@ -101,3 +103,33 @@ class triton:
     # should we stop a fusion to allow better tiling?
     tiling_prevents_pointwise_fusion = True
     tiling_prevents_reduction_fusion = True
+
+
+# create a directory containing lots of debug information
+class trace:
+    # master switch for all debugging flags below
+    enabled = os.environ.get("TORCHINDUCTOR_TRACE", "0") == "1"
+
+    # Save python logger call >=logging.DEBUG
+    debug_log = True
+
+    # Save python logger call >=logging.INFO
+    info_log = False
+
+    # Save input FX graph (post decomps)
+    fx_graph = True
+
+    # Save TorchInductor IR before fusion pass
+    ir_pre_fusion = True
+
+    # Save TorchInductor IR after fusion pass
+    ir_post_fusion = True
+
+    # Copy generated code to trace dir
+    output_code = True
+
+    # SVG figure showing post-fusion graph
+    graph_diagram = False
+
+    # Store cProfile (see snakeviz to view)
+    compile_profile = False

--- a/torchinductor/debug.py
+++ b/torchinductor/debug.py
@@ -1,33 +1,65 @@
 import collections
+import contextlib
+import cProfile
+import functools
+import itertools
+import logging
+import os.path
+import pstats
+import shutil
+import subprocess
 from typing import Any
 from typing import List
 
 import torch
+from functorch.compile import draw_graph
+from functorch.compile import get_graph_being_compiled
 from torch import fx as fx
+from torch.fx.graph_module import GraphModule
+from torch.fx.passes.shape_prop import TensorMetadata
+from torch.fx.passes.tools_common import legalize_graph
 
-from torchinductor import ir
-from torchinductor.scheduler import BaseSchedulerNode
-from torchinductor.scheduler import ExternKernelSchedulerNode
-from torchinductor.scheduler import FusedSchedulerNode
-from torchinductor.scheduler import NopKernelSchedulerNode
-from torchinductor.scheduler import OutputNode
-from torchinductor.scheduler import SchedulerNode
-from torchinductor.scheduler import TemplateSchedulerNode
+import torchinductor
+from torchdynamo.debug_utils import save_graph_repro
+from torchdynamo.debug_utils import wrap_debug
+from torchdynamo.utils import init_logging
+
+from . import config
+from . import ir
+from .codecache import cache_dir
+from .scheduler import BaseSchedulerNode
+from .scheduler import ExternKernelSchedulerNode
+from .scheduler import FusedSchedulerNode
+from .scheduler import NopKernelSchedulerNode
+from .scheduler import OutputNode
+from .scheduler import SchedulerNode
+from .scheduler import TemplateSchedulerNode
+from .virtualized import V
+
+log = logging.getLogger(__name__)
 
 
-def draw_buffers(nodes, print_graph=False):
+@functools.lru_cache(None)
+def has_dot():
+    try:
+        subprocess.check_output(["which", "dot"], stderr=subprocess.PIPE)
+        return True
+    except subprocess.SubprocessError:
+        return False
+
+
+def draw_buffers(nodes, print_graph=False, fname=None):
     """
     Draw a graph in fname.svg.
     nodes is a list of SchedulerNode objects.
     """
+    if not has_dot():
+        log.warning("draw_buffers() requires `graphviz` package")
+        return
 
-    from functorch.compile import draw_graph
-    from functorch.compile import get_graph_being_compiled
-    from torch.fx.graph_module import GraphModule
-    from torch.fx.passes.shape_prop import TensorMetadata
-    from torch.fx.passes.tools_common import legalize_graph
+    if fname is None:
+        fname = get_graph_being_compiled()
 
-    fname = get_graph_being_compiled()
     graph = create_fx_from_snodes(nodes)
 
     for node in graph.nodes:
@@ -47,11 +79,10 @@ def draw_buffers(nodes, print_graph=False):
 
     if print_graph:
         print(graph)
-    print("starting creating module")
+
     gm = GraphModule({}, graph)
     legalize_graph(gm)
     gm.graph.lint()
-    print("starting drawing")
     draw_graph(gm, fname, clear_meta=False)
 
 
@@ -138,3 +169,148 @@ def create_fx_from_snodes(snodes: List[BaseSchedulerNode]) -> fx.Graph:
 
     graph.output(outputs[0] if len(outputs) == 1 else tuple(outputs))
     return graph
+
+
+class DebugContext:
+    _counter = itertools.count()
+
+    @staticmethod
+    def wrap(fn):
+        @functools.wraps(fn)
+        def inner(*args, **kwargs):
+            with DebugContext():
+                return fn(*args, **kwargs)
+
+        return wrap_debug(inner, compiler_name="inductor")
+
+    @staticmethod
+    def create_debug_dir():
+        for n in DebugContext._counter:
+            dirname = os.path.join(cache_dir(), f"debug.{os.getpid()}.{n}")
+            if not os.path.exists(dirname):
+                os.makedirs(dirname)
+                return dirname
+
+    def __init__(self):
+        self._prof = None
+        self._path = None
+        self._stack = contextlib.ExitStack()
+
+    def rename(self, new_path: str):
+        if not self._path:
+            return
+        assert new_path.endswith(".debug"), new_path
+        if os.path.exists(new_path):
+            shutil.rmtree(new_path)
+        try:
+            os.rename(self._path, new_path)
+            self._path = new_path
+        except OSError:
+            # other OS might have troubling renaming dir with open files
+            pass
+
+    def fopen(self, filename):
+        assert self._path
+        return open(os.path.join(self._path, filename), "w")
+
+    def filename(self, suffix):
+        return os.path.join(self._path, suffix)
+
+    def __enter__(self):
+        log = logging.getLogger("torchinductor")
+        if not log.handlers:
+            init_logging()
+
+        for handler in itertools.chain([log], log.handlers):
+            handler.setLevel(logging.DEBUG if config.debug else logging.WARNING)
+
+        self._stack.enter_context(V.set_debug_handler(self))
+
+        if not config.trace.enabled:
+            return
+
+        self._path = self.create_debug_dir()
+
+        if config.trace.debug_log:
+            self._setup_log_capture("debug.log", logging.DEBUG)
+        if config.trace.info_log:
+            self._setup_log_capture("info.log", logging.INFO)
+        if config.trace.compile_profile:
+            self._prof = cProfile.Profile()
+            self._prof.enable()
+
+    def _setup_log_capture(self, filename, level):
+        log = logging.getLogger("torchinductor")
+        fd = self._stack.enter_context(self.fopen(filename))
+        ch = logging.StreamHandler(fd)
+        ch.setLevel(level)
+        ch.setFormatter(
+            logging.Formatter("[%(filename)s:%(lineno)d %(levelname)s] %(message)s")
+        )
+        log.addHandler(ch)
+        log.setLevel(min(log.level, level))
+        self._stack.callback(log.removeHandler, ch)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._prof:
+            self._prof.disable()
+            self._save_profile_data()
+
+        if self._path:
+            log.warning("%s debug trace: %s", get_graph_being_compiled(), self._path)
+        self._stack.close()
+
+    def _save_profile_data(self):
+        self._prof.dump_stats(self.filename("compile.prof"))
+        with self.fopen("compile.stats") as fd:
+            stats = pstats.Stats(self._prof, stream=fd)
+            stats.strip_dirs()
+            stats.sort_stats("cumtime")
+            stats.print_stats(100)
+            stats.sort_stats("tottime")
+            stats.print_stats(100)
+
+    def __getattr__(self, name):
+        if config.trace.enabled and getattr(config.trace, name):
+            try:
+                return getattr(DebugFormatter(self), name)
+            except Exception:
+                log.warning("Ignoring exception in debug code", exc_info=True)
+        else:
+
+            def ignored(*args, **kwargs):
+                pass
+
+            return ignored
+
+
+SchedulerNodeList = List["torchinductor.scheduler.BaseSchedulerNode"]
+
+
+class DebugFormatter:
+    def __init__(self, handler):
+        self.fopen = handler.fopen
+        self.filename = handler.filename
+        self.handler = handler
+
+    def fx_graph(self, gm: torch.fx.GraphModule, inputs: List[torch.Tensor]):
+        with self.fopen("fx_graph.py") as fd:
+            save_graph_repro(fd, gm, inputs, "inductor")
+
+    def ir_pre_fusion(self, nodes: SchedulerNodeList):
+        self._write_ir("ir_pre_fusion.txt", nodes)
+
+    def ir_post_fusion(self, nodes: SchedulerNodeList):
+        self._write_ir("ir_post_fusion.txt", nodes)
+
+    def _write_ir(self, filename: str, nodes: SchedulerNodeList):
+        with self.fopen(filename) as fd:
+            for node in nodes:
+                fd.write(node.debug_str())
+                fd.write("\n\n\n")
+
+    def graph_diagram(self, nodes: SchedulerNodeList):
+        draw_buffers(nodes, fname=self.filename("graph_diagram.svg"))
+
+    def output_code(self, filename):
+        shutil.copy(filename, self.filename("output_code.py"))

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -3398,5 +3398,7 @@ class LoopBodyBlock:
         code = self.make_gm().code
         return re.sub(
             # strip `; del var0` suffixes to make output prettier
-            r";[^\n]*", "", code.strip().replace("def forward(", f"def {name}(")
+            r";[^\n]*",
+            "",
+            code.strip().replace("def forward(", f"def {name}("),
         )

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -3397,5 +3397,6 @@ class LoopBodyBlock:
     def debug_str(self, name="block"):
         code = self.make_gm().code
         return re.sub(
+            # strip `; del var0` suffixes to make output prettier
             r";[^\n]*", "", code.strip().replace("def forward(", f"def {name}(")
         )

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -3,6 +3,7 @@ import dataclasses
 import functools
 import itertools
 import logging
+import re
 import textwrap
 from collections import OrderedDict
 from functools import partial
@@ -3239,6 +3240,19 @@ class LoopBody:
         self.root_block = LoopBodyBlock(self, fn, args)
         self.indexing = None
 
+    def debug_str(self):
+        lines = [f"var_ranges = {dict(self.var_ranges)}"]
+        lines.extend([f"{name} = {val}" for name, val in self.indexing_exprs.items()])
+        lines.extend(
+            [
+                block.debug_str(name)
+                for name, block in itertools.chain(
+                    [("body", self.root_block)], self.subblocks.items()
+                )
+            ]
+        )
+        return "\n".join(lines)
+
     def add_index_expr(self, expr: sympy.Expr, category, buf_name):
         getattr(self, category).append(expr)
         if buf_name is not None:
@@ -3372,8 +3386,16 @@ class LoopBodyBlock:
             tracer.create_proxy("output", "output", (fn(*args),), {})
         self.graph = tracer.graph
 
-    def __call__(self):
-        gm = torch.fx.GraphModule(
+    def make_gm(self):
+        return torch.fx.GraphModule(
             {**self.body.submodules, "get_index": self.body.get_index}, self.graph
         )
-        return gm.forward(V.get_ops_handler())
+
+    def __call__(self):
+        return self.make_gm().forward(V.get_ops_handler())
+
+    def debug_str(self, name="block"):
+        code = self.make_gm().code
+        return re.sub(
+            r";[^\n]*", "", code.strip().replace("def forward(", f"def {name}(")
+        )

--- a/torchinductor/virtualized.py
+++ b/torchinductor/virtualized.py
@@ -92,6 +92,7 @@ MockHandler._init_cls()
 ops = Virtualized("ops", MockHandler)
 _graph = Virtualized("graph", NullHandler)
 _kernel = Virtualized("kernel", NullHandler)
+_debug = Virtualized("debug", NullHandler)
 
 
 class _V:
@@ -102,6 +103,7 @@ class _V:
     get_ops_handler = ops._get_handler
     set_graph_handler = _graph._set_handler
     set_kernel_handler = _kernel._set_handler
+    set_debug_handler = _debug._set_handler
 
     @property
     def ops(self) -> MockHandler:
@@ -117,6 +119,10 @@ class _V:
     def kernel(self) -> "torchdynamo.codegen.common.Kernel":
         """The kernel currently being generated"""
         return _kernel._get_handler()
+
+    @property
+    def debug(self) -> "torchdynamo.debug.DebugContext":
+        return _debug._get_handler()
 
 
 V = _V()


### PR DESCRIPTION
This is a new debugging tool designed to make it easier to debug/understand the internals of  TorchInductor.

Setting the environment variable `TORCHINDUCTOR_TRACE=1` will cause a debug trace directory to be created and printed:
```
$ env TORCHINDUCTOR_TRACE=1 python repro.py
torchinductor.debug: [WARNING] model_forward_0 debug trace: /tmp/torchinductor_jansel/rh/crhwqgmbqtchqt3v3wdeeszjb352m4vbjbvdovaaeqpzi7tdjxqr.debug
```

Here is an [example debug directory output](https://gist.github.com/jansel/f4af078791ad681a0d4094adeb844396) for the test program:
```
torch.nn.Sequential(
        torch.nn.Linear(10, 10),
        torch.nn.LayerNorm(10),
        torch.nn.ReLU(),
    )
```

Note each file in that debug trace can be enabled/disabled via `torchinductor.config.trace.*`.  The profile and the diagram are both disabled by default since they are expensive to generate.

A single node in this new debug format looks like:
```
buf1: SchedulerNode(ComputedBuffer)
buf1.writes = 
    {   MemoryDep(name='buf1', index=0, size=()),
        MemoryDep(name='buf1', index=0, size=(s0,))}
buf1.unmet_dependencies = {MemoryDep(name='buf0', index=c0, size=(s0,))}
buf1.met_dependencies = {MemoryDep(name='primals_2', index=c0, size=(s0,))}
buf1.group.device = cuda:0
buf1.group.iteration = (1, s0)
buf1.sizes = ([], [s0])
class buf1_loop_body:
    var_ranges = {z0: s0}
    index0 = z0
    index1 = 0
    def body(self, ops):
        get_index = self.get_index('index0')
        load = ops.load('buf0', get_index, False)
        get_index_1 = self.get_index('index0')
        load_1 = ops.load('primals_2', get_index_1, False)
        add = ops.add(load, load_1)
        get_index_2 = self.get_index('index1')
        reduction = ops.reduction('buf1', torch.float32, torch.float32, 'sum', get_index_2, add)
        return reduction
```
See the [example debug directory output](https://gist.github.com/jansel/f4af078791ad681a0d4094adeb844396) for more examples.