### PR TITLE
Lowering for upsample_bicubic2d

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -2175,6 +2175,15 @@ class CommonTemplate:
             check_lowp=False,
         )
 
+    def test_upsample_bicubic2d(self):
+        def fn(a):
+            return (
+                aten.upsample_bicubic2d(a, (128, 128), True),
+                aten.upsample_bicubic2d(a, (128, 256), False),
+            )
+
+        self.common(fn, (torch.randn([4, 3, 64, 32], dtype=torch.float32),))
+
     def test_sort(self):
         def fn(a):
             return torch.sort(a)

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -62,6 +62,7 @@ add_needs_realized_inputs(
         aten.mm,
         aten.upsample_bilinear2d,
         aten.upsample_nearest2d,
+        aten.upsample_bicubic2d,
     ]
 )
 
@@ -953,7 +954,6 @@ make_fallback(aten.sort.stable)
 make_fallback(aten.topk)
 make_fallback(aten.unfold)
 make_fallback(aten.unfold_backward)
-make_fallback(aten.upsample_bicubic2d)
 make_fallback(aten.upsample_bicubic2d_backward)
 make_fallback(aten.upsample_bilinear2d_backward)
 
@@ -1715,6 +1715,110 @@ def upsample_nearest2d(x, output_size=None, scale_factors=None):
         dtype=x.get_dtype(),
         inner_fn=fn,
         ranges=[*batch, sympy.Integer(oh), sympy.Integer(ow)],
+    )
+
+
+@register_lowering(aten.upsample_bicubic2d)
+def upsample_bicubic2d(x, output_size, align_corners, scales_h=None, scales_w=None):
+    x.realize_hint()
+    x_loader = x.make_loader()
+
+    N, C, iH, iW = x.get_size()
+    oH, oW = output_size
+
+    iH = V.graph.sizevars.guard_static_shape(iH)
+    iW = V.graph.sizevars.guard_static_shape(iW)
+
+    def compute_scale(in_size, out_size, align_corners, scale=None):
+        if align_corners:
+            return (in_size - 1) / (out_size - 1) if out_size > 1 else 0
+        else:
+            return 1 / scale if scale is not None and scale > 0 else in_size / out_size
+
+    def compute_source_index(scale, dst_index, align_corners):
+        dst_index_ie = ops.index_expr(dst_index, torch.float32)
+        if align_corners:
+            return ops.mul(scale, dst_index_ie)
+        else:
+            return ops.sub(
+                ops.mul(scale, ops.add(dst_index_ie, 0.5)), 0.5
+            )  # scale * (dst_index + 0.5) - 0.5
+
+    def cubic_convolution1(x, A):
+        # ((A + 2) * x - (A+3)) * x * x + 1
+        return ops.add(ops.mul(ops.mul(ops.sub(ops.mul(A + 2, x), A + 3), x), x), 1.0)
+
+    def cubic_convolution2(x, A):
+        # ((A * x - 5 * A) * x + 8 * A) * x - 4*A
+        return ops.sub(
+            ops.mul(ops.add(ops.mul(ops.sub(ops.mul(A, x), 5 * A), x), 8 * A), x), 4 * A
+        )
+
+    def get_cubic_upsample_coefficients(t):
+        A = -0.75
+        c0 = cubic_convolution2(ops.add(t, 1.0), A)
+        c1 = cubic_convolution1(t, A)
+
+        x2 = ops.sub(1.0, t)
+        c2 = cubic_convolution1(x2, A)
+        c3 = cubic_convolution2(ops.add(x2, 1.0), A)
+        return (
+            c0,
+            c1,
+            c2,
+            c3,
+        )
+
+    def cubic_interp1d(xs, t):
+        cs = get_cubic_upsample_coefficients(t)
+        # dot product between xs and cs
+        return ops.add(
+            ops.mul(xs[0], cs[0]),
+            ops.add(
+                ops.mul(xs[1], cs[1]),
+                ops.add(ops.mul(xs[2], cs[2]), ops.mul(xs[3], cs[3])),
+            ),
+        )
+
+    height_scale = compute_scale(iH, oH, align_corners, scales_h)
+    width_scale = compute_scale(iW, oW, align_corners, scales_h)
+
+    def clamp(v, min, max):
+        return ops.maximum(min, ops.minimum(max, v))
+
+    def fn(idx):
+        n, c, oy, ox = idx
+
+        real_x = compute_source_index(width_scale, ox, align_corners)
+        in_x = ops.floor(real_x)
+        t_x = ops.sub(real_x, in_x)
+
+        real_y = compute_source_index(height_scale, oy, align_corners)
+        in_y = ops.floor(real_y)
+        t_y = ops.sub(real_y, in_y)
+
+        def load_bounded(fy, fx):
+            iy = ops.indirect_indexing(clamp(fy, 0, iH - 1))
+            ix = ops.indirect_indexing(clamp(fx, 0, iW - 1))
+            return x_loader([n, c, iy, ix])
+
+        iy = ops.to_dtype(in_y, torch.int32)
+        ix = ops.to_dtype(in_x, torch.int32)
+        iys_ofs = tuple((ops.add(iy, ofs) for ofs in (-1, 0, 1, 2)))
+        ixs_ofs = tuple((ops.add(ix, ofs) for ofs in (-1, 0, 1, 2)))
+
+        def get_x_interp(y):
+            coeffs_x = tuple((load_bounded(y, x) for x in ixs_ofs))
+            return cubic_interp1d(coeffs_x, t_x)
+
+        coeffs_y = tuple(get_x_interp(y) for y in iys_ofs)
+        return cubic_interp1d(coeffs_y, t_y)
+
+    return Pointwise.create(
+        device=x.get_device(),
+        dtype=x.get_dtype(),
+        inner_fn=fn,
+        ranges=[N, C, sympy.Integer(oH), sympy.Integer(oW)],
     )
 
 


