### PR TITLE
Move unspec variable to GPU if it ops with tensor on GPU

### DIFF
--- a/torchdynamo/variables/builtin.py
+++ b/torchdynamo/variables/builtin.py
@@ -273,7 +273,10 @@ class BuiltinVariable(VariableTracker):
                     fn, args = operator.add, [args[1], args[0]]
 
                 proxy = tx.output.create_proxy(
-                    "call_function", fn, *proxy_args_kwargs(args, kwargs), current_tx=tx
+                    "call_function",
+                    fn,
+                    *proxy_args_kwargs(tx, args, kwargs, True),
+                    current_tx=tx,
                 )
                 if any([isinstance(arg, FakeItemVariable) for arg in args]):
                     return variables.FakeItemVariable.create(
@@ -313,7 +316,7 @@ class BuiltinVariable(VariableTracker):
                     if self.fn is operator.truediv and isinstance(
                         args[0], variables.UnspecializedPythonVariable
                     ):
-                        args[0] = args[0].convert_to_constant(tx)
+                        args[0] = args[0].as_specialized(tx)
                     return variables.TensorVariable.create(tx, proxy, **options)
 
             except NotImplementedError:

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -476,7 +476,7 @@ class GetAttrVariable(VariableTracker):
                         proxy=tx.output.create_proxy(
                             "call_function",
                             original_torch_or_getattr_variable.value,
-                            *proxy_args_kwargs(new_args, new_kwargs),
+                            *proxy_args_kwargs(tx, new_args, new_kwargs),
                             current_tx=tx,
                         ),
                         **options,
@@ -487,7 +487,7 @@ class GetAttrVariable(VariableTracker):
                         proxy=tx.output.create_proxy(
                             "call_method",
                             original_torch_or_getattr_variable.name,
-                            *proxy_args_kwargs(new_args, new_kwargs),
+                            *proxy_args_kwargs(tx, new_args, new_kwargs),
                             current_tx=tx,
                         ),
                         **options,

--- a/torchdynamo/variables/nn_module.py
+++ b/torchdynamo/variables/nn_module.py
@@ -197,7 +197,7 @@ class NNModuleVariable(VariableTracker):
                     proxy=tx.output.create_proxy(
                         "call_module",
                         self.module_key,
-                        *proxy_args_kwargs(args, kwargs),
+                        *proxy_args_kwargs(tx, args, kwargs),
                         current_tx=tx,
                     ),
                     nnmodule=mod,

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -479,7 +479,7 @@ class TensorVariable(VariableTracker):
             tx.output.create_proxy(
                 "call_function",
                 operator.setitem,
-                *proxy_args_kwargs([self] + args, kwargs),
+                *proxy_args_kwargs(tx, [self] + args, kwargs),
                 current_tx=tx,
             )
             return ConstantVariable(None, **options)
@@ -499,7 +499,7 @@ class TensorVariable(VariableTracker):
                 tx.output.create_proxy(
                     "call_method",
                     name,
-                    *proxy_args_kwargs([self] + args, kwargs),
+                    *proxy_args_kwargs(tx, [self] + args, kwargs),
                     current_tx=tx,
                 ),
                 **options,

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -219,7 +219,7 @@ class TorchVariable(VariableTracker):
                 proxy=tx.output.create_proxy(
                     "call_function",
                     self.value,
-                    *proxy_args_kwargs(args, kwargs),
+                    *proxy_args_kwargs(tx, args, kwargs),
                     current_tx=tx,
                 ),
                 **options,
@@ -289,7 +289,7 @@ class TorchVariable(VariableTracker):
                 proxy=tx.output.create_proxy(
                     "call_function",
                     torch.nn.functional.softmax,
-                    *proxy_args_kwargs([input, dim], {}),
+                    *proxy_args_kwargs(tx, [input, dim], {}),
                     current_tx=tx,
                 ),
                 **VariableTracker.propagate([self, dim, input]),
@@ -342,6 +342,7 @@ class TorchVariable(VariableTracker):
                     "call_function",
                     torch.nn.functional.cross_entropy,
                     *proxy_args_kwargs(
+                        tx,
                         [
                             input,
                             target,


### PR DESCRIPTION
We wrap unspecialized variable as 1-element tensor on CPU by default. If it ops with tensor whose device is GPU, we have to move it from CPU to GPU explicitly.

I verified this can fix #1176.