### PR TITLE
Make torch.ops.profiler.* as FakeContextWrappingVariable and do nothing

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1316,6 +1316,18 @@ class MiscTests(torchdynamo.testing.TestCase):
         res = opt_fn(x)
         self.assertTrue(same(ref, res))
 
+    def test_torch_ops_profiler(self):
+        # wrap torch.ops.profiler.* as FakeContextWrappingVariable and do nothing
+        def fn(x):
+            torch.ops.profiler._record_function_enter("name", "args")
+            return x + 1
+
+        x = torch.randn((2, 2), requires_grad=True)
+        ref = fn(x)
+        opt_fn = torchdynamo.optimize("eager")(fn)
+        res = opt_fn(x)
+        self.assertTrue(same(ref, res))
+
     def test_python_slice(self):
         def f1(input):
             y = 0

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -202,12 +202,7 @@ class TorchVariable(VariableTracker):
                 tensor_with_tf_override.subclass_torch_function__func,
                 tensor_with_tf_override.subclass_type,
             )
-        elif self.value is torch.autograd.profiler.profile:
-            if len(args) == 0 or len(args) > 0 and args[0]:
-                log.warning("Profiler will be ignored")
-            return FakeContextWrappingVariable(**options)
-        elif self.value is torch.autograd.profiler.record_function:
-            assert len(args) == 1
+        elif self.value in dir(torch.autograd.profiler) + dir(torch.ops.profiler):
             log.warning("Profiler will be ignored")
             return FakeContextWrappingVariable(**options)
         elif self.value is torch.jit.annotate:


### PR DESCRIPTION
Fix #1212

```torch.ops.profiler._record_function_enter``` should not be a common usage, but appeared in some places. Just treat it the same as ```torch.autograd.profiler.*``` and actually the return value is useless.