### PR TITLE
Downgrade gym to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
           name: Generate date for cache key
           command: date +%F > .circleci-date
       - restore_cache:
-          key: env-v4-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}
+          key: env-v4-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}-{{ checksum "requirements.txt" }}
       - run:
           name: Install libs
           command: |
@@ -29,6 +29,7 @@ commands:
               wget -O torchbenchmark.tar.bz2 "https://github.com/jansel/benchmark/releases/download/snapshots/torchbenchmark.tar.bz2"
               tar jxvf torchbenchmark.tar.bz2
               (cd torchbenchmark && python install.py && touch env-v4.key)
+              pip install gym==0.25.2  # workaround issue in 0.26.0
             fi
       - run:
           name: Install HuggingFace
@@ -41,7 +42,7 @@ commands:
             source .circleci/setup_env.sh
             python -m pip install git+https://github.com/rwightman/pytorch-image-models
       - save_cache:
-          key: env-v4-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}
+          key: env-v4-{{ arch }}-{{ checksum ".circleci/setup_env.sh" }}-{{ checksum "Makefile" }}-{{ checksum ".circleci-date" }}-{{ checksum "requirements.txt" }}
           paths:
             - conda
             - env

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pyyaml
 sympy
 tabulate
 torch>=1.12.0
-gym==0.25.2
+gym==0.24.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pyyaml
 sympy
 tabulate
 torch>=1.12.0
-gym==0.24.1
+gym==0.23.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ pyyaml
 sympy
 tabulate
 torch>=1.12.0
-gym==0.25.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pyyaml
 sympy
 tabulate
 torch>=1.12.0
+gym==0.25.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-black==22.6.0
-flake8==4.0.1
+black==22.8.0
+flake8==5.0.4
 isort==5.10.1
 mypy==0.960
 click>=8.1
@@ -13,4 +13,4 @@ pyyaml
 sympy
 tabulate
 torch>=1.12.0
-gym==0.23.1
+gym==0.25.2


### PR DESCRIPTION
Our CI is failing with an error from the gym package. A [new version of it](https://pypi.org/project/gym/0.26.0/#history) was pushed today, so I am hoping using an older one will fix things.