### PR TITLE
[inductor] More compile time optimizations

### DIFF
--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -14,8 +14,10 @@ import sympy
 from sympy.printing.printer import Printer
 
 from .. import metrics
+from ..utils import free_symbol_startswith
 from ..utils import freeze_inputs
 from ..utils import sympy_dot
+from ..utils import sympy_subs
 from ..utils import unique
 from ..virtualized import V
 from ..virtualized import ops
@@ -52,8 +54,8 @@ def _simplify_loops(index_vars, sizes, index_formulas):
                 va = index_vars[a]
                 vb = index_vars[b]
                 v = sympy.Symbol("_merge_tester")
-                expr1 = index_formulas[k].subs({va: v * sizes[a], vb: 0})
-                expr2 = index_formulas[k].subs({va: 0, vb: v})
+                expr1 = sympy_subs(index_formulas[k], {va: v * sizes[a], vb: 0})
+                expr2 = sympy_subs(index_formulas[k], {va: 0, vb: v})
                 if V.graph.sizevars.simplify(expr1) == V.graph.sizevars.simplify(expr2):
                     continue
             return False
@@ -596,7 +598,7 @@ class Kernel(CodeGen):
                     # A load from an invalidated store requires us to
                     # keep the actual buffer around
                     V.kernel.must_keep_buffers.add(name)
-                if "tmp" in str(index):
+                if free_symbol_startswith(index, "tmp"):
                     return self.indirect_load(name, index)
                 store_cache = self.cse.store_cache
                 if name in store_cache:
@@ -635,5 +637,7 @@ class Kernel(CodeGen):
             return [self.rename_indexing(x) for x in index]
         index = V.graph.sizevars.simplify(index)
         sorted_symbols = sorted(index.free_symbols, key=lambda s: s.name)
-        subs = {x: self.args.size(x) for x in sorted_symbols if str(x).startswith("s")}
-        return index.subs(subs)
+        replacements = {
+            x: self.args.size(x) for x in sorted_symbols if x.name.startswith("s")
+        }
+        return sympy_subs(index, replacements)

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -18,6 +18,8 @@ from .codegen.common import _simplify_loops
 from .codegen.common import index_prevent_reordering
 from .utils import VarRanges
 from .utils import sympy_product
+from .utils import sympy_str
+from .utils import sympy_subs
 from .virtualized import V
 
 log = logging.getLogger(__name__)
@@ -44,9 +46,9 @@ class MemoryDep(typing.NamedTuple):
         ):
             c = canonicalization_prefix()
             size = (self.size[1], self.size[0])
-            s0 = sympy.Symbol(c + "0", is_integer=True)
-            s1 = sympy.Symbol(c + "1", is_integer=True)
-            index = self.index.subs(s0, s1)
+            s0 = sympy.Symbol(c + "0")
+            s1 = sympy.Symbol(c + "1")
+            index = sympy_subs(self.index, {s0: s1})
             return MemoryDep(self.name, index, size)
         else:
             return self
@@ -83,14 +85,6 @@ class MemoryDep(typing.NamedTuple):
             sympy_product([s for s in self.size if s in vars])
         )
 
-    def is_simple(self) -> bool:
-        s = str(self.index)
-        if "indirect" in s:
-            return False
-        if "ModularIndexing" in s:
-            return False
-        return True
-
     def is_contiguous(self) -> bool:
         return isinstance(self.index, (sympy.Symbol, sympy.Integer))
 
@@ -106,9 +100,6 @@ class StarDep(typing.NamedTuple):
 
     def numel_hint(self):
         return 1
-
-    def is_simple(self) -> bool:
-        return False
 
     def is_contiguous(self) -> bool:
         return False
@@ -189,18 +180,18 @@ class RecordLoadStore(V.MockHandler):  # type: ignore[name-defined]
         _, add_var = var_builder(canonicalization_prefix())
         replacement = dict(zip(index_vars, reindex([add_var(x) for x in new_sizes])))
 
-        index = sympy.expand(index).subs(replacement)
+        index = sympy_subs(sympy.expand(index), replacement)
         return index, tuple(new_sizes)
 
     def load(self, name: str, index: sympy.Expr) -> str:
         canonicalized_index, canonicalized_size = self.canonicalize(index)
         self._reads.add(MemoryDep(name, canonicalized_index, canonicalized_size))
-        return f"load({name}, {index})"
+        return f"load({name}, {sympy_str(index)})"
 
     def store(self, name: str, index: sympy.Expr, value: str, mode=None) -> str:
         canonicalized_index, canonicalized_size = self.canonicalize(index)
         self._writes.add(MemoryDep(name, canonicalized_index, canonicalized_size))
-        return f"store({name}, {index}, {value}, {mode})"
+        return f"store({name}, {sympy_str(index)}, {value}, {mode})"
 
     def reduction(
         self, name: str, dtype, src_dtype, reduction_type, index, value
@@ -210,7 +201,7 @@ class RecordLoadStore(V.MockHandler):  # type: ignore[name-defined]
     def index_expr(self, index: sympy.Expr, dtype) -> str:
         canonicalized_index, canonicalized_size = self.canonicalize(index)
         self._index_exprs.add(IndexExprDep(canonicalized_index, canonicalized_size))
-        return f"index_expr({index}, {dtype})"
+        return f"index_expr({sympy_str(index)}, {dtype})"
 
 
 def var_builder(prefix: str) -> Tuple[VarRanges, Callable[[sympy.Expr], sympy.Symbol]]:
@@ -218,7 +209,7 @@ def var_builder(prefix: str) -> Tuple[VarRanges, Callable[[sympy.Expr], sympy.Sy
     var_ranges: VarRanges = collections.OrderedDict()
 
     def add_var(length: sympy.Expr) -> sympy.Symbol:
-        v = sympy.Symbol(f"{prefix}{next(cnt)}", is_integer=True)
+        v = sympy.Symbol(f"{prefix}{next(cnt)}")
         var_ranges[v] = length
         return v
 

--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -194,20 +194,14 @@ def sympy_subs(expr: sympy.Expr, replacements: Dict[Any, Any]):
     xreplace is faster than subs, but is way more picky
     """
 
-    def swap_key(key):
+    def promote_strings(key):
         if isinstance(key, str):
             return sympy.Symbol(key)
-        assert isinstance(key, sympy.Symbol), key
         return key
 
-    def swap_value(val):
-        if isinstance(val, int):
-            return sympy.Integer(val)
-        if isinstance(val, sympy.Expr):
-            return val
-        return swap_key(val)
-
-    return expr.xreplace({swap_key(k): swap_value(v) for k, v in replacements.items()})
+    return expr.xreplace(
+        {promote_strings(k): promote_strings(v) for k, v in replacements.items()}
+    )
 
 
 def free_symbol_startswith(index: sympy.Expr, prefix: str):


### PR DESCRIPTION
Mostly improving `sympy` usage.  This give another ~2x improvement in warm compile time.

BERT_pytorch fp16 backwards before:
```
         25532823 function calls (24706453 primitive calls) in 14.294 seconds

   Ordered by: cumulative time
   List reduced from 5313 to 100 due to restriction <100>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   14.320   14.320 compile_fx.py:42(compile_fx_inner)
      6/3    0.000    0.000   14.288    4.763 utils.py:70(time_wrapper)
        1    0.000    0.000    9.977    9.977 graph.py:332(compile_to_fn)
        1    0.000    0.000    9.977    9.977 graph.py:315(compile_to_module)
        1    0.000    0.000    9.881    9.881 graph.py:307(codegen)
        1    0.004    0.004    6.572    6.572 scheduler.py:502(__init__)
     1768    0.015    0.000    6.229    0.004 ir.py:3289(__call__)
     2449    0.022    0.000    5.727    0.002 dependencies.py:249(extract_read_writes)
     1768    0.010    0.000    5.635    0.003 ir.py:3393(__call__)
      484    0.006    0.000    4.987    0.010 scheduler.py:220(__init__)
        1    0.000    0.000    4.009    4.009 graph.py:136(run)
        1    0.008    0.008    4.009    4.009 interpreter.py:95(run)
     3102    0.014    0.000    3.998    0.001 graph.py:294(run_node)
53758/53756    0.090    0.000    3.582    0.000 _print_helpers.py:27(__str__)
53758/53756    0.043    0.000    3.492    0.000 printer.py:371(__call__)
64669/50536    0.041    0.000    3.480    0.000 printer.py:290(doprint)
53758/53756    0.045    0.000    3.449    0.000 str.py:982(sstr)
124788/50536    0.480    0.000    3.448    0.000 printer.py:294(_print)
     6879    0.023    0.000    3.019    0.000 dependencies.py:195(load)
        1    0.004    0.004    2.985    2.985 scheduler.py:1012(codegen)
8652/8379    0.057    0.000    2.972    0.000 str.py:50(_print_Add)
      484    0.016    0.000    2.919    0.006 ir.py:1850(simplify_and_reorder)
      303    0.003    0.000    2.905    0.010 triton.py:1035(codegen_nodes)
      303    0.006    0.000    2.888    0.010 triton.py:1113(codegen_node_schedule)
    95418    0.938    0.000    2.796    0.000 basic.py:802(subs)
     3102    0.011    0.000    2.740    0.001 interpreter.py:144(run_node)
     4013    0.003    0.000    2.646    0.001 utils.py:161(wrapper)
     1198    0.009    0.000    2.587    0.002 ir.py:1781(get_read_writes)
     8881    0.014    0.000    2.535    0.000 expr.py:384(__format__)
     8881    0.006    0.000    2.503    0.000 {function Expr.__format__ at 0x7fe9b7aea670}
      968    0.003    0.000    2.371    0.002 ir.py:3226(__init__)
      968    0.016    0.000    2.367    0.002 ir.py:3310(__init__)
      484    0.006    0.000    2.296    0.005 scheduler.py:315(codegen)
8652/1216    0.016    0.000    2.283    0.002 lowering.py:272(inner_fn)
8652/1216    0.012    0.000    2.258    0.002 lowering.py:277(<listcomp>)
      910    0.003    0.000    1.947    0.002 ir.py:340(store_output)
     4272    0.007    0.000    1.895    0.000 sizevars.py:487(load)
     1768    0.008    0.000    1.859    0.001 ir.py:3388(make_gm)
     1768    0.035    0.000    1.819    0.001 graph_module.py:311(__init__)
     2711    0.006    0.000    1.761    0.001 graph.py:226(call_function)
7825/2711    0.031    0.000    1.752    0.001 lowering.py:154(wrapped)
     8652    0.018    0.000    1.725    0.000 printer.py:340(_as_ordered_terms)
20199/16663    0.040    0.000    1.706    0.000 module.py:1268(__setattr__)
8655/8653    0.055    0.000    1.705    0.000 expr.py:1113(as_ordered_terms)
```

After:
```
         15284480 function calls (14520161 primitive calls) in 7.152 seconds

   Ordered by: cumulative time
   List reduced from 1726 to 100 due to restriction <100>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    7.174    7.174 compile_fx.py:42(compile_fx_inner)
      6/3    0.000    0.000    7.143    2.381 utils.py:70(time_wrapper)
        1    0.000    0.000    5.102    5.102 graph.py:332(compile_to_fn)
        1    0.000    0.000    5.102    5.102 graph.py:315(compile_to_module)
        1    0.000    0.000    4.998    4.998 graph.py:307(codegen)
     1769    0.046    0.000    4.000    0.002 interpreter.py:95(run)
        1    0.003    0.003    3.481    3.481 scheduler.py:502(__init__)
    35434    0.096    0.000    3.406    0.000 interpreter.py:144(run_node)
      484    0.004    0.000    2.838    0.006 scheduler.py:220(__init__)
     1768    0.014    0.000    2.368    0.001 ir.py:3288(__call__)
     1768    0.006    0.000    2.264    0.001 ir.py:3388(__call__)
      484    0.013    0.000    2.169    0.004 ir.py:1849(simplify_and_reorder)
      968    0.004    0.000    1.890    0.002 ir.py:3225(__init__)
      968    0.013    0.000    1.887    0.002 ir.py:3310(__init__)
        1    0.000    0.000    1.769    1.769 graph.py:136(run)
     3102    0.012    0.000    1.759    0.001 graph.py:294(run_node)
     2449    0.019    0.000    1.632    0.001 dependencies.py:240(extract_read_writes)
    20973    0.026    0.000    1.559    0.000 interpreter.py:236(call_method)
        1    0.003    0.003    1.306    1.306 scheduler.py:1012(codegen)
      303    0.003    0.000    1.251    0.004 triton.py:1044(codegen_nodes)
      303    0.005    0.000    1.236    0.004 triton.py:1122(codegen_node_schedule)
    16048    0.039    0.000    1.193    0.000 proxy.py:52(create_proxy)
8652/1216    0.014    0.000    1.048    0.001 lowering.py:272(inner_fn)
8652/1216    0.010    0.000    1.025    0.001 lowering.py:277(<listcomp>)
     4272    0.006    0.000    0.990    0.000 sizevars.py:488(load)
     2711    0.005    0.000    0.920    0.000 graph.py:226(call_function)
7825/2711    0.029    0.000    0.912    0.000 lowering.py:154(wrapped)
    10292    0.009    0.000    0.880    0.000 proxy.py:355(__call__)
      484    0.005    0.000    0.837    0.002 scheduler.py:315(codegen)
    16048    0.010    0.000    0.786    0.000 proxy.py:32(create_node)
      910    0.003    0.000    0.779    0.001 ir.py:341(store_output)
    16048    0.042    0.000    0.776    0.000 graph.py:738(create_node)
   145136    0.080    0.000    0.769    0.000 node.py:595(map_arg)
     4013    0.003    0.000    0.718    0.000 utils.py:161(wrapper)
      768    0.003    0.000    0.698    0.001 ir.py:398(store_reduction)
     1198    0.007    0.000    0.688    0.001 ir.py:1778(get_read_writes)
315155/145136    0.429    0.000    0.677    0.000 node.py:603(map_aggregate)
     2935    0.007    0.000    0.608    0.000 ir.py:1702(loader)
     6879    0.016    0.000    0.605    0.000 dependencies.py:186(load)
        1    0.000    0.000    0.605    0.605 scheduler.py:727(fuse_nodes)
        2    0.002    0.001    0.604    0.302 scheduler.py:737(fuse_nodes_once)
43809/29684    0.026    0.000    0.592    0.000 printer.py:290(doprint)
52335/29684    0.208    0.000    0.574    0.000 printer.py:294(_print)
    32904    0.051    0.000    0.559    0.000 _print_helpers.py:27(__str__)
```

