### PR TITLE
Add support for jagged tensor - remove from cudagraphs, better handling of multioutput 

### DIFF
--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -197,6 +197,9 @@ class WrapperCodeGen(CodeGen):
                     from torchinductor.triton_ops.autotune import reduction_heuristics
                     from torchinductor.triton_ops.autotune import grid
 
+                    import operator as _operator
+                    from torchinductor.utils import assert_size_match, assert_stride_match
+
                 """
             )
 

--- a/torchinductor/codegen/wrapper.py
+++ b/torchinductor/codegen/wrapper.py
@@ -184,6 +184,9 @@ class WrapperCodeGen(CodeGen):
 
                 aten = torch.ops.aten
 
+                import operator as _operator
+                from torchinductor.utils import assert_size_match, assert_stride_match
+
             """
         )
 
@@ -196,9 +199,6 @@ class WrapperCodeGen(CodeGen):
                     from torchinductor.triton_ops.autotune import pointwise_heuristics
                     from torchinductor.triton_ops.autotune import reduction_heuristics
                     from torchinductor.triton_ops.autotune import grid
-
-                    import operator as _operator
-                    from torchinductor.utils import assert_size_match, assert_stride_match
 
                 """
             )

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -17,6 +17,7 @@ from .debug import DebugContext
 from .decomposition import select_decomp_table
 from .graph import GraphLowering
 from .utils import ceildiv
+from .utils import has_incompatible_cudagraph_ops
 from .virtualized import V
 
 log = logging.getLogger(__name__)
@@ -57,7 +58,12 @@ def compile_fx_inner(
         wrap(graph.run)(*example_inputs)
         compiled_fn = wrap(graph.compile_to_fn())
 
-    if cudagraphs and set(graph.device_types) == {"cuda"} and not graph.mutated_inputs:
+    if (
+        cudagraphs
+        and set(graph.device_types) == {"cuda"}
+        and not graph.mutated_inputs
+        and not has_incompatible_cudagraph_ops(gm)
+    ):
         compiled_fn = cudagraphify(
             compiled_fn, example_inputs, static_input_idxs=range(num_fixed)
         )

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -56,13 +56,13 @@ class cpp:
     simdlen = None
     min_chunk_size = 4096
     cxx = (
-        # None,  # download gcc12 from conda-forge if conda is installed
+        None,  # download gcc12 from conda-forge if conda is installed
         "g++-12",
         "g++-11",
         "g++-10",
-        # "clang++-12",
-        # "clang++-11",
-        # "clang++-10",
+        "clang++-12",
+        "clang++-11",
+        "clang++-10",
         "g++",
     )
 

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -56,13 +56,13 @@ class cpp:
     simdlen = None
     min_chunk_size = 4096
     cxx = (
-        None,  # download gcc12 from conda-forge if conda is installed
+        # None,  # download gcc12 from conda-forge if conda is installed
         "g++-12",
         "g++-11",
         "g++-10",
-        "clang++-12",
-        "clang++-11",
-        "clang++-10",
+        # "clang++-12",
+        # "clang++-11",
+        # "clang++-10",
         "g++",
     )
 

--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -165,3 +165,39 @@ def cache_on_self(fn):
         return getattr(self, key)
 
     return wrapper
+
+
+def has_incompatible_cudagraph_ops(gm):
+    forbidden_list = set(
+        [
+            "fbgemm.dense_to_jagged.default",
+            "fbgemm.jagged_to_padded_dense.default",
+        ]
+    )
+    for node in gm.graph.nodes:
+        if str(node.target) in forbidden_list:
+            return True
+    return False
+
+
+def assert_size_match(item, size):
+    assert isinstance(size, tuple)
+    if size == ():
+        return
+
+    if isinstance(item, (list, tuple)):
+        return
+
+    assert item.size() == size, f"Mismatched {item.size()}, {size}"
+
+
+def assert_stride_match(item, stride):
+    assert isinstance(stride, tuple)
+
+    if stride == ():
+        return
+
+    if isinstance(item, (list, tuple)):
+        return
+
+    assert item.stride() == stride, f"Mismatched {item.stride()}, {stride}"


### PR DESCRIPTION
Tested in fbcode with:

```
from typing import List

import torch

import torchdynamo

try:
    # pyre-ignore[21]
    from fbgemm_gpu import open_source  # noqa: F401

    from test_utils import gpu_available, gpu_unavailable
except Exception:
    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")


def _generate_jagged_tensor(
    num_jagged_dim: int,
    outer_dense_size: int,
    inner_dense_size: int,
    dtype: torch.dtype,
    device: torch.device,
):
    max_lengths = [3, 3, 3]
    x_offsets: List[torch.LongTensor] = []
    num_lengths = outer_dense_size
    for d in range(num_jagged_dim):
        lengths = torch.randint(
            low=0,
            high=max_lengths[d] * 2,
            size=(num_lengths,),
            device=device,
        )
        x_offsets.append(torch.ops.fbgemm.asynchronous_complete_cumsum(lengths))
        num_lengths = x_offsets[-1][-1].item()

    x_values = torch.rand(
        x_offsets[-1][-1] * inner_dense_size,
        dtype=dtype,
        device=device
    ).reshape(x_offsets[-1][-1].item(), inner_dense_size)

    return x_values, x_offsets, max_lengths

def fn(values, offsets, lengths):
    dense = torch.ops.fbgemm.jagged_to_padded_dense(values, offsets, lengths, 10)
    jagged_values, jagged_offsets = torch.ops.fbgemm.dense_to_jagged(
                dense, offsets, 2
            )
    return jagged_values, jagged_offsets

x_values, x_offsets, max_lengths = _generate_jagged_tensor(3, 3, 3, torch.float, 'cuda')


@torchdynamo.optimize("inductor", nopython=False)
def foo():
    return fn(x_values, x_offsets, max_lengths)

x = foo()
```

Couldn't figure out how to get fbgemm setup on OSS workflow. 