### PR TITLE
Tracking compilation latency in nightly

### DIFF
--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -28,6 +28,7 @@ import importlib
 import io
 import itertools
 import os
+from collections import defaultdict
 from os.path import abspath
 from os.path import exists
 
@@ -35,6 +36,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import torch
 from matplotlib import rcParams
+from numpy.core.fromnumeric import mean
 from scipy.stats import gmean
 from tabulate import tabulate
 
@@ -101,6 +103,11 @@ DEFAULTS = {
     "devices": [
         "cuda",
     ],
+    "quick": {
+        "torchbench": ["resnet18", "resnet50"],
+        "huggingface": ["AlbertForMaskedLM", "BertForMaskedLM"],
+        "timm_models": ["resnest101e", "mobilenetv2_100"],
+    },
 }
 
 
@@ -227,18 +234,15 @@ def generate_commands(args, dtypes, suites, devices, compilers, output_dir):
                 skip_tests_str = get_skip_tests(suite)
                 cmd = f"{cmd} {skip_tests_str}"
 
-                if args.quick:
-                    if suite == "torchbench":
-                        cmd = f"{cmd} --only=resnet18"
-                    elif suite == "huggingface":
-                        cmd = f"{cmd} --only=BertForPreTraining_P1_bert"
-                    else:
-                        raise NotImplementedError(
-                            f"Quick not implemented for {suite}.py"
-                        )
                 if args.log_operator_inputs:
                     cmd = f"{cmd} --log-operator-inputs"
-                lines.append(cmd)
+
+                if args.quick:
+                    for name in DEFAULTS["quick"][suite]:
+                        new_cmd = f"{cmd} --only={name}"
+                        lines.append(new_cmd)
+                else:
+                    lines.append(cmd)
             lines.append("")
         runfile.writelines([line + "\n" for line in lines])
 
@@ -443,7 +447,9 @@ class ParseCompilerProfileLogs(Parser):
 class ParsePerformanceLogs(Parser):
     def __init__(self, suites, devices, dtypes, compilers, mode, output_dir):
         super().__init__(suites, devices, dtypes, compilers, mode, output_dir)
-        self.parsed_frames = {}
+        self.parsed_frames = defaultdict(lambda: defaultdict(None))
+        self.metrics = ["speedup", "start_latency", "peak_memory"]
+        self.bottom_k = 50
         self.parse()
 
     def plot_graph(self, df, title):
@@ -470,15 +476,25 @@ class ParsePerformanceLogs(Parser):
         else:
             return pd.read_csv(
                 output_filename,
-                names=["dev", "name", "batch_size", "speedup"],
+                names=[
+                    "dev",
+                    "name",
+                    "batch_size",
+                    "speedup",
+                    "start_latency",
+                    "peak_memory",
+                ],
                 header=None,
             )
 
     def parse(self):
-        self.extract_df()
+        for metric in self.metrics:
+            self.extract_df(metric)
         self.generate_executive_summary()
         for suite in self.suites:
-            self.plot_graph(self.parsed_frames[suite], f"{suite}_{self.dtypes[0]}")
+            self.plot_graph(
+                self.parsed_frames[suite]["speedup"], f"{suite}_{self.dtypes[0]}"
+            )
 
     def clean_batch_sizes(self, frames):
         # Clean up batch sizes when its 0
@@ -498,14 +514,15 @@ class ParsePerformanceLogs(Parser):
             frame["batch_size"] = batch_sizes
         return frames
 
-    def extract_df(self):
+    def extract_df(self, metric):
         for iter in itertools.product(self.suites, self.devices, self.dtypes):
             suite, device, dtype = iter
             frames = []
             for compiler in self.compilers:
                 output_filename = f"{self.output_dir}/{compiler}_{suite}_{dtype}_{self.mode}_{device}.csv"
                 df = self.read_csv(output_filename)
-                df.rename(columns={"speedup": compiler}, inplace=True)
+                df = df[["dev", "name", "batch_size", metric]]
+                df.rename(columns={metric: compiler}, inplace=True)
                 df["batch_size"] = df["batch_size"].astype(int)
                 frames.append(df)
 
@@ -520,7 +537,11 @@ class ParsePerformanceLogs(Parser):
                     df = pd.merge(df, frames[idx], on=["dev", "name", "batch_size"])
 
             df = df.sort_values(by=list(reversed(self.compilers)), ascending=False)
-            self.parsed_frames[suite] = df
+            self.parsed_frames[suite][metric] = df
+
+    def comp_time(self, compiler, df):
+        df = df.sort_values(by=compiler, ascending=False)[compiler][: self.bottom_k]
+        return f"{mean(df):.2f}"
 
     def geomean(self, compiler, df):
         cleaned_df = df[compiler][df[compiler] > 0].clip(1)
@@ -534,14 +555,14 @@ class ParsePerformanceLogs(Parser):
         perc = int(percentage(passing, total, decimals=0))
         return f"{perc}%, {passing}/{total}"
 
-    def exec_summary_df(self, fn):
+    def exec_summary_df(self, fn, metric):
         """
         Generate a table with passrate and geomean perf
         """
         cols = {}
         cols["Compiler"] = self.compilers
         for suite in self.suites:
-            df = self.parsed_frames[suite]
+            df = self.parsed_frames[suite][metric]
             # speedups = [self.geomean(compiler, df) for compiler in self.compilers]
             speedups = [fn(compiler, df) for compiler in self.compilers]
             col = pd.Series(data=speedups, index=self.compilers)
@@ -551,8 +572,8 @@ class ParsePerformanceLogs(Parser):
         df.to_csv(os.path.join(self.output_dir, f"{fn.__name__}.csv"))
         return df
 
-    def exec_summary_text(self, caption, fn):
-        df = self.exec_summary_df(fn)
+    def exec_summary_text(self, caption, fn, metric):
+        df = self.exec_summary_df(fn, metric)
         tabform = tabulate(df, headers="keys", tablefmt="pretty", showindex="never")
 
         str_io = io.StringIO()
@@ -572,7 +593,8 @@ class ParsePerformanceLogs(Parser):
             "these experiments on A100 GPUs. Each experiment runs one iteration of forward "
             "and backward pass. For accuracy, we check the numerical correctness of forward "
             "pass outputs and gradients by comparing with native pytorch. We measure speedup "
-            "by normalizing against the performance of native pytorch.\n\n"
+            "by normalizing against the performance of native pytorch. We also report compilation "
+            f"time metric which is mean of worst {self.bottom_k} compilation models.\n\n"
             "Caveats\n"
             "1) Batch size has been reduced to workaround OOM errors. Work is in progress to "
             "reduce peak memory footprint.\n"
@@ -582,26 +604,45 @@ class ParsePerformanceLogs(Parser):
         str_io.write(description)
 
         speedup_caption = "Geometric mean speedup\n"
-        speedup_summary = self.exec_summary_text(speedup_caption, self.geomean)
+        speedup_summary = self.exec_summary_text(
+            speedup_caption, self.geomean, "speedup"
+        )
 
         passrate_caption = "Passrate\n"
-        passrate_summary = self.exec_summary_text(passrate_caption, self.passrate)
+        passrate_summary = self.exec_summary_text(
+            passrate_caption, self.passrate, "speedup"
+        )
+
+        comp_time_caption = (
+            f"Mean compilation time (seconds) for worst {self.bottom_k} models\n"
+        )
+        comp_time_summary = self.exec_summary_text(
+            comp_time_caption, self.comp_time, "start_latency"
+        )
 
         str_io.write(passrate_summary)
         str_io.write(speedup_summary)
+        str_io.write(comp_time_summary)
         self.executive_summary = str_io.getvalue()
 
     def prepare_message(self, suite):
         title = f"## {suite} suite with {self.dtypes[0]} precision ##"
-        df = self.parsed_frames[suite]
-        df = df.drop("dev", axis=1)
-        tabform = tabulate(df, headers="keys", tablefmt="pretty", showindex="never")
-        str_io = io.StringIO()
-        str_io.write("\n")
-        str_io.write("~~~\n")
-        str_io.write(f"{tabform}\n")
-        str_io.write("~~~\n")
-        body = str_io.getvalue()
+        body = ""
+        for metric in ["speedup", "start_latency"]:
+            df = self.parsed_frames[suite][metric]
+            df = df.drop("dev", axis=1)
+            tabform = tabulate(df, headers="keys", tablefmt="pretty", showindex="never")
+            str_io = io.StringIO()
+            str_io.write("\n")
+            if metric == "speedup":
+                str_io.write("Performance speedup\n")
+            elif metric == "start_latency":
+                str_io.write("Compilation latency\n")
+            str_io.write("~~~\n")
+            str_io.write(f"{tabform}\n")
+            str_io.write("~~~\n")
+            body += str_io.getvalue()
+
         comment = generate_dropdown_comment(title, body)
         return comment
 


### PR DESCRIPTION
Tracking the mean of worst 50 compilation latency in nightly. Sample output here - https://github.com/anijain2305/ghissue/issues/1#issuecomment-1238928755

cc @wconstab 

Will mentioned that we can use `dynamo_timed` results and can track more detailed breakdown of different components. 

This PR, however, puts timers at the highest level and just measures the total time for first 3 iterations. Pro is that this measurement reflects the compilation time observed by the user. However, con is that it lacks the details that `dynamo_timed` provides.

Bonus is that - we can extend this for measuring user-observed peak memory footprint.
