### PR TITLE
Use only reduction deps to determine if reduction is inner

### DIFF
--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -1116,7 +1116,6 @@ class TritonScheduling:
     def is_contiguous(node):
         if node in (EnableReduction, DisableReduction):
             return True
-        # print("Node readwrites", node.read_writes.reads, node.read_writes.writes, node.read_writes.index_exprs, node.read_writes.range_vars)
         if node.is_reduction():
             return all(
                 dep.is_contiguous()

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -1137,7 +1137,6 @@ class TritonScheduling:
                 node_schedule,
             )
         )
-        print(reductions)
         is_inner_reduction = (
             all(map(self.is_inner_reduction, reductions))
             if len(reductions) > 0

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -1162,7 +1162,8 @@ class TritonScheduling:
         else:
             kernel_name = wrapper.next_kernel_name()
             wrapper.kernels[src_code] = kernel_name
-            src_code = src_code.format(kernel_name=kernel_name)
+            subs_name = kernel_name if config.triton.ordered_kernel_names else "kernel"
+            src_code = src_code.format(kernel_name=subs_name)
             wrapper.define_kernel(kernel_name, src_code)
         kernel.call_kernel(wrapper, kernel_name)
         self.scheduler.free_buffers()

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -100,6 +100,8 @@ class triton:
     # should we stop a fusion to allow better tiling?
     tiling_prevents_pointwise_fusion = True
     tiling_prevents_reduction_fusion = True
+    # should we give different names to kernels
+    ordered_kernel_names = False
 
 
 # create a directory containing lots of debug information

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -2,7 +2,6 @@ import functools
 import logging
 import math
 import numbers
-from enum import Enum
 
 import torch
 import torch._decomp as decomp

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -249,12 +249,6 @@ def baddbmm(self, batch1, batch2, beta=1, alpha=1):
     return self + result
 
 
-class Reduction(Enum):
-    NONE = 0
-    MEAN = 1
-    SUM = 2
-
-
 @register_decomposition([aten.index_put])
 def index_put(self, indices, values, accumulate=False):
     return aten.index_put_(self.clone(), indices, values, accumulate)


### PR DESCRIPTION
This doesn't change the benchmarking numbers, but adds a few more kernels to "no autotune" list
Also, preserves unique kernel names to make it easier to inspect cuda profiles (before all kernels were called "kernel")