### PR TITLE
Use pinned Triton commit in build-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PIP ?= python -m pip
 
 # versions used in CI
 PYTORCH_VERSION ?= dev20220916
-TRITON_VERSION ?= 5b04331dd2efdd23f4475823761fa975de60a514
+TRITON_VERSION ?= 889d9e34a114b1fe2e8871d21e713794344d12d3
 
 
 default: develop
@@ -87,7 +87,7 @@ pull-deps:
 	(cd ../torchaudio     && git pull && git submodule update --init --recursive)
 	(cd ../detectron2     && git pull && git submodule update --init --recursive)
 	(cd ../torchbenchmark && git pull && git submodule update --init --recursive)
-	(cd ../triton         && git pull && git submodule update --init --recursive)
+	(cd ../triton         && git checkout master && git pull && git checkout $(TRITON_VERSION) && git submodule update --init --recursive)
 
 build-deps: clone-deps
 	# conda env remove --name torchdynamo


### PR DESCRIPTION
@jansel Is this ok? Atleast I use `make build-deps` frequently to setup my dev environment. And given recent Triton changes, we get lots of triton missing code_gen issues.

This would fix nightly as well. 

 