### PR TITLE
Stride sort

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -420,6 +420,19 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(32),))
 
+    def test_add_inplace_permuted(self):
+        def fn(x, y):
+            return x.add_(y)
+
+        x=torch.ones([2, 12, 13, 17]).transpose(1,2)
+        y=torch.randn([2, 13, 1, 17])
+
+        self.common(fn, (x,y))
+
+
+
+
+
     def test_abs(self):
         def fn(a):
             return (a / (torch.abs(a) + 1),)

--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -424,14 +424,10 @@ class CommonTemplate:
         def fn(x, y):
             return x.add_(y)
 
-        x=torch.ones([2, 12, 13, 17]).transpose(1,2)
-        y=torch.randn([2, 13, 1, 17])
+        x = torch.ones([2, 12, 13, 17]).transpose(1, 2)
+        y = torch.randn([2, 13, 1, 17])
 
-        self.common(fn, (x,y))
-
-
-
-
+        self.common(fn, (x, y))
 
     def test_abs(self):
         def fn(a):

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -724,7 +724,7 @@ def same(
             res = res.to_dense()
         assert isinstance(res, torch.Tensor), f"type mismatch {type(ref)} {type(res)}"
         if exact_dtype:
-            assert ref.dtype == res.dtype
+            assert ref.dtype == res.dtype, f"dtype mismatch {ref.dtype}, {res.dtype}"
         if cos_similarity:
             ref = ref.flatten().to(torch.float32)
             res = res.flatten().to(torch.float32)

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -2,7 +2,6 @@ import logging
 import operator
 import os
 import time
-from itertools import chain
 
 import sympy
 import torch

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -52,11 +52,7 @@ class GraphLowering(torch.fx.Interpreter):
             }
             # iterate over unbound strides in sorted order
             val_list = sorted(
-                [
-                    (ex.stride()[i], i)
-                    for i in range(len(stride))
-                    if stride[i] is None
-                ]
+                [(ex.stride()[i], i) for i in range(len(stride)) if stride[i] is None]
             )
             for _, i in val_list:
                 if stride[i] is None and ex.stride()[i] in candidates:

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -44,14 +44,21 @@ class GraphLowering(torch.fx.Interpreter):
         for i, val in enumerate(ex.stride()):
             if val in (0, 1):
                 stride[i] = Integer(val)
-
         while any(x is None for x in stride):
             candidates = {
                 ex.size(i) * ex.stride()[i]: size[i] * stride[i]
                 for i in range(len(size))
                 if stride[i] is not None and ex.stride()[i] >= 0
             }
-            for i in chain(reversed(range(len(stride))), range(len(stride))):
+            # iterate over unbound strides in sorted order
+            val_list = sorted(
+                [
+                    (ex.stride()[i], i)
+                    for i in range(len(stride))
+                    if stride[i] is None
+                ]
+            )
+            for _, i in val_list:
                 if stride[i] is None and ex.stride()[i] in candidates:
                     stride[i] = candidates[ex.stride()[i]]
                     candidates[ex.size(i) * ex.stride()[i]] = size[i] * stride[i]


### PR DESCRIPTION
Fixes one of the issues with permuted inputs in #1245. Prior to this PR, we didn't sort strides before assigning symbolic vars to them, which sometimes lead to stride ending up as independent variable whereas it should be a product of permuted sizes. Iterating over strides in sorted order should solve this. 