### PR TITLE
Autotune

### DIFF
--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -1150,10 +1150,9 @@ class TritonScheduling:
             )
         )
         if len(reductions) > 0:
-            if all(self.reduction_hint(n) == ReductionHint.INNER for n in reductions):
-                reduction_hint_val = ReductionHint.INNER
-            elif all(self.reduction_hint(n) == ReductionHint.OUTER for n in reductions):
-                reduction_hint_val = ReductionHint.OUTER
+            hints = [self.reduction_hint(n) for n in reductions]
+            if hints.count(hints[0]) == len(hints):
+                reduction_hint_val = hints[0]
             else:
                 reduction_hint_val = ReductionHint.DEFAULT
         else:

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -16,6 +16,7 @@ import torchinductor
 
 from .. import config
 from .. import ir
+from ..triton_ops.autotune import ReductionHint
 from ..utils import free_symbol_startswith
 from ..utils import has_triton_libdevice
 from ..utils import sympy_product
@@ -28,7 +29,6 @@ from .common import IndentedBuffer
 from .common import Kernel
 from .common import OpOverrides
 from .common import index_prevent_reordering
-from ..triton_ops.autotune import ReductionHint
 
 log = logging.getLogger(__name__)
 

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -1133,11 +1133,9 @@ class TritonScheduling:
     def reduction_hint(node):
         assert node.is_reduction()
         if all(
-                dep.is_contiguous()
-                for dep in itertools.chain(
-                    node.read_writes.reads, node.read_writes.writes
-                )
-            ):
+            dep.is_contiguous()
+            for dep in itertools.chain(node.read_writes.reads, node.read_writes.writes)
+        ):
             return ReductionHint.INNER
         else:
             return node.node.data.reduction_hint
@@ -1160,9 +1158,7 @@ class TritonScheduling:
                 reduction_hint_val = ReductionHint.DEFAULT
         else:
             reduction_hint_val = ReductionHint.DEFAULT
-        with TritonKernel(
-            *tiled_groups, reduction_hint=reduction_hint_val
-        ) as kernel:
+        with TritonKernel(*tiled_groups, reduction_hint=reduction_hint_val) as kernel:
             stack = contextlib.ExitStack()
             for node in node_schedule:
                 if node is DisableReduction:

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -30,13 +30,13 @@ from .codegen.common import _simplify_loops
 from .codegen.common import index_prevent_reordering
 from .dependencies import extract_read_writes
 from .dependencies import var_builder
+from .triton_ops.autotune import ReductionHint
 from .utils import cache_on_self
 from .utils import sympy_dot
 from .utils import sympy_product
 from .utils import sympy_subs
 from .virtualized import V
 from .virtualized import ops
-from .triton_ops.autotune import ReductionHint
 
 log = logging.getLogger(__name__)
 indent = functools.partial(textwrap.indent, prefix="  ")

--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -327,7 +327,7 @@ def reduction_heuristics(size_hints, reduction_hint=False, filename=None):
         elif reduction_hint == ReductionHint.OUTER:
             return apply_triton_config(outer_config)
         elif reduction_hint == ReductionHint.OUTER_TINY:
-            return apply_triton_config(size_hints, 2 * (256//rnumel), rnumel)
+            return apply_triton_config(size_hints, 2 * (256 // rnumel), rnumel)
         if not config.triton.autotune:
             return apply_triton_config(triton_config_reduction(size_hints, 32, 128))
         return cached_autotune(

--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -310,7 +310,8 @@ def pointwise_heuristics(size_hints, filename=None):
 class ReductionHint(Enum):
     INNER = 0
     OUTER = 1
-    DEFAULT = 2
+    OUTER_TINY = 2
+    DEFAULT = 3
 
 
 def reduction_heuristics(size_hints, reduction_hint=False, filename=None):
@@ -323,8 +324,10 @@ def reduction_heuristics(size_hints, reduction_hint=False, filename=None):
         outer_config = triton_config_reduction(size_hints, 128, 8)
         if reduction_hint == ReductionHint.INNER:
             return apply_triton_config(contiguous_config)
-        # elif reduction_hint == ReductionHint.OUTER:
-        #     return apply_triton_config(outer_config)
+        elif reduction_hint == ReductionHint.OUTER:
+            return apply_triton_config(outer_config)
+        elif reduction_hint == ReductionHint.OUTER_TINY:
+            return apply_triton_config(size_hints, 2 * (256//rnumel), rnumel)
         if not config.triton.autotune:
             return apply_triton_config(triton_config_reduction(size_hints, 32, 128))
         return cached_autotune(

--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -322,12 +322,15 @@ def reduction_heuristics(size_hints, reduction_hint=False, filename=None):
             size_hints, 1, (rnumel if 256 <= rnumel < 2048 else 2048), num_stages=1
         )
         outer_config = triton_config_reduction(size_hints, 128, 8)
+        tiny_config = triton_config_reduction(
+            size_hints, 2 * (256 // rnumel) if rnumel <= 256 else 1, rnumel
+        )
         if reduction_hint == ReductionHint.INNER:
             return apply_triton_config(contiguous_config)
         elif reduction_hint == ReductionHint.OUTER:
             return apply_triton_config(outer_config)
         elif reduction_hint == ReductionHint.OUTER_TINY:
-            return apply_triton_config(size_hints, 2 * (256 // rnumel), rnumel)
+            return apply_triton_config(tiny_config)
         if not config.triton.autotune:
             return apply_triton_config(triton_config_reduction(size_hints, 32, 128))
         return cached_autotune(

--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -320,8 +320,11 @@ def reduction_heuristics(size_hints, reduction_hint=False, filename=None):
         contiguous_config = triton_config_reduction(
             size_hints, 1, (rnumel if 256 <= rnumel < 2048 else 2048), num_stages=1
         )
+        outer_config = triton_config_reduction(size_hints, 128, 8)
         if reduction_hint == ReductionHint.INNER:
             return apply_triton_config(contiguous_config)
+        # elif reduction_hint == ReductionHint.OUTER:
+        #     return apply_triton_config(outer_config)
         if not config.triton.autotune:
             return apply_triton_config(triton_config_reduction(size_hints, 32, 128))
         return cached_autotune(


### PR DESCRIPTION
Add more reduction autotuning cases, this mostly doesn't change benchmarking numbers (marginal decreases on a couple models), but improves compile times 30-75% (1.30 -> 1 minute on hf_Bert, 12 min -> 4 min on densenet). Densenet now doesn't have autotuned kernels at all, but there are still some autotuned kernels for other nets. 