### PR TITLE
Inductor changes for fake tensor

### DIFF
--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -18,6 +18,7 @@ import sys
 import time
 import types
 import weakref
+from contextlib import contextmanager
 from functools import lru_cache
 from typing import Any
 from typing import Dict
@@ -396,6 +397,19 @@ def clone_inputs(example_inputs):
         if isinstance(res[i], torch.Tensor):
             res[i] = clone_input(res[i])
     return res
+
+
+@contextmanager
+def preserve_rng_state():
+    rng = torch.clone(torch.random.get_rng_state())
+    if torch.cuda.is_available():
+        cuda_rng = torch.clone(torch.cuda.get_rng_state())
+    try:
+        yield
+    finally:
+        torch.random.set_rng_state(rng)
+        if torch.cuda.is_available():
+            torch.cuda.set_rng_state(cuda_rng)
 
 
 def is_jit_model(model0):

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -33,6 +33,7 @@ from ..source import AttrSource
 from ..utils import clone_input
 from ..utils import is_lazy_module
 from ..utils import istype
+from ..utils import preserve_rng_state
 from ..utils import product
 from ..utils import proxy_args_kwargs
 from .base import MutableLocal
@@ -41,19 +42,6 @@ from .base import typestr
 from .constant import ConstantVariable
 from .lists import ShapeVariable
 from .lists import SizeVariable
-
-
-@contextmanager
-def preserve_rng_state():
-    rng = torch.clone(torch.random.get_rng_state())
-    if torch.cuda.is_available():
-        cuda_rng = torch.clone(torch.cuda.get_rng_state())
-    try:
-        yield
-    finally:
-        torch.random.set_rng_state(rng)
-        if torch.cuda.is_available():
-            torch.cuda.set_rng_state(cuda_rng)
 
 
 class TensorVariable(VariableTracker):

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -5,7 +5,6 @@ import itertools
 import math
 import numbers
 import operator
-from contextlib import contextmanager
 from typing import Dict
 from typing import List
 

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -7,11 +7,14 @@ import functorch
 import torch.fx
 from functorch.compile import make_boxed_compiler
 from functorch.compile import min_cut_rematerialization_partition
+from torch._subclasses.fake_tensor import FakeTensor
+from torch.utils._mode_utils import no_dispatch
 
 from torchdynamo.optimizations.backends import aot_autograd
 from torchdynamo.optimizations.normalize import normalize_ir
 from torchdynamo.utils import dynamo_timed
 from torchdynamo.utils import identity
+from torchdynamo.utils import preserve_rng_state
 
 from . import config
 from . import overrides
@@ -40,6 +43,7 @@ class BoxedBool:
 
 
 @DebugContext.wrap
+@no_dispatch()
 def compile_fx_inner(
     gm: torch.fx.GraphModule,
     example_inputs: List[torch.Tensor],
@@ -74,8 +78,25 @@ def compile_fx_inner(
     return compiled_fn
 
 
-@dynamo_timed
 def cudagraphify(model, inputs, static_input_idxs=()):
+    # if using fake tensors, defer cudagraphs until we get real inputs at runtime
+    if not any(isinstance(inp, FakeTensor) for inp in inputs):
+        return cudagraphify_impl(model, inputs, static_input_idxs)
+
+    compiled_fn = None
+
+    def run(*new_inputs):
+        nonlocal compiled_fn
+        if compiled_fn is None:
+            with preserve_rng_state():
+                compiled_fn = cudagraphify_impl(model, new_inputs, static_input_idxs)
+
+        return compiled_fn(*new_inputs)
+
+    return run
+
+
+def cudagraphify_impl(model, inputs, static_input_idxs=()):
     """
     Assumes inputs[static_input_idxs[i]] are always the same memory address
     """

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -78,6 +78,7 @@ def compile_fx_inner(
     return compiled_fn
 
 
+@dynamo_timed
 def cudagraphify(model, inputs, static_input_idxs=()):
     # if using fake tensors, defer cudagraphs until we get real inputs at runtime
     if not any(isinstance(inp, FakeTensor) for inp in inputs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1160

- Defer cudagraphs until runtime if using fake tensors
- Disable FakeTensorMode with no_dispatch in compilation

Will require https://github.com/pytorch/pytorch/pull/84432 before we can actually turn on