### PR TITLE
[Bytecode Transformation] Add missing torch.set_grad_enable calls in Fx Graphs

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -516,15 +516,15 @@ class MiscTests(torchdynamo.testing.TestCase):
             return x
 
         with torch.no_grad():
-            torchdynamo.testing.standard_test(self, fn=fn1, nargs=2, expected_ops=3)
-            torchdynamo.testing.standard_test(self, fn=fn2, nargs=2, expected_ops=3)
+            torchdynamo.testing.standard_test(self, fn=fn1, nargs=2, expected_ops=5)
+            torchdynamo.testing.standard_test(self, fn=fn2, nargs=2, expected_ops=5)
             torchdynamo.testing.standard_test(self, fn=fn3, nargs=2, expected_ops=5)
             torchdynamo.testing.standard_test(self, fn=fn4, nargs=2, expected_ops=5)
         with torch.enable_grad():
             torchdynamo.testing.standard_test(self, fn=fn1, nargs=2, expected_ops=5)
             torchdynamo.testing.standard_test(self, fn=fn2, nargs=2, expected_ops=5)
-            torchdynamo.testing.standard_test(self, fn=fn3, nargs=2, expected_ops=3)
-            torchdynamo.testing.standard_test(self, fn=fn4, nargs=2, expected_ops=3)
+            torchdynamo.testing.standard_test(self, fn=fn3, nargs=2, expected_ops=5)
+            torchdynamo.testing.standard_test(self, fn=fn4, nargs=2, expected_ops=5)
 
     def test_build_tuple_unpack(self):
         def fn1(a, b, c):

--- a/test/test_subgraphs.py
+++ b/test/test_subgraphs.py
@@ -428,8 +428,7 @@ class SubGraphTests(torchdynamo.testing.TestCase):
         self._common(fn, 2, 9)
         torchdynamo.reset()
         with torch.no_grad():
-            # fewer ops (no disable grad) if already disabled
-            self._common(fn, 2, 5)
+            self._common(fn, 2, 9)
 
     def test_resume_with_no_grad2(self):
         def fn(a, b):
@@ -458,7 +457,7 @@ class SubGraphTests(torchdynamo.testing.TestCase):
             x = x + 4
             return x
 
-        self._common(fn, 2, 15)
+        self._common(fn, 2, 19)
 
     def test_resume_tuple_iterator(self):
         def fn(a, b):

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -1243,7 +1243,6 @@ class InstructionTranslatorBase(object):
         self.output.guards.add(
             GlobalWeakRefSource(name).create_guard(GuardBuilder.WEAKREF_ALIVE)
         )
-        # self.f_globals[name] = weakref.ref(value)
         if name not in self.output.root_globals:
             self.output.install_global(name, weakref.ref(value))
 

--- a/torchdynamo/symbolic_convert.py
+++ b/torchdynamo/symbolic_convert.py
@@ -604,7 +604,14 @@ class InstructionTranslatorBase(object):
         self.push(None)
 
     def END_FINALLY(self, inst):
-        assert self.pop() is None
+        tos = self.pop()
+        if sys.version_info < (3, 8):
+            # python3.7 and 3.8 can have END_FINALLY without BEGIN_FINALLY
+            assert tos is None or (
+                tos.is_python_constant() and tos.as_python_constant() is None
+            )
+        else:
+            assert tos is None
 
     def FOR_ITER(self, inst):
         it = self.pop()
@@ -1236,7 +1243,9 @@ class InstructionTranslatorBase(object):
         self.output.guards.add(
             GlobalWeakRefSource(name).create_guard(GuardBuilder.WEAKREF_ALIVE)
         )
-        self.f_globals[name] = weakref.ref(value)
+        # self.f_globals[name] = weakref.ref(value)
+        if name not in self.output.root_globals:
+            self.output.install_global(name, weakref.ref(value))
 
     @property
     def fake_mode(self):

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -277,8 +277,6 @@ class GradModeVariable(ContextWrappingVariable):
         return variables.ConstantVariable(None, **VariableTracker.propagate(self))
 
     def _call_func(self, tx, value):
-        if self.target_value == self.initial_value:
-            return
         tx.output.graph.create_node(
             "call_function", torch._C._set_grad_enabled, (value,), {}
         ),

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -262,14 +262,19 @@ class ContextWrappingVariable(ContextManagerVariable):
 
 
 class GradModeVariable(ContextWrappingVariable):
+    @staticmethod
+    def create(tx, target_value, initial_value=None, **kwargs):
+        var = GradModeVariable(target_value, initial_value, **kwargs)
+        var._call_func(tx, target_value)
+        return var
+
     def __init__(self, target_value, initial_value=None, **kwargs):
         super(GradModeVariable, self).__init__(
             target_value=target_value, initial_value=initial_value, **kwargs
         )
 
     def enter(self, tx):
-        assert self.initial_value == torch.is_grad_enabled()
-        return super(GradModeVariable, self).enter(tx)
+        return variables.ConstantVariable(None, **VariableTracker.propagate(self))
 
     def _call_func(self, tx, value):
         if self.target_value == self.initial_value:

--- a/torchdynamo/variables/torch.py
+++ b/torchdynamo/variables/torch.py
@@ -159,11 +159,11 @@ class TorchVariable(VariableTracker):
         ):
             return self._call_ntuple(tx, args, kwargs, options)
         elif self.value is torch.no_grad:
-            return GradModeVariable(False, **options)
+            return GradModeVariable.create(tx, False, **options)
         elif self.value is torch.enable_grad:
-            return GradModeVariable(True, **options)
+            return GradModeVariable.create(tx, True, **options)
         elif self.value is torch.set_grad_enabled and len(args) == 1:
-            return GradModeVariable(args[0].as_python_constant(), **options)
+            return GradModeVariable.create(tx, args[0].as_python_constant(), **options)
         elif self.value is torch.is_grad_enabled:
             assert not (args or kwargs)
             return ConstantVariable(torch.is_grad_enabled(), **options).add_guards(


### PR DESCRIPTION
On the main branch, we put set_grad_enabled calls into a ContextWrappingVariable

https://github.com/pytorch/torchdynamo/blob/41c44bc1d080d6cf063419a4166732b983b84eef/torchdynamo/variables/torch.py#L161-L166

However, `set_grad_enabled` can be called w/o context manager as well. And, the test added in this PR fails.


To do this, we explicitly call `enter` of GradModeVariable on seeing a `POP_TOP`
