### PR TITLE
Install missing global

### DIFF
--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -399,6 +399,8 @@ class InstructionTranslatorBase(object):
                 source = AttrSource(
                     self.import_source(self.f_globals["__name__"]), name
                 )
+                if name not in self.output.root_globals and name in self.f_globals:
+                    self.output.install_global(name, self.f_globals[name])
             else:
                 mangled_name = f"___unnamed_scope_{id(self.f_globals)}"
                 if mangled_name not in self.output.root_globals:


### PR DESCRIPTION
Related to https://github.com/pytorch/torchdynamo/issues/1126

Not really sure if this is the right fix. My understanding is the `output.root_globals` is the final `f_globals` passed on to the modified frame. During inlining, we need to ensure that `globals` from the inlined functions/files are also reflected in the `output.root_globals`. This fixes the speech_transformer issue.

@voznesenskym @jansel 