### PR TITLE
Improve Bytcode analysis time - Copying guards

### DIFF
--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -1,5 +1,4 @@
 import collections
-import copy
 import itertools
 import logging
 import operator
@@ -109,7 +108,7 @@ class OutputGraph(fx.Tracer):
         return (
             graph_nodes,
             list(self.graphargs),
-            copy.deepcopy(self.guards),
+            set(self.guards),
             dict(self.nn_modules),
             self.side_effects.clone(),
         )


### PR DESCRIPTION
Related to https://github.com/pytorch/torchdynamo/pull/1114 and https://github.com/pytorch/torchdynamo/issues/525

deepcopy of guards is quite expensive because there are 1000s of guards. Also, these guards are copied multiple times to checkpoint state.

@jansel Do we need deepcopy here? iiuc, we only add new guards, but we dont mutate the guards. So, if we just use a `set()`, is that enough to checkpoint?