### PR TITLE
[inductor] Don't autotune contiguous reductions

### DIFF
--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -92,9 +92,6 @@ class triton:
     # limit tiling dimensions
     max_tiles = 2
 
-    # put each kernel in its own file
-    many_files = False
-
     # use triton.autotune?
     autotune = True
 

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -91,6 +91,9 @@ class MemoryDep(typing.NamedTuple):
             return False
         return True
 
+    def is_contiguous(self) -> bool:
+        return isinstance(self.index, (sympy.Symbol, sympy.Integer))
+
 
 class StarDep(typing.NamedTuple):
     # depends on the entire buffer
@@ -105,6 +108,9 @@ class StarDep(typing.NamedTuple):
         return 1
 
     def is_simple(self) -> bool:
+        return False
+
+    def is_contiguous(self) -> bool:
         return False
 
 

--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -1,4 +1,9 @@
+import hashlib
+import json
 import logging
+import os.path
+import textwrap
+from typing import List
 
 import triton
 from triton import Config
@@ -18,23 +23,99 @@ from .conv_perf_model import estimate_conv_time
 log = logging.getLogger(__name__)
 
 
-class Autotuner(triton.code_gen.Autotuner):
+def load_cached_autotuning(
+    cache_filename: str, configs_hash: str, configs: List[Config]
+):
     """
-    Customized triton autotuner
+    Read a cached autotuning result from disk
     """
+    if not os.path.exists(cache_filename):
+        return None
 
-    def _bench(self, *args, config, **kwargs):
-        try:
-            return super()._bench(*args, config=config, **kwargs)
-        except triton.code_gen.OutOfResources as e:
-            log.warning("OutOfResources: %s %s", e, config)
-            return (float("inf"), float("inf"), float("inf"))
+    best_config = json.loads(open(cache_filename).read())
+    if best_config.get("configs_hash") != configs_hash:
+        return None
+
+    matching_configs = [
+        cfg
+        for cfg in configs
+        if all(val == best_config.get(key) for key, val in cfg.kwargs.items())
+    ]
+    if len(matching_configs) != 1:
+        return None
+
+    return matching_configs[0]
 
 
-def autotune(configs, key, prune_configs_by=None, reset_to_zero=None):
+def hash_configs(configs: List[Config]):
     """
-    A copy of triton.autotune that calls our subclass above
+    Hash used to check for changes in configurations
     """
+    hasher = hashlib.sha256()
+    for cfg in configs:
+        hasher.update(
+            f"{sorted(cfg.kwargs.items())} {cfg.num_warps} {cfg.num_stages}\n".encode(
+                "utf-8"
+            )
+        )
+    return hasher.hexdigest()
+
+
+def autotune(
+    configs: List[Config],
+    key: List[str],
+    prune_configs_by=None,
+    reset_to_zero=None,
+    debug_label=None,
+    filename=None,
+):
+    """
+    A copy of triton.autotune that calls our subclass.  Our subclass
+    has additional debugging, error handling, and on-disk caching.
+    """
+    configs = unique_configs(configs)
+    results = []
+
+    class Autotuner(triton.code_gen.Autotuner):
+        def _bench(self, *args, config, **kwargs):
+            try:
+                result = super()._bench(*args, config=config, **kwargs)
+                if debug_label:
+                    results.append(f"{config}: {result[0]}")
+                    if len(results) == len(configs):
+                        log.warning(
+                            "Autouning Results %s\n%s",
+                            debug_label,
+                            textwrap.indent("\n".join(results), " " * 4),
+                        )
+                return result
+            except triton.code_gen.OutOfResources as e:
+                log.warning("OutOfResources: %s %s", e, config)
+                return (float("inf"), float("inf"), float("inf"))
+
+    # on disk caching logic
+    if filename is not None and len(configs) > 1:
+        cache_filename = os.path.splitext(filename)[0] + ".best_config"
+        configs_hash = hash_configs(configs)
+
+        best_config = load_cached_autotuning(cache_filename, configs_hash, configs)
+        if best_config:
+            configs = [best_config]
+        else:
+
+            def call_and_store_cache(self, *args, **kwargs):
+                result = triton.code_gen.Autotuner.__call__(self, *args, **kwargs)
+                with open(cache_filename, "w") as fd:
+                    fd.write(
+                        json.dumps(
+                            {**self.best_config.kwargs, "configs_hash": configs_hash}
+                        )
+                    )
+                self.configs = [self.best_config]
+                del Autotuner.__call__  # uninstall this hook
+                return result
+
+            Autotuner.__call__ = call_and_store_cache
 
     def decorator(fn):
         def wrapper(kernel):
@@ -48,7 +129,19 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None):
     return decorator
 
 
-def triton_config(size_hints, x, y=None, z=None, num_stages=1):
+def unique_configs(configs: List[Config]):
+    """Remove duplicate configurations"""
+    seen = set()
+    pruned_configs = []
+    for cfg in configs:
+        key = tuple(cfg.kwargs.items())
+        if key not in seen:
+            seen.add(key)
+            pruned_configs.append(cfg)
+    return pruned_configs
+
+
+def triton_config(size_hints, x, y=None, z=None, num_stages=1) -> Config:
     """
     Construct a pointwise triton config with some adjustment heuristics
     based on size_hints. Size_hints is a tuple of numels in each tile
@@ -100,7 +193,7 @@ def triton_config(size_hints, x, y=None, z=None, num_stages=1):
     return Config(cfg, num_warps=num_warps, num_stages=num_stages)
 
 
-def triton_config_reduction(size_hints, x, r, num_stages=2):
+def triton_config_reduction(size_hints, x, r, num_stages=2) -> Config:
     """
     Construct a reduction triton config with some adjustment heuristics
     based on size_hints. Size_hints is a tuple of numels in each tile
@@ -159,21 +252,14 @@ def apply_triton_config(config):
     """
     Decorator that applies a fixed triton config using triton.heuristics.
     """
-
-    def getter(name):
-        def get(args):
-            return config.kwargs[name]
-
-        return get
-
-    return heuristics({name: getter(name) for name in config.kwargs.keys()})
+    # Autotuner with 1-config is no-op
+    return autotune([config], ["xnumel"])
 
 
-def pointwise_heuristics(size_hints):
+def pointwise_heuristics(size_hints, contiguous=False, filename=None):
     """
     Construct @triton.heuristics() based on size_hints.
     """
-
     if len(size_hints) == 1:
         return apply_triton_config(triton_config(size_hints, 1024))
     if len(size_hints) == 2:
@@ -188,6 +274,7 @@ def pointwise_heuristics(size_hints):
                 triton_config(size_hints, 1024, 1),
             ],
             key=["xnumel", "ynumel"],
+            filename=filename,
         )
     if len(size_hints) == 3:
         if not config.triton.autotune:
@@ -203,30 +290,35 @@ def pointwise_heuristics(size_hints):
                 triton_config(size_hints, 1, 1, 1024),
             ],
             key=["xnumel", "ynumel", "znumel"],
+            filename=filename,
         )
     raise NotImplementedError(f"size_hints: {size_hints}")
 
 
-def reduction_heuristics(size_hints):
+def reduction_heuristics(size_hints, contiguous=False, filename=None):
     """args to @triton.heuristics()"""
-
+    rnumel = size_hints[-1]
     if len(size_hints) == 2:
+        contiguous_config = triton_config_reduction(
+            size_hints, 1, (rnumel if 256 <= rnumel < 2048 else 2048), num_stages=1
+        )
+        if contiguous:
+            return apply_triton_config(contiguous_config)
         if not config.triton.autotune:
             return apply_triton_config(triton_config_reduction(size_hints, 32, 128))
         return autotune(
             [
                 triton_config_reduction(size_hints, 64, 64),
-                #                triton_config_reduction(size_hints, 16, 64),
-                #                triton_config_reduction(size_hints, 32, 128),
                 triton_config_reduction(
                     size_hints, 128, 8
                 ),  # this one is the best for outer reduction
                 triton_config_reduction(
                     size_hints, 8, 512
                 ),  # this and the next one seem very similar but both are needed for perf
-                triton_config_reduction(size_hints, 1, 2048, num_stages=1),
+                contiguous_config,
             ],
             key=["xnumel", "rnumel"],
+            filename=filename,
         )
     """
     # This is not tested yet:
@@ -243,6 +335,7 @@ def reduction_heuristics(size_hints):
                 triton_config_tiled_reduction(size_hints, 1, 1, 2048, num_stages=1),
             ],
             key=["xnumel", "ynumel", "rnumel"],
+            filename=filename,
         )
     """
     raise NotImplementedError(f"size_hints: {size_hints}")


### PR DESCRIPTION
This PR should improve compile times.  Previously we spent >50% of our time inside the Triton autotuner.

This removes the bulk of those autotuner calls by using a heuristic to schedule contiguous reductions instead of autotuning them.  I'd estimate this is a ~2x improvement in compile time based on some limited testing.

This also adds caching of autotuning results, which will speed up compile times dramatically (I measured 8.1x on TorchBench, including the other changes) when your cache is warm.

As a bonus, this also speeds up our geomean perf by a couple percent.  The prior autotuner was missing some choices that help some models.  Specifically for `numel=1024, reduction_numel=512`, the new heuristic picks a block of `[1, 512]` -- which is faster than the autotuner's chosen config of `[4, 512]`.
