### PR TITLE
Fix inplace ops type promotion and graph outputs

### DIFF
--- a/benchmarks/microbenchmarks/operatorbench.py
+++ b/benchmarks/microbenchmarks/operatorbench.py
@@ -27,9 +27,10 @@ def compute_speedups(
             # change to assert later
             try:
                 same(actual, expected, cos_similarity=True, equal_nan=True)
-            except AssertionError:
+            except AssertionError as e:
+                print(e)
                 print(f"Accuracy check failed: {operator}")
-                print(expected[0] - actual[0])
+                print((expected[0] - actual[0]).abs().max())
 
     timings = np.zeros((repeats, len(models)), np.float64)
     for rep in range(repeats):

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -297,7 +297,7 @@ class GraphLowering(torch.fx.Interpreter):
                 try:
                     ind = self.graph_outputs.index(value_storage_box)
                     self.graph_outputs[ind] = self.graph_inputs_original[name]
-                except:
+                except Exception:
                     pass
 
         self.finalize()

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -289,10 +289,16 @@ class GraphLowering(torch.fx.Interpreter):
             assert isinstance(value, TensorBox)
             value = value.data
             assert isinstance(value, ir.StorageBox)
+            value_storage_box = value
             value = value.data
             if not isinstance(value, InputBuffer) or value.get_name() != name:
                 # one of our inputs was mutated, need to turn that into a copy
                 ir.MutationLayout.realize_into(value, self.graph_inputs_original[name])
+                try:
+                    ind = self.graph_outputs.index(value_storage_box)
+                    self.graph_outputs[ind] = self.graph_inputs_original[name]
+                except:
+                    pass
 
         self.finalize()
 

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -294,10 +294,11 @@ class GraphLowering(torch.fx.Interpreter):
             if not isinstance(value, InputBuffer) or value.get_name() != name:
                 # one of our inputs was mutated, need to turn that into a copy
                 ir.MutationLayout.realize_into(value, self.graph_inputs_original[name])
+                # replace output with mutated input
                 try:
                     ind = self.graph_outputs.index(value_storage_box)
                     self.graph_outputs[ind] = self.graph_inputs_original[name]
-                except Exception:
+                except ValueError:
                     pass
 
         self.finalize()

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -2723,12 +2723,6 @@ def mutate_to(changed, val):
         ).data
         assert isinstance(val, ir.StorageBox)
 
-    if isinstance(changed_data, ir.StorageBox):
-        # Fast path, just swing the data pointer
-        val.realize()
-        changed_data.data = val.data
-        return changed
-
     ir.MutationLayout.realize_into(val, changed_data)
     return changed
 


### PR DESCRIPTION
This fixes #1245 and causes inplace ops to return `self` rather than a copy of self, but I'm not sure if that's the correct fix
