### PR TITLE
Fix warning-related issues

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -793,7 +793,7 @@ def read_batch_size_from_file(args, filename, model_name):
             if model_name == cur_name:
                 batch_size = int(b)
     if batch_size is None:
-        warnings.warn("Could not find batch size for {}".format(model_name))
+        log.warning("Could not find batch size for {}".format(model_name))
     elif batch_size == -1:
         raise RuntimeError(
             f"Batch size is unset for {model_name} in {args.batch_size_file}"
@@ -1051,7 +1051,7 @@ class BenchmarkRunner:
                 batch_size=batch_size,
             )
         except NotImplementedError:
-            logging.warning(f"{model_name} failed to load")
+            log.warning(f"{model_name} failed to load")
 
         assert (
             device == "cuda"
@@ -1233,7 +1233,7 @@ class BenchmarkRunner:
                 optimized_model_iter_fn = optimize_ctx(model_iter_fn)
                 new_result = optimized_model_iter_fn(model, example_inputs)
             except Exception as e:
-                logging.exception("unhandled error")
+                log.exception("unhandled error")
                 print("ERROR")
                 print(e)
                 return sys.exit(-1)
@@ -1855,7 +1855,7 @@ def main(runner, original_dir=None):
                     batch_size=batch_size,
                 )
             except NotImplementedError:
-                logging.warning(f"{args.only} failed to load")
+                log.warning(f"{args.only} failed to load")
                 continue  # bad benchmark implementation
 
             current_name = name

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -1051,7 +1051,7 @@ class BenchmarkRunner:
                 batch_size=batch_size,
             )
         except NotImplementedError:
-            logging.warn(f"{model_name} failed to load")
+            logging.warning(f"{model_name} failed to load")
 
         assert (
             device == "cuda"
@@ -1855,7 +1855,7 @@ def main(runner, original_dir=None):
                     batch_size=batch_size,
                 )
             except NotImplementedError:
-                logging.warn(f"{args.only} failed to load")
+                logging.warning(f"{args.only} failed to load")
                 continue  # bad benchmark implementation
 
             current_name = name

--- a/benchmarks/huggingface.py
+++ b/benchmarks/huggingface.py
@@ -11,10 +11,10 @@ import torch
 from common import BenchmarkRunner
 from common import main
 
-log = logging.getLogger(__name__)
-
 from torchdynamo.testing import collect_results
 from torchdynamo.utils import clone_inputs
+
+log = logging.getLogger(__name__)
 
 
 def pip_install(package):

--- a/benchmarks/huggingface.py
+++ b/benchmarks/huggingface.py
@@ -160,7 +160,7 @@ def get_sequence_length(model_cls, model_name):
     ) or model_name in ("DistillGPT2", "GoogleFnet", "YituTechConvBert", "CamemBert"):
         seq_length = 512
     else:
