### PR TITLE
Fix Cudagraphs Expanded Inputs

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -3276,3 +3276,27 @@ if HAS_CUDA:
             mod = make_fx(forward)()
             compiled = compile_fx_inner(mod, ())
             assert compiled()[0].device.type == "cuda"
+
+        @patch.object(config.triton, "cudagraphs", True)
+        def test_expanded_inputs_cudagraphs(self):
+            @torchdynamo.optimize("inductor")
+            def fn(x, y):
+                return x + y
+
+            inputs = (
+                rand_strided((10, 10), (0, 1), device="cuda"),
+                rand_strided((10, 10), (0, 1), device="cuda"),
+            )
+            self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))
+
+        @patch.object(config, "size_asserts", False)
+        def test_expanded_inputs_cudagraphs_no_size_asserts(self):
+            @torchdynamo.optimize("inductor")
+            def fn(x, y):
+                return x + y
+
+            inputs = (
+                rand_strided((10, 10), (0, 1), device="cuda"),
+                rand_strided((10, 10), (0, 1), device="cuda"),
+            )
+            self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))

--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -3284,8 +3284,8 @@ if HAS_CUDA:
                 return x + y
 
             inputs = (
-                rand_strided((1, 5, 1, 5), (0, 5, 0, 1), device="cuda"),
-                rand_strided((1, 5, 1, 5), (0, 5, 0, 1), device="cuda"),
+                rand_strided((5, 5, 5, 5), (0, 5, 0, 1), device="cuda"),
+                rand_strided((5, 5, 5, 5), (0, 5, 0, 1), device="cuda"),
             )
             self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))
 
@@ -3297,7 +3297,7 @@ if HAS_CUDA:
                 return x + y
 
             inputs = (
-                rand_strided((1, 5, 1, 5), (0, 5, 0, 1), device="cuda"),
-                rand_strided((1, 5, 1, 5), (0, 5, 0, 1), device="cuda"),
+                rand_strided((5, 5, 5, 5), (0, 5, 0, 1), device="cuda"),
+                rand_strided((5, 5, 5, 5), (0, 5, 0, 1), device="cuda"),
             )
             self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))

--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -3284,19 +3284,20 @@ if HAS_CUDA:
                 return x + y
 
             inputs = (
-                rand_strided((10, 10), (0, 1), device="cuda"),
-                rand_strided((10, 10), (0, 1), device="cuda"),
+                rand_strided((1, 5, 1, 5), (0, 5, 0, 1), device="cuda"),
+                rand_strided((1, 5, 1, 5), (0, 5, 0, 1), device="cuda"),
             )
             self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))
 
         @patch.object(config, "size_asserts", False)
+        @patch.object(config.triton, "cudagraphs", True)
         def test_expanded_inputs_cudagraphs_no_size_asserts(self):
             @torchdynamo.optimize("inductor")
             def fn(x, y):
                 return x + y
 
             inputs = (
-                rand_strided((10, 10), (0, 1), device="cuda"),
-                rand_strided((10, 10), (0, 1), device="cuda"),
+                rand_strided((1, 5, 1, 5), (0, 5, 0, 1), device="cuda"),
+                rand_strided((1, 5, 1, 5), (0, 5, 0, 1), device="cuda"),
             )
             self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -162,8 +162,9 @@ def cudagraphify(model, inputs, static_input_idxs=()):
                 if idx in static_input_idxs:
                     assert dst.data_ptr() == src.data_ptr()
                 else:
-                    # TODO - could make one single op here, avoid dispatch
-                    # Could also pre-index the `dstt tensors
+                    # TODO - could make one single op of multiple slices
+                    # and avoid dispatch.
+                    # Could also pre-index the `dst` tensors
                     dst = index_expanded_dims(dst, expanded_dims)
                     src = index_expanded_dims(src, expanded_dims)
                     dst.copy_(src)


### PR DESCRIPTION
When we ran Cudagraphs with inputs that had internal memory overlap, previously we would hit an error in `dst.copy_(src)` 
```
    "unsupported operation: more than one element of the written-to tensor "
    "refers to a single memory location. Please clone() the tensor before "
    "performing the operation.");
```

For expanded dimensions (a dimension which used to have size 1 -> ?), we can slice one element from that dimension and write to it to achieve copying all values of the src to dst. For more complex internal memory overlap, bail on cudagraphs.