### PR TITLE
[inductor] Compile time optimizations

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -116,6 +116,7 @@ CI_SKIP_TRAINING = [
     "T5Small",
     "XGLMForCausalLM",
     "XLNetLMHeadModel",
+    "PegasusForCausalLM",
 ]
 
 

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -41,7 +41,7 @@ prefuse_nodes = True
 tune_layout = False
 
 # fuse even in cases without common reads
-aggressive_fusion = True
+aggressive_fusion = False
 
 # how many nodes to allow into a single fusion
 max_fusion_size = 64

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -30,6 +30,7 @@ from .codegen.common import _simplify_loops
 from .codegen.common import index_prevent_reordering
 from .dependencies import extract_read_writes
 from .dependencies import var_builder
+from .utils import cache_on_self
 from .utils import sympy_dot
 from .utils import sympy_product
 from .virtualized import V
@@ -310,6 +311,7 @@ class Loops(IRNode):
     def is_zero_elements(self):
         return any(r == 0 for r in self.ranges)
 
+    @cache_on_self
     def get_reads(self):
         with patch.object(FlexibleLayout, "allow_indexing", True):
             if self.get_reduction_type():
@@ -910,6 +912,7 @@ class BaseView(IRNode):
     def is_extern(self):
         return self.data.is_extern()
 
+    @cache_on_self
     def get_reads(self):
         with patch.object(FlexibleLayout, "allow_indexing", True):
             return extract_read_writes(
@@ -1724,6 +1727,7 @@ class Buffer(IRNode):
             return [self.layout.target.get_name()]
         return ()
 
+    @cache_on_self
     def get_read_writes(self):
         with patch.object(FlexibleLayout, "allow_indexing", True):
             return extract_read_writes(
@@ -1774,6 +1778,7 @@ class NoneAsConstantBuffer(IRNode):
 class ComputedBuffer(Buffer):
     data: Loops
 
+    @cache_on_self
     def get_read_writes(self):
         with patch.object(FlexibleLayout, "allow_indexing", True):
             if self.data.get_reduction_type():

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -51,6 +51,7 @@ class SizeVarAllocator(object):
         self.guards = []
         self.replacements: Dict[sympy.Symbol, Expr] = {}
         self.need_seed = False
+        self.stride_vars = self.make_stride_vars_cache()
         if not zero_one_const:
             self.val_to_var.clear()
 
@@ -252,7 +253,33 @@ class SizeVarAllocator(object):
     def size_hint(self, expr: Expr) -> int:
         return int(sympy.expand(expr).subs(self.var_to_val))
 
-    def stride_vars(self, index: Expr, vars: List[sympy.Symbol]) -> List[Expr]:
+    def _lru_cache(self, fn, maxsize=None):
+        """
+        Wrapper around functools.lru_cache that clears when replacements
+        has been invalidated.
+        """
+        fn_cache = functools.lru_cache(maxsize)(fn)
+        prior_len = len(self.replacements)
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            nonlocal prior_len
+            if prior_len != len(self.replacements):
+                prior_len = len(self.replacements)
+                fn_cache.cache_clear()
+            return fn_cache(*args, **kwargs)
+
+        return wrapper
+
+    def make_stride_vars_cache(self):
+        cache = self._lru_cache(self._stride_vars)
+
+        def stride_vars(index: Expr, vars: List[sympy.Symbol]) -> List[Expr]:
+            return cache(index, tuple(vars))
+
+        return stride_vars
+
+    def _stride_vars(self, index: Expr, vars: List[sympy.Symbol]) -> List[Expr]:
         """Convert an indexing expression back into strides"""
         strides = []
         index = index.subs(self.replacements)

--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -153,3 +153,15 @@ def precompute_methods(obj: Any, methods: List[str]):
 
 def cmp(a, b):
     return int(a > b) - int(a < b)
+
+
+def cache_on_self(fn):
+    key = f"__{fn.__name__}_cache"
+
+    @functools.wraps(fn)
+    def wrapper(self):
+        if not hasattr(self, key):
+            setattr(self, key, fn(self))
+        return getattr(self, key)
+
+    return wrapper


### PR DESCRIPTION
The PR is aimed at reducing compile time, primary via adding caching, turning off aggressive fusions (negligible perf impact), and converting `get_possible_fusions()` to use an asymptotically faster algorithm.  

Some of the benchmarks that used to be a problem in the past seem to have been fixed.  With a warm cache (and my other open PRs applied) `pytorch_struct` now spends <1 second compiling both the forwards and the backwards.

One of the slower remaining models is `BERT_pytorch` backwards.  With a warm cache this PR reduces compile time (of that one subgraph) from 40 seconds to 14 seconds.

cProfile Before:
```
         78145306 function calls (76783971 primitive calls) in 39.987 seconds

   Ordered by: cumulative time
   List reduced from 10766 to 100 due to restriction <100>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   40.029   40.029 compile_fx.py:39(compile_fx_inner)
        1    0.000    0.000   34.856   34.856 graph.py:329(compile_to_fn)
        1    0.000    0.000   34.856   34.856 graph.py:313(compile_to_module)
        1    0.000    0.000   34.721   34.721 graph.py:305(codegen)
        1    0.004    0.004   30.878   30.878 scheduler.py:500(__init__)
        1    0.000    0.000   23.582   23.582 scheduler.py:726(fuse_nodes)
        2    0.006    0.003   23.582   11.791 scheduler.py:736(fuse_nodes_once)
   677670    0.733    0.000   22.834    0.000 scheduler.py:794(can_fuse)
        2    0.123    0.062   21.730   10.865 scheduler.py:761(get_possible_fusions)
    13008    0.067    0.000   20.837    0.002 triton.py:1196(select_tiling)
9291/9171    0.039    0.000   20.623    0.002 triton.py:974(can_fuse)
     3796    0.059    0.000   19.607    0.005 triton.py:1136(candidate_tilings)
   396350    4.180    0.000   15.807    0.000 basic.py:802(subs)
     5640    0.056    0.000   14.470    0.003 dependencies.py:249(extract_read_writes)
     4496    0.042    0.000   14.070    0.003 ir.py:3284(__call__)
    19037    0.104    0.000   12.936    0.001 sizevars.py:308(stride_hints)
     4496    0.028    0.000   12.596    0.003 ir.py:3388(__call__)
    19503    0.367    0.000   11.579    0.001 sizevars.py:277(stride_vars)
     3044    0.009    0.000    9.207    0.003 scheduler.py:331(pointwise_read_writes)
     3044    0.009    0.000    8.911    0.003 scheduler.py:337(fn)
93301/93299    0.169    0.000    7.373    0.000 _print_helpers.py:27(__str__)
      484    0.007    0.000    7.251    0.015 scheduler.py:218(__init__)
93301/93299    0.083    0.000    7.204    0.000 printer.py:371(__call__)
93301/93299    0.088    0.000    7.121    0.000 str.py:982(sstr)
103642/90308    0.074    0.000    6.964    0.000 printer.py:290(doprint)
219924/90308    0.832    0.000    6.898    0.000 printer.py:294(_print)
18485/17948    0.121    0.000    6.257    0.000 str.py:50(_print_Add)
    18966    0.061    0.000    6.179    0.000 dependencies.py:195(load)
    23965    0.035    0.000    6.078    0.000 expr.py:384(__format__)
...
```


cProfile After:
```
         25518044 function calls (24693271 primitive calls) in 14.245 seconds

   Ordered by: cumulative time
   List reduced from 5312 to 100 due to restriction <100>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   14.276   14.276 compile_fx.py:39(compile_fx_inner)
        1    0.000    0.000    9.928    9.928 graph.py:329(compile_to_fn)
        1    0.000    0.000    9.928    9.928 graph.py:313(compile_to_module)
        1    0.000    0.000    9.829    9.829 graph.py:305(codegen)
        1    0.004    0.004    6.546    6.546 scheduler.py:500(__init__)
     1768    0.015    0.000    6.178    0.003 ir.py:3289(__call__)
     2449    0.022    0.000    5.695    0.002 dependencies.py:249(extract_read_writes)
     1768    0.009    0.000    5.588    0.003 ir.py:3393(__call__)
      484    0.006    0.000    4.952    0.010 scheduler.py:218(__init__)
        1    0.000    0.000    3.989    3.989 graph.py:134(run)
        1    0.008    0.008    3.989    3.989 interpreter.py:95(run)
     3102    0.014    0.000    3.977    0.001 graph.py:292(run_node)
53743/53741    0.090    0.000    3.570    0.000 _print_helpers.py:27(__str__)
53743/53741    0.044    0.000    3.481    0.000 printer.py:371(__call__)
64640/50521    0.041    0.000    3.470    0.000 printer.py:290(doprint)
124759/50521    0.470    0.000    3.438    0.000 printer.py:294(_print)
53743/53741    0.045    0.000    3.437    0.000 str.py:982(sstr)
     6879    0.023    0.000    3.010    0.000 dependencies.py:195(load)
8652/8379    0.057    0.000    2.974    0.000 str.py:50(_print_Add)
        1    0.004    0.004    2.963    2.963 scheduler.py:1012(codegen)
      484    0.016    0.000    2.904    0.006 ir.py:1850(simplify_and_reorder)
      303    0.004    0.000    2.884    0.010 triton.py:1031(codegen_nodes)
      303    0.006    0.000    2.868    0.009 triton.py:1109(codegen_node_schedule)
    95404    0.934    0.000    2.783    0.000 basic.py:802(subs)
     3102    0.011    0.000    2.732    0.001 interpreter.py:144(run_node)
     1860    0.002    0.000    2.631    0.001 utils.py:161(wrapper)
     1198    0.009    0.000    2.576    0.002 ir.py:1781(get_read_writes)
     8881    0.014    0.000    2.536    0.000 expr.py:384(__format__)
     8881    0.006    0.000    2.504    0.000 {function Expr.__format__ at 0x7fd80fddaf70}
      968    0.003    0.000    2.353    0.002 ir.py:3226(__init__)
      968    0.016    0.000    2.350    0.002 ir.py:3310(__init__)
      484    0.006    0.000    2.276    0.005 scheduler.py:313(codegen)
8652/1216    0.016    0.000    2.269    0.002 lowering.py:264(inner_fn)
8652/1216    0.012    0.000    2.244    0.002 lowering.py:269(<listcomp>)
...
```

Still a lot of time spent in sympy-related things.  We spend 3.5s in sympy printing, 2.8s in sympy `subs`, etc.  I bet we are mostly printing and `subs`-ing the same expressions over and over again, so more caching could help even further.