### PR TITLE
Improvements to @dynamo_timed

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -426,11 +426,14 @@ def speedup_experiment(args, model_iter_fn, model, example_inputs):
         ("dev", "name", "batch_size", "speedup"),
         [current_device, current_name, current_batch_size, float(speedup)],
     )
-    headers, data = torchdynamo.utils.compile_times(repr='csv', aggregate=True)
+    headers, data = torchdynamo.utils.compile_times(repr="csv", aggregate=True)
+    assert (
+        output_filename.find(".csv") > 0
+    ), f"expected output_filename to be a .csv, but got {output_filename}"
     output_csv(
-        "compilation_metrics.csv",
+        output_filename[:-4] + "_compilation_metrics.csv",
         ["dev", "name", "batch_size"] + headers,
-        [current_device, current_name, current_batch_size] + data
+        [current_device, current_name, current_batch_size] + data,
     )
     return format_speedup(speedup, pvalue, is_correct=is_correct)
 

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -426,6 +426,12 @@ def speedup_experiment(args, model_iter_fn, model, example_inputs):
         ("dev", "name", "batch_size", "speedup"),
         [current_device, current_name, current_batch_size, float(speedup)],
     )
+    headers, data = torchdynamo.utils.compile_times(repr='csv', aggregate=True)
+    output_csv(
+        "compilation_metrics.csv",
+        ["dev", "name", "batch_size"] + headers,
+        [current_device, current_name, current_batch_size] + data
+    )
     return format_speedup(speedup, pvalue, is_correct=is_correct)
 
 

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -43,11 +43,11 @@ compilation_metrics = collections.OrderedDict()
 
 def dynamo_timed(func):
     def time_wrapper(*args, **kwargs):
-        t0 = time.time()
-        r = func(*args, **kwargs)
         key = func.__qualname__
         if key not in compilation_metrics:
             compilation_metrics[key] = []
+        t0 = time.time()
+        r = func(*args, **kwargs)
         compilation_metrics[key].append(time.time() - t0)
         return r
 
@@ -68,22 +68,26 @@ def compile_times(repr="str", aggregate=False):
     per metric.
     """
 
-    def fmt_fn(values):
-        def as_str(v):
-            return f"{v:.4f}"
+    def fmt_fn(values, item_fn=lambda x: x):
 
         if aggregate:
-            return as_str(sum(values))
-        return ", ".join(map(as_str, values))
+            return item_fn(sum(values))
+        return ", ".join(map(item_fn, values))
 
     if repr == "str":
-        rows = [(k, fmt_fn(compilation_metrics[k])) for k in compilation_metrics]
+        rows = [
+            (k, fmt_fn(compilation_metrics[k], item_fn=lambda x: f"{x:.4f}"))
+            for k in compilation_metrics
+        ]
         out = "TorchDynamo compilation metrics:\n"
         out += tabulate.tabulate(rows, headers=("Function", "Runtimes (s)"))
         return out
     elif repr == "csv":
+        values = [
+            fmt_fn(v, item_fn=lambda x: f"{x:.6f}")
+            for v in compilation_metrics.values()
+        ]
         headers = list(compilation_metrics.keys())
-        values = [fmt_fn(v) for v in compilation_metrics.values()]
         return headers, values
 
 

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -37,7 +37,6 @@ class BoxedBool:
         return False
 
 
-@dynamo_timed
 @DebugContext.wrap
 def compile_fx_inner(
     gm: torch.fx.GraphModule,


### PR DESCRIPTION
- order keys in the order of entry not exit
- hook up csv output to benchmark runner

Example output:
<img width="1654" alt="image" src="https://user-images.githubusercontent.com/4984825/187321241-96e5387d-ed6e-4e50-a9bf-1aac9e54f5bd.png">

(actual sheet:)
https://docs.google.com/spreadsheets/d/14uEHPAQDlOx1nPTac4i_3aNdrdQZoJmoxmrLfTBd6r4/edit?usp=sharing