### PR DESCRIPTION
Added a lowering for upsample_bicubic2d. 

Currently performance is about 40% worse than eager.
Not sure why this is happening, would appreciate suggestions on how to address it @Chillee @ezyang @jansel @Lezcano 

<details><summary>Benchmarks</summary>

```
[------------------------------ upsample_bicubic2d ------------------------------]
                                                             |  Inductor  |  Eager
32 threads: ----------------------------------------------------------------------
      (torch.Size([16, 4, 128, 256]),), ((64, 128), True)    |     140    |   130
      (torch.Size([16, 4, 128, 256]),), ((64, 128), False)   |     141    |   130
      (torch.Size([16, 4, 128, 256]),), ((128, 256), True)   |     226    |   170
      (torch.Size([16, 4, 128, 256]),), ((128, 256), False)  |     224    |   169
      (torch.Size([16, 4, 128, 256]),), ((384, 768), True)   |    1100    |   804
      (torch.Size([16, 4, 128, 256]),), ((384, 768), False)  |    1100    |   803
```
</details>

<details><summary>The generated triton looks reasonable to me</summary>

```python
kernel0 = TritonCodeCache.load('''
import triton
import triton.language as tl
from torchinductor.triton_ops.autotune import pointwise_heuristics

@pointwise_heuristics(size_hints=[524288], filename=__file__)
@triton.jit
def kernel(in_ptr0, out_ptr0, xnumel, XBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK])
    xmask = xindex < xnumel
    x0 = xindex % 128
    x1 = (xindex // 128) % 64
    x2 = (xindex // 8192)
    x4 = xindex
    tmp0 = x0
    tmp1 = 2.0078740157480315 * tmp0
    tmp2 = tl.libdevice.floor(tmp1)
    tmp3 = tmp1 - tmp2
    tmp4 = x1
    tmp5 = 2.015873015873016 * tmp4
    tmp6 = tl.libdevice.floor(tmp5)
    tmp7 = tmp5 - tmp6
    tmp8 = tmp6.to(tl.int32)
    tmp9 = tmp2.to(tl.int32)
    tmp10 = tmp8 + -1
    tmp11 = tmp8 + 0
    tmp12 = tmp8 + 1
    tmp13 = tmp8 + 2
    tmp14 = tmp9 + -1
    tmp15 = tmp9 + 0
    tmp16 = tmp9 + 1
    tmp17 = tmp9 + 2
    tmp18 = tl.minimum(127, tmp10)
    tmp19 = tl.maximum(0, tmp18)
    tmp20 = tl.minimum(255, tmp14)
    tmp21 = tl.maximum(0, tmp20)
    tmp22 = tl.load(in_ptr0 + tmp21 + (256*tmp19) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp23 = tl.minimum(255, tmp15)
    tmp24 = tl.maximum(0, tmp23)
    tmp25 = tl.load(in_ptr0 + tmp24 + (256*tmp19) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp26 = tl.minimum(255, tmp16)
    tmp27 = tl.maximum(0, tmp26)
    tmp28 = tl.load(in_ptr0 + tmp27 + (256*tmp19) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp29 = tl.minimum(255, tmp17)
    tmp30 = tl.maximum(0, tmp29)
    tmp31 = tl.load(in_ptr0 + tmp30 + (256*tmp19) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp32 = tmp3 + 1.0
    tmp33 = -0.75 * tmp32
    tmp34 = tmp33 - -3.75
    tmp35 = tmp34 * tmp32
    tmp36 = tmp35 + -6.0
    tmp37 = tmp36 * tmp32
    tmp38 = tmp37 - -3.0
    tmp39 = 1.25 * tmp3
    tmp40 = tmp39 - 2.25
    tmp41 = tmp40 * tmp3
    tmp42 = tmp41 * tmp3
    tmp43 = tmp42 + 1.0
    tmp44 = 1.0 - tmp3
    tmp45 = 1.25 * tmp44
    tmp46 = tmp45 - 2.25
    tmp47 = tmp46 * tmp44
    tmp48 = tmp47 * tmp44
    tmp49 = tmp48 + 1.0
    tmp50 = tmp44 + 1.0
    tmp51 = -0.75 * tmp50
    tmp52 = tmp51 - -3.75
    tmp53 = tmp52 * tmp50
    tmp54 = tmp53 + -6.0
    tmp55 = tmp54 * tmp50
    tmp56 = tmp55 - -3.0
    tmp57 = tmp22 * tmp38
    tmp58 = tmp25 * tmp43
    tmp59 = tmp28 * tmp49
    tmp60 = tmp31 * tmp56
    tmp61 = tmp59 + tmp60
    tmp62 = tmp58 + tmp61
    tmp63 = tmp57 + tmp62
    tmp64 = tl.minimum(127, tmp11)
    tmp65 = tl.maximum(0, tmp64)
    tmp66 = tl.load(in_ptr0 + tmp21 + (256*tmp65) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp67 = tl.load(in_ptr0 + tmp24 + (256*tmp65) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp68 = tl.load(in_ptr0 + tmp27 + (256*tmp65) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp69 = tl.load(in_ptr0 + tmp30 + (256*tmp65) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp70 = tmp66 * tmp38
    tmp71 = tmp67 * tmp43
    tmp72 = tmp68 * tmp49
    tmp73 = tmp69 * tmp56
    tmp74 = tmp72 + tmp73
    tmp75 = tmp71 + tmp74
    tmp76 = tmp70 + tmp75
    tmp77 = tl.minimum(127, tmp12)
    tmp78 = tl.maximum(0, tmp77)
    tmp79 = tl.load(in_ptr0 + tmp21 + (256*tmp78) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp80 = tl.load(in_ptr0 + tmp24 + (256*tmp78) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp81 = tl.load(in_ptr0 + tmp27 + (256*tmp78) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp82 = tl.load(in_ptr0 + tmp30 + (256*tmp78) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp83 = tmp79 * tmp38
    tmp84 = tmp80 * tmp43
    tmp85 = tmp81 * tmp49
    tmp86 = tmp82 * tmp56
    tmp87 = tmp85 + tmp86
    tmp88 = tmp84 + tmp87
    tmp89 = tmp83 + tmp88
    tmp90 = tl.minimum(127, tmp13)
    tmp91 = tl.maximum(0, tmp90)
    tmp92 = tl.load(in_ptr0 + tmp21 + (256*tmp91) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp93 = tl.load(in_ptr0 + tmp24 + (256*tmp91) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp94 = tl.load(in_ptr0 + tmp27 + (256*tmp91) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp95 = tl.load(in_ptr0 + tmp30 + (256*tmp91) + (32768*x2) + tl.zeros([XBLOCK], tl.int32), xmask)
    tmp96 = tmp92 * tmp38
    tmp97 = tmp93 * tmp43
    tmp98 = tmp94 * tmp49
    tmp99 = tmp95 * tmp56
    tmp100 = tmp98 + tmp99
    tmp101 = tmp97 + tmp100
    tmp102 = tmp96 + tmp101
    tmp103 = tmp7 + 1.0
    tmp104 = -0.75 * tmp103
    tmp105 = tmp104 - -3.75
    tmp106 = tmp105 * tmp103
    tmp107 = tmp106 + -6.0
    tmp108 = tmp107 * tmp103
    tmp109 = tmp108 - -3.0
    tmp110 = 1.25 * tmp7
    tmp111 = tmp110 - 2.25
    tmp112 = tmp111 * tmp7
    tmp113 = tmp112 * tmp7
    tmp114 = tmp113 + 1.0
    tmp115 = 1.0 - tmp7
    tmp116 = 1.25 * tmp115
    tmp117 = tmp116 - 2.25
    tmp118 = tmp117 * tmp115
    tmp119 = tmp118 * tmp115
    tmp120 = tmp119 + 1.0
    tmp121 = tmp115 + 1.0
    tmp122 = -0.75 * tmp121
    tmp123 = tmp122 - -3.75
    tmp124 = tmp123 * tmp121
    tmp125 = tmp124 + -6.0
    tmp126 = tmp125 * tmp121
    tmp127 = tmp126 - -3.0
    tmp128 = tmp63 * tmp109
    tmp129 = tmp76 * tmp114
    tmp130 = tmp89 * tmp120
    tmp131 = tmp102 * tmp127
    tmp132 = tmp130 + tmp131
    tmp133 = tmp129 + tmp132
    tmp134 = tmp128 + tmp133
    tl.store(out_ptr0 + x4 + tl.zeros([XBLOCK], tl.int32), tmp134, xmask)
''').kernel

def call(arg0_1):
    arg0_1_size = arg0_1.size()
    s0 = arg0_1_size[0]
    s1 = arg0_1_size[1]
    s2 = arg0_1_size[2]
    s3 = arg0_1_size[3]
    buf0 = empty_strided((s0, s1, 64, 128), (8192*s1, 8192, 128, 1), device='cuda', dtype=torch.float32)
    kernel0_xnumel = 8192*s0*s1
    kernel0[grid(kernel0_xnumel)](arg0_1, buf0, kernel0_xnumel)
    return (buf0, )
```

</details>

<details><summary>Code used for benchmarking</summary>

```python
import torch
from torch.fx.experimental.proxy_tensor import make_fx
from torch.utils.benchmark import Timer, Compare
import torchinductor
from torchinductor.compile_fx import compile_fx_inner, cudagraphify
from torchinductor.decomposition import decompositions
from itertools import product
from functools import partial
import sys


batch_size = (16, 4)
sizes =  ((128, 256),)
#((8,2), (2,8), (16, 32), (32,16), (73, 198), (198,74))
# (8,2), (8,3), (8,4), (8,5),) #(64, 128), (256, 256),)
scales = ( 0.5, 1, 3 )
options = (True, False)

test_func = torch.ops.aten.upsample_bicubic2d
benchmark_name = test_func.__name__

def gen_inputs():
    make_arg = partial(torch.randn, dtype=torch.float32, device="cuda")
    for (iH, iW), scale, option in product(sizes, scales, options):
        oH = int(scale*iH)
        oW = int(scale*iW)
        t_args = (make_arg( (*batch_size, iH, iW)), )
        nont_args = ( (oH, oW,), option)
        yield t_args, nont_args

def adapt_func(f, nont_args):
    def f_adapted(*t_args):
        val = f(*(t_args+nont_args))
        return (val,)
    return f_adapted

def make_nondecomposed(f, t_args, nont_args):
    f_adapted = adapt_func(f, nont_args)
    non_decomposed = make_fx(f_adapted, tracing_mode="fake")(*t_args)
    compiled_non_decomposed = compile_fx_inner(non_decomposed, t_args)
    return compiled_non_decomposed

def make_decomposed(f, t_args, nont_args):
    f_adapted = adapt_func(f, nont_args)
    decomposed = make_fx(f_adapted, decomposition_table=decompositions, tracing_mode="fake")(*t_args)
    compiled_decomposed = compile_fx_inner(decomposed, t_args)
    return compiled_decomposed

def make_eager(f, t_args, nont_args):
    f_adapted = adapt_func(f, nont_args)
    return cudagraphify(f_adapted, t_args)

def benchmark(label, sublabel, f, args):
    return Timer("f(*args)",
                 globals={"f": f, "args": args},
                 label=benchmark_name,
                 description=label,
                 sub_label=sublabel,
                 num_threads=torch.get_num_threads()).blocked_autorange()


def compare_func(test_func, t_args, nont_args):
    sublabel = f"{tuple(arg.shape for arg in t_args)}"
    if nont_args: sublabel += f", {nont_args}"
    print(sublabel)

    yield benchmark("Inductor", sublabel, make_decomposed(test_func, t_args, nont_args), t_args)

    yield benchmark("Eager", sublabel, make_eager(test_func, t_args, nont_args), t_args)


def run_benchmarks():
    results = []
    for t_args, nont_args in gen_inputs():
        for res in compare_func(test_func, t_args, nont_args):
            results.append(res)

    compare = Compare(results)
    compare.trim_significant_figures()
    compare.print()

def check_equality():
    for t_args, nont_args in gen_inputs():
        f_eager = make_eager(test_func, t_args, nont_args)
        f_inductor = make_decomposed(test_func, t_args, nont_args)
        result_eager = f_eager(*t_args)[0]
        result_inductor = f_inductor(*t_args)[0]

        if not torch.allclose(result_eager, result_inductor, atol=1e-4, rtol=10):
            print(f"ERROR Mismatch for t_args={t_args[0].shape}, non_targs={nont_args}!")
            diff = result_eager - result_inductor
            max_abs = diff.abs().max().item()
            print(f"Max abs difference: {max_abs}")
            max_rel = (diff.abs()/torch.maximum(result_eager.abs(), result_inductor.abs())).max().item()
            print(f"Max rel difference: {max_rel}")
            print(f"Input tensors: {t_args}")
            print(f"Eager returned\n{result_eager[0]}\n")
            print(f"Inductor returned\n{result_inductor[0]}\n\n")
            print(f"Difference\n{diff}\n\n")
        else:
            print(f"OK {t_args[0].shape} {nont_args}")


if __name__ == '__main__':
    torchinductor.config.debug = True
    t_args, nont_args = next(gen_inputs())
    fi = make_decomposed(test_func, t_args, nont_args)
    torchinductor.config.debug = False
    check_equality()
    run_benchmarks()
```

</details>