### PR TITLE
Improve torchdynamo.explain() explanation

### DIFF
--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -228,10 +228,6 @@ class OutputGraph(fx.Tracer):
         Automatically restore live variables.
         """
         self.partial_convert = partial_convert
-        if msg is not None:
-            stack = tx.frame_summary()
-            msgs = reversed(traceback.StackSummary.from_list([stack]).format())
-            msg = f"{msg} \n {''.join(msgs)}"
         self.compile_subgraph_reason = msg
 
         if not all(block.can_restore() for block in tx.block_stack):


### PR DESCRIPTION
Improve the stack trace to point to the actual location of the graph
break.

Before, we were lazily computing the stack trace at the time we were
compiling the subgraph. However, if were graph breaking inside an
inlined function, the sequence of events looked like:
1. Catch the graph break exception
2. Restore the old graph state <-- thus overriding the user stack location
3. Compute the stack trace and add it as a message to the compiled graph

So the graph break explanation pointed to the caller, not the actual
location of the graph break. By computing the stack trace at the same
time we're processing the graph break exception, we can fix that.

This also starts printing the whole stack trace that we have instead of
just the most recent line, which I think is more useful (but if people
find it noisy I can change it back).

Looking for advice on testing.
