### PR TITLE
Fail on using the context manager

### DIFF
--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -127,7 +127,7 @@ enforce_cond_guards_match = True
 
 
 # If True, raises exception if TorchDynamo is called with a context manager
-raise_on_ctx_manager_usage = False
+raise_on_ctx_manager_usage = True
 
 
 class _AccessLimitingConfig(ModuleType):

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -105,14 +105,10 @@ class _TorchDynamoContext:
 
     def __enter__(self):
         if config.raise_on_ctx_manager_usage:
-            raise RuntimeError("TorchDynamo is used with a context manager")
-        else:
-            log.warning(
-                (
-                    "Using TorchDynamo with a context manager will be deprecated soon."
-                    "Please read https://github.com/pytorch/torchdynamo#usage-example "
-                    "to use TorchDynamo using an annotation."
-                )
+            raise RuntimeError(
+                "torchdynamo.optimize(...) is used with a context manager. "
+                "Please refer to https://github.com/pytorch/torchdynamo#usage-example "
+                "to use torchdynamo.optimize(...) as an annotation/decorator. "
             )
         self.on_enter()
         self.prior = set_eval_frame(self.callback)

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -104,15 +104,16 @@ class _TorchDynamoContext:
         patch_fn()
 
     def __enter__(self):
-        log.warning(
-            (
-                "Using TorchDynamo with a context manager will be deprecated soon."
-                "Please read https://github.com/pytorch/torchdynamo#usage-example "
-                "to use TorchDynamo using an annotation."
-            )
-        )
         if config.raise_on_ctx_manager_usage:
             raise RuntimeError("TorchDynamo is used with a context manager")
+        else:
+            log.warning(
+                (
+                    "Using TorchDynamo with a context manager will be deprecated soon."
+                    "Please read https://github.com/pytorch/torchdynamo#usage-example "
+                    "to use TorchDynamo using an annotation."
+                )
+            )
         self.on_enter()
         self.prior = set_eval_frame(self.callback)
         self.backend_ctx = self.extra_ctx_ctor()


### PR DESCRIPTION
I have removed the context manager usage in PyTorch CI - https://github.com/pytorch/pytorch/pull/85124

Internally, there are 3 files where context manager is used. And I am talking to migrate to use annotation.

With this, we can remove the context manager.