### PR TITLE
Release the memory hold by correct_rerun_result

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -1184,6 +1184,7 @@ class BenchmarkRunner:
             ):
                 accuracy_status = "eager_variation"
                 return record_status(accuracy_status)
+            correct_rerun_result = None
 
             # Run with Dynamo
             reset_rng_state()


### PR DESCRIPTION
Summary:  Release the memory hold by correct_rerun_result after its corresponding accuracy checking is done