### PR TITLE
Add `use_openmp` option to cxx config

### DIFF
--- a/torchinductor/codecache.py
+++ b/torchinductor/codecache.py
@@ -76,7 +76,7 @@ def cpp_supports_flag(flag: str) -> bool:
 
 
 def cxx_flags() -> str:
-    flags = "-march=native -O3 -ffast-math -fno-finite-math-only"
+    flags = "-march=native -ffast-math -fno-finite-math-only"
     if config.cpp.use_openmp:
         flags += " -fopenmp"
     return " ".join([f for f in flags.split() if cpp_supports_flag(f)])
@@ -131,7 +131,7 @@ def cpp_compile_command(input, output, include_pytorch=False):
         f"""
             {cpp_compiler()} -shared -fPIC -Wall -std=c++2a -Wno-unused-variable
             {ipaths} {lpaths} {libs}
-            {cxx_flags()}
+            -O3 {cxx_flags()}
             -o{output} {input}
         """,
     ).strip()

--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -106,7 +106,8 @@ def cpp_prefix():
             #include <cmath>
             #include <cstdlib>
             #include <limits>
-            #include <omp.h>
+            """ + ("#include <omp.h>\n" if config.cpp.use_openmp else "") +
+            """
 
             #include <ATen/core/PhiloxRNGEngine.h>
             #include <c10/util/Half.h>

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 # add some debug printouts
 debug = False
@@ -53,6 +54,7 @@ unroll_reductions_threshold = 8
 # config specific to codegen/cpp.pp
 class cpp:
     threads = -1  # set to cpu_count()
+    use_openmp = True if platform.system() == 'Linux' else False
     simdlen = None
     min_chunk_size = 4096
     cxx = (
@@ -64,7 +66,7 @@ class cpp:
         "clang++-11",
         "clang++-10",
         "g++",
-    )
+    ) if platform.system() == 'Linux' else ( "clang++" )
 
 
 # config specific to codegen/triton.py


### PR DESCRIPTION
And do not use it by default when running on MacOS
Also introduce memoizable `cpp_supports_flag` and `cxx_flags` function

Above changes make inductor usable out-of-box on MacOS
