### PR TITLE
Correct TorchDynamo pytest log output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ develop:
 	python setup.py develop
 
 test: develop
-	pytest test
+	pytest test -o log_cli=False
 
 torchbench: develop
 	python benchmarks/torchbench.py --fast

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 testpaths =
     test
 log_cli = True
-log_cli_level = DEBUG
+log_cli_level = INFO

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 testpaths =
     test
-log_cli = False
-log_cli_level = INFO
+log_cli = True
+log_cli_level = DEBUG


### PR DESCRIPTION
Fix #1184

If running ```make test```: don't output logging records.
If running ```pytest test_***```: output logging at ```INFO``` level by default.