-        logging.warn(
+        logging.warning(
             f"Sequence Length not defined for {model_name}. Choosing 128 arbitrarily"
         )
         seq_length = 128
@@ -363,7 +363,7 @@ class HuggingfaceRunner(BenchmarkRunner):
             batch_size_default = BATCH_SIZE_KNOWN_MODELS[model_name]
         elif batch_size is None:
             batch_size_default = 16
-            logging.warn(
+            logging.warning(
                 "Batch size not specified for {model_name}. Setting batch_size=16"
             )
 
@@ -371,12 +371,12 @@ class HuggingfaceRunner(BenchmarkRunner):
             batch_size = batch_size_default
             if model_name in USE_SMALL_BATCH_SIZE:
                 batch_size = USE_SMALL_BATCH_SIZE[model_name]
-                logging.warn(
+                logging.warning(
                     f"Running smaller batch size={batch_size} for {model_name}, orig batch_size={batch_size_default}"
                 )
             elif USE_HALF_BATCH_SIZE and batch_size >= 2:
                 batch_size = int(batch_size / 2)
-                logging.warn(
+                logging.warning(
                     f"Running smaller batch size={batch_size} for {model_name}, orig batch_size={batch_size_default}"
                 )
 
@@ -526,7 +526,7 @@ def refresh_model_names_and_batch_sizes():
                 + [f"--output={MODELS_FILENAME}"]
             )
         except subprocess.SubprocessError:
-            logging.warn(f"Failed to find suitable batch size for {model_name}")
+            logging.warning(f"Failed to find suitable batch size for {model_name}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/huggingface.py
+++ b/benchmarks/huggingface.py
@@ -11,6 +11,8 @@ import torch
 from common import BenchmarkRunner
 from common import main
 
+log = logging.getLogger(__name__)
+
 from torchdynamo.testing import collect_results
 from torchdynamo.utils import clone_inputs
 
@@ -160,7 +162,7 @@ def get_sequence_length(model_cls, model_name):
     ) or model_name in ("DistillGPT2", "GoogleFnet", "YituTechConvBert", "CamemBert"):
         seq_length = 512
     else:
-        logging.warning(
+        log.warning(
             f"Sequence Length not defined for {model_name}. Choosing 128 arbitrarily"
         )
         seq_length = 128
@@ -363,7 +365,7 @@ class HuggingfaceRunner(BenchmarkRunner):
             batch_size_default = BATCH_SIZE_KNOWN_MODELS[model_name]
         elif batch_size is None:
             batch_size_default = 16
-            logging.warning(
+            log.warning(
                 "Batch size not specified for {model_name}. Setting batch_size=16"
             )
 
@@ -371,12 +373,12 @@ class HuggingfaceRunner(BenchmarkRunner):
             batch_size = batch_size_default
             if model_name in USE_SMALL_BATCH_SIZE:
                 batch_size = USE_SMALL_BATCH_SIZE[model_name]
-                logging.warning(
+                log.warning(
                     f"Running smaller batch size={batch_size} for {model_name}, orig batch_size={batch_size_default}"
                 )
             elif USE_HALF_BATCH_SIZE and batch_size >= 2:
                 batch_size = int(batch_size / 2)
-                logging.warning(
+                log.warning(
                     f"Running smaller batch size={batch_size} for {model_name}, orig batch_size={batch_size_default}"
                 )
 
@@ -526,7 +528,7 @@ def refresh_model_names_and_batch_sizes():
                 + [f"--output={MODELS_FILENAME}"]
             )
         except subprocess.SubprocessError:
-            logging.warning(f"Failed to find suitable batch size for {model_name}")
+            log.warning(f"Failed to find suitable batch size for {model_name}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/microbenchmarks/operator_inp_utils.py
+++ b/benchmarks/microbenchmarks/operator_inp_utils.py
@@ -256,7 +256,7 @@ class OperatorInputsLoader:
         ), f"Could not find {operator}, must provide overload"
 
         if "embedding" in str(operator):
-            logging.warn("Embedding inputs NYI, input data cannot be randomized")
+            logging.warning("Embedding inputs NYI, input data cannot be randomized")
             yield
             return
 

--- a/benchmarks/microbenchmarks/operator_inp_utils.py
+++ b/benchmarks/microbenchmarks/operator_inp_utils.py
@@ -16,6 +16,8 @@ from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_flatten
 from torch.utils._pytree import tree_map
 
+log = logging.getLogger(__name__)
+
 OP_INP_DIRECTORY = os.path.join(os.path.dirname(__file__), "operator_inp_logs")
 
 TIMM_DIR = os.path.join(OP_INP_DIRECTORY, "timm_train")
@@ -256,7 +258,7 @@ class OperatorInputsLoader:
         ), f"Could not find {operator}, must provide overload"
 
         if "embedding" in str(operator):
-            logging.warning("Embedding inputs NYI, input data cannot be randomized")
+            log.warning("Embedding inputs NYI, input data cannot be randomized")
             yield
             return
 

--- a/torchdynamo/debug_utils.py
+++ b/torchdynamo/debug_utils.py
@@ -16,6 +16,8 @@ import torchdynamo
 from torchdynamo import config
 from torchdynamo.utils import clone_inputs
 
+log = logging.getLogger(__name__)
+
 
 def minifier_dir():
     return f"/tmp/minifier_{getpass.getuser()}"
@@ -46,7 +48,7 @@ class NNModuleToString:
                 cant_convert.add(module)
 
         if len(cant_convert) > 0:
-            logging.warn(
+            log.warning(
                 f"Was not able to save the following children modules as reprs {cant_convert}"
             )
             return False
@@ -526,7 +528,7 @@ def wrap_backend_debug(compiler_fn, compiler_name: str):
                 run_fwd_maybe_bwd(compiled_gm, clone_inputs(example_inputs))
             except Exception as exc:
                 orig_failure = str(exc)
-                logging.warn(
+                log.warning(
                     f"Compiled Fx GraphModule failed with {orig_failure}. Starting minifier."
                 )
                 dump_state_fn = functools.partial(

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -103,7 +103,7 @@ class _TorchDynamoContext:
         patch_fn()
 
     def __enter__(self):
-        logging.warn(
+        log.warning(
             (
                 "Using TorchDynamo with a context manager will be deprecated soon."
                 "Please read https://github.com/pytorch/torchdynamo#usage-example "
@@ -233,8 +233,7 @@ def catch_errors_wrapper(callback):
             with compile_lock:
                 return callback(frame, cache_size)
         except Exception:
-            logging.basicConfig()
-            logging.exception("Error while processing frame")
+            log.exception("Error while processing frame")
             raise
 
     catch_errors._torchdynamo_orig_callable = callback

--- a/torchdynamo/optimizations/backends.py
+++ b/torchdynamo/optimizations/backends.py
@@ -5,7 +5,6 @@ import logging
 import os
 import subprocess
 import tempfile
-import warnings
 
 import numpy as np
 import torch
@@ -296,7 +295,7 @@ def ipex(subgraph, **kwargs):
             traced_model = torch.jit.freeze(traced_model)
             return traced_model
         except Exception:
-            warnings.warn("JIT trace failed during the 'ipex' optimize process.")
+            log.warning("JIT trace failed during the 'ipex' optimize process.")
             return model
 
 

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -463,7 +463,7 @@ class InstructionTranslatorBase(object):
         spec = self.f_globals.get("__spec__")
         if package is not None:
             if spec is not None and package != spec.parent:
-                log.warn(
+                log.warning(
                     "__package__ != __spec__.parent "
                     f"({package!r} != {spec.parent!r})",
                     ImportWarning,
@@ -473,7 +473,7 @@ class InstructionTranslatorBase(object):
         elif spec is not None:
             return spec.parent
         else:
-            log.warn(
+            log.warning(
                 "can't resolve package from __spec__ or __package__, "
                 "falling back on __name__ and __path__",
                 ImportWarning,


### PR DESCRIPTION
Address https://github.com/pytorch/torchdynamo/issues/948 and fix related issues:
- replace the use of the `warnings` module in the main code
- replace root logging with module-scoped logging
- use function `logging.warning` instead of deprecated `logging.warn`.