### PR TITLE
[TIMM] Use pretrained models and deterministic inputs to help CI

### DIFF
--- a/benchmarks/timm_models.py
+++ b/benchmarks/timm_models.py
@@ -54,7 +54,6 @@ BATCH_SIZE_DIVISORS = {
     "densenet121": 2,
     "dla102": 2,
     "dpn107": 2,
-    "ecaresnet101d": 2,
     "eca_botnext26ts_256": 2,
     "eca_halonext26ts": 2,
     "gluon_senet154": 2,
@@ -63,11 +62,9 @@ BATCH_SIZE_DIVISORS = {
     "gmlp_s16_224": 2,
     "hrnet_w18": 64,
     "jx_nest_base": 4,
-    "legacy_senet154": 2,
     "mixer_b16_224": 2,
     "mixnet_l": 2,
     "mobilevit_s": 4,
-    "nasnetalarge": 2,
     "nfnet_l0": 2,
     "pit_b_224": 2,
     "pnasnet5large": 2,
@@ -206,6 +203,7 @@ class TimmRunnner(BenchmarkRunner):
             drop_rate=0.0,
             drop_path_rate=None,
             drop_block_rate=None,
+            pretrained=True,
             # global_pool=kwargs.pop('gp', 'fast'),
             # num_classes=kwargs.pop('num_classes', None),
             # drop_rate=kwargs.pop('drop', 0.),
@@ -232,6 +230,7 @@ class TimmRunnner(BenchmarkRunner):
         # example_inputs = torch.randn(
         #     (batch_size,) + input_size, device=device, dtype=data_dtype
         # )
+        torch.manual_seed(1337)
         input_tensor = torch.randint(
             256, size=(batch_size,) + input_size, device=device
         ).to(dtype=torch.float32)

--- a/benchmarks/timm_models_list.txt
+++ b/benchmarks/timm_models_list.txt
@@ -15,7 +15,6 @@ dm_nfnet_f0 128
 dpn107 64
 eca_botnext26ts_256 128
 eca_halonext26ts 128
-ecaresnet101d 128
 ese_vovnet19b_dw 128
 fbnetc_100 128
 fbnetv3_b 128
@@ -26,12 +25,10 @@ gluon_senet154 64
 gluon_xception65 64
 gmixer_24_224 128
 gmlp_s16_224 128
-hardcorenas_a 128
 hrnet_w18 128
 inception_v3 128
 jx_nest_base 128
 lcnet_050 128
-legacy_senet154 64
 levit_128 128
 mixer_b16_224 128
 mixnet_l 128
@@ -39,7 +36,6 @@ mnasnet_100 128
 mobilenetv2_100 128
 mobilenetv3_large_100 128
 mobilevit_s 128
-nasnetalarge 32
 nfnet_l0 128
 pit_b_224 128
 pnasnet5large 32


### PR DESCRIPTION
As title

Removed the models for which we TIMM does not have pretrained models. This will reduce flakiness in CI as we move to accuracy testing.