### PR TITLE
Using cProfiler

### DIFF
--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -118,9 +118,6 @@ capture_scalar_outputs = False
 # false_fn produces code with identical guards.
 enforce_cond_guards_match = True
 
-# Use cProfiler to profile important functions of the stack
-use_cprofiler = True
-
 
 class _AccessLimitingConfig(ModuleType):
     def __setattr__(self, name, value):

--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -118,6 +118,9 @@ capture_scalar_outputs = False
 # false_fn produces code with identical guards.
 enforce_cond_guards_match = True
 
+# Use cProfiler to profile important functions of the stack
+use_cprofiler = True
+
 
 class _AccessLimitingConfig(ModuleType):
     def __setattr__(self, name, value):

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -46,16 +46,7 @@ compilation_metrics = collections.OrderedDict()
 timer_counter = itertools.count()
 
 
-def dynamo_timed(func):
-    def time_wrapper(*args, **kwargs):
-        key = func.__qualname__
-        if key not in compilation_metrics:
-            compilation_metrics[key] = []
-        t0 = time.time()
-        r = func(*args, **kwargs)
-        compilation_metrics[key].append(time.time() - t0)
-        return r
-
+def dynamo_profiled(func):
     def profile_wrapper(*args, **kwargs):
         global timer_counter
         datafn = (
@@ -72,8 +63,18 @@ def dynamo_timed(func):
         prof.dump_stats(datafn)
         return retval
 
-    if config.use_cprofiler:
-        return profile_wrapper
+    return profile_wrapper
+
+
+def dynamo_timed(func):
+    def time_wrapper(*args, **kwargs):
+        key = func.__qualname__
+        if key not in compilation_metrics:
+            compilation_metrics[key] = []
+        t0 = time.time()
+        r = func(*args, **kwargs)
+        compilation_metrics[key].append(time.time() - t0)
+        return r
 
     return time_wrapper
 


### PR DESCRIPTION
@wconstab I used this to debug https://github.com/pytorch/torchdynamo/issues/525

This was the result. It was not directly obvious. But going through the stack, I found the culprit. Sending a separate PR for the fix. 

~~~
### Cprofile for _convert_frame_assert iter 1 ###
         286220504 function calls (233962842 primitive calls) in 83.329 seconds

   Ordered by: internal time
   List reduced from 1100 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
41821129/1714   31.516    0.000   72.515    0.042 /scratch/anijain/work/env/lib/python3.9/copy.py:128(deepcopy)
  2200500   10.596    0.000   43.838    0.000 /scratch/anijain/work/env/lib/python3.9/copy.py:226(_deepcopy_dict)
 83704980    7.091    0.000    7.093    0.000 {method 'get' of 'dict' objects}
2209659/1714    5.539    0.000   72.458    0.042 /scratch/anijain/work/env/lib/python3.9/copy.py:258(_reconstruct)
 54266296    4.164    0.000    4.164    0.000 {built-in method builtins.id}
1365676/4046    2.741    0.000    6.135    0.002 /scratch/anijain/work/torchdynamo/torchdynamo/variables/base.py:80(apply)
 35214941    2.612    0.000    2.612    0.000 /scratch/anijain/work/env/lib/python3.9/copy.py:182(_deepcopy_atomic)
  4405814    1.834    0.000    2.586    0.000 /scratch/anijain/work/env/lib/python3.9/copy.py:242(_keep_alive)
   227929    1.444    0.000    1.444    0.000 /scratch/anijain/work/torchdynamo/torchdynamo/variables/base.py:249(__init__)
  2203348    1.013    0.000    1.013    0.000 {method '__reduce_ex__' of 'object' objects}
8285240/8276442    0.995    0.000    1.008    0.000 {built-in method builtins.isinstance}
4417050/3680    0.963    0.000   69.649    0.019 /scratch/anijain/work/env/lib/python3.9/copy.py:263(<genexpr>)
     1714    0.949    0.001   69.642    0.041 /scratch/anijain/work/env/lib/python3.9/copy.py:200(_deepcopy_list)
  6865319    0.801    0.000    0.801    0.000 {built-in method builtins.getattr}
  2202651    0.778    0.000    1.980    0.000 /scratch/anijain/work/torchdynamo/torchdynamo/guards.py:92(__hash__)
  2200500    0.713    0.000    0.955    0.000 /scratch/anijain/work/env/lib/python3.9/copyreg.py:94(__newobj__)
4413109/2210458    0.680    0.000    1.021    0.000 {built-in method builtins.hash}
  6812109    0.646    0.000    0.646    0.000 {method 'append' of 'list' objects}
  2424800    0.624    0.000    0.624    0.000 {method 'update' of 'dict' objects}
  2359280    0.485    0.000    0.682    0.000 /scratch/anijain/work/pytorch/torch/fx/graph.py:229(__iter__)


         286220504 function calls (233962842 primitive calls) in 83.329 seconds

   Ordered by: cumulative time
   List reduced from 1100 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   83.423   83.423 /scratch/anijain/work/env/lib/python3.9/cProfile.py:106(runcall)
        1    0.000    0.000   83.423   83.423 /scratch/anijain/work/torchdynamo/torchdynamo/convert_frame.py:224(_convert_frame_assert)
        1    0.000    0.000   83.114   83.114 /scratch/anijain/work/torchdynamo/torchdynamo/bytecode_transformation.py:310(transform_code_object)
        1    0.000    0.000   83.113   83.113 /scratch/anijain/work/torchdynamo/torchdynamo/convert_frame.py:286(transform)
    379/1    0.005    0.000   83.110   83.110 /scratch/anijain/work/torchdynamo/torchdynamo/symbolic_convert.py:326(run)
7141/2101    0.233    0.000   83.106    0.040 /scratch/anijain/work/torchdynamo/torchdynamo/symbolic_convert.py:283(step)
 1205/386    0.002    0.000   77.902    0.202 /scratch/anijain/work/torchdynamo/torchdynamo/symbolic_convert.py:149(wrapper)
     1588    0.006    0.000   73.369    0.046 /scratch/anijain/work/torchdynamo/torchdynamo/symbolic_convert.py:1165(copy_graphstate)
     1588    0.482    0.000   73.363    0.046 /scratch/anijain/work/torchdynamo/torchdynamo/output_graph.py:106(copy_graphstate)
41821129/1714   31.516    0.000   72.515    0.042 /scratch/anijain/work/env/lib/python3.9/copy.py:128(deepcopy)
2209659/1714    5.539    0.000   72.458    0.042 /scratch/anijain/work/env/lib/python3.9/copy.py:258(_reconstruct)
4417050/3680    0.963    0.000   69.649    0.019 /scratch/anijain/work/env/lib/python3.9/copy.py:263(<genexpr>)
     1714    0.949    0.001   69.642    0.041 /scratch/anijain/work/env/lib/python3.9/copy.py:200(_deepcopy_list)
 1206/387    0.007    0.000   60.381    0.156 /scratch/anijain/work/torchdynamo/torchdynamo/symbolic_convert.py:228(call_function)
 1009/379    0.003    0.000   60.368    0.159 /scratch/anijain/work/torchdynamo/torchdynamo/symbolic_convert.py:690(CALL_FUNCTION)
      315    0.045    0.000   57.719    0.183 /scratch/anijain/work/torchdynamo/torchdynamo/variables/functions.py:61(call_function)
  378/315    0.001    0.000   57.674    0.183 /scratch/anijain/work/torchdynamo/torchdynamo/symbolic_convert.py:270(inline_user_function_return)
  2200500   10.596    0.000   43.838    0.000 /scratch/anijain/work/env/lib/python3.9/copy.py:226(_deepcopy_dict)
  378/315    0.004    0.000   43.180    0.137 /scratch/anijain/work/torchdynamo/torchdynamo/symbolic_convert.py:1421(inline_call)
  378/315    0.011    0.000   43.173    0.137 /scratch/anijain/work/torchdynamo/torchdynamo/symbolic_convert.py:1426(inline_call_)


~~~


