### PR TITLE
[export] dedupe break reasons in explain() output

### DIFF
--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -5,10 +5,12 @@ import operator
 import re
 import sys
 import traceback
+from dataclasses import dataclass
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import Optional
 
 import torch.nn
 from torch import fx
@@ -39,6 +41,14 @@ from .variables.tensor import UnspecializedNumpyVariable
 from .variables.tensor import UnspecializedPythonVariable
 
 log = logging.getLogger(__name__)
+
+
+@dataclass
+class GraphCompileReason:
+    """Stores why a given output graph was compiled; i.e. what caused the graph break."""
+
+    reason: str
+    user_stack: List[traceback.FrameSummary]
 
 
 def _get_gen_rand_values_fn(random_calls):
@@ -222,13 +232,15 @@ class OutputGraph(fx.Tracer):
 
         assert False
 
-    def compile_subgraph(self, tx, partial_convert=False, msg=None):
+    def compile_subgraph(
+        self, tx, partial_convert=False, reason: Optional[GraphCompileReason] = None
+    ):
         """
         Generate a subgraph to continue execution on user code.
         Automatically restore live variables.
         """
         self.partial_convert = partial_convert
-        self.compile_subgraph_reason = msg
+        self.compile_subgraph_reason = reason
 
         if not all(block.can_restore() for block in tx.block_stack):
             unimplemented("compile_subgraph with block_depth != 0")


### PR DESCRIPTION
Currently, the `explain()` summary lists the graph break reason for
every graph. This can lead to repetitive output when either:
- A single graph break produces multiple graphs (happens for jumps)
- A single instruction is called many times in the same model and causes
  a graph break.

This PR dedupes the break reasons listed in the `explain()` summary by
the innermost stack frame referenced, which should reduce the verbose of
the explanation.

This is not always what you want--for example, maybe you want to track
down all the different stack traces that lead to a graph break, even if
they end in the same actual instruction. So I also added an additional
output that returns the un-deduped graph break reasons. At some point we
should make a nice API for interacting with these.
