### PR TITLE
Moving 0 dim CPU tensor to GPU to make unspec works well on cudagraph

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -3427,16 +3427,16 @@ class CommonTemplate:
         out = compiled(torch.randn(12, 4, device=self.device))
         self.assertEqual(out[0].shape, (24, 2))
 
+    @patch.object(config.triton, "cudagraphs", True)
     def test_unspec_variable(self):
-        # dynamo wraps unspec variable as 1-element tensor on CPU
         def fn(x, y):
             return x + y
 
-        check_model(
-            self,
-            fn,
-            (torch.randn([2, 3], device=self.device), torch.tensor(10, device="cpu")),
+        inputs = (
+            rand_strided((2, 3), (3, 1), device="cuda"),
+            rand_strided((), (), device="cpu"),
         )
+        self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))
 
 
 if HAS_CPU:

--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -3435,7 +3435,7 @@ class CommonTemplate:
         check_model(
             self,
             fn,
-            (torch.randn([2, 3], device = self.device), torch.tensor(10, device = "cpu"))
+            (torch.randn([2, 3], device=self.device), torch.tensor(10, device="cpu")),
         )
 
 

--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -3427,6 +3427,17 @@ class CommonTemplate:
         out = compiled(torch.randn(12, 4, device=self.device))
         self.assertEqual(out[0].shape, (24, 2))
 
+    def test_unspec_variable(self):
+        # dynamo wraps unspec variable as 1-element tensor on CPU
+        def fn(x, y):
+            return x + y
+
+        check_model(
+            self,
+            fn,
+            (torch.randn([2, 3], device = self.device), torch.tensor(10, device = "cpu"))
+        )
+
 
 if HAS_CPU:
 

--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -3428,8 +3428,20 @@ class CommonTemplate:
         self.assertEqual(out[0].shape, (24, 2))
 
     @requires_cuda()
+    @patch.object(config.triton, "cudagraphs", False)
+    def test_unspec_inputs(self):
+        def fn(x, y):
+            return x + y
+
+        inputs = (
+            rand_strided((2, 3), (3, 1), device="cuda"),
+            rand_strided((), (), device="cpu"),
+        )
+        self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))
+
+    @requires_cuda()
     @patch.object(config.triton, "cudagraphs", True)
-    def test_unspec_variable(self):
+    def test_unspec_inputs_cudagraphs(self):
         def fn(x, y):
             return x + y
 

--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -3427,6 +3427,7 @@ class CommonTemplate:
         out = compiled(torch.randn(12, 4, device=self.device))
         self.assertEqual(out[0].shape, (24, 2))
 
+    @requires_cuda()
     @patch.object(config.triton, "cudagraphs", True)
     def test_unspec_variable(self):
         def fn(x, y):

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -1037,7 +1037,6 @@ class TritonKernel(Kernel):
 
     def call_kernel(self, code, name: str):
         _, call_args, _ = self.args.python_argdefs()
-
         grid = []
         # TODO(jansel): if there are constants, we shouldn't bother passing them as args
         for tree in self.range_trees:

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -1037,10 +1037,6 @@ class TritonKernel(Kernel):
 
     def call_kernel(self, code, name: str):
         _, call_args, _ = self.args.python_argdefs()
-        # dynamo wraps unspec variable as 1-element tensor on CPU, need to convert to scalar
-        for i in range(len(call_args)):
-            if V.graph.is_unspec_arg(call_args[i]):
-                call_args[i] = call_args[i] + ".item()"
 
         grid = []
         # TODO(jansel): if there are constants, we shouldn't bother passing them as args

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -766,11 +766,7 @@ class TritonKernel(Kernel):
         else:
             ep = ""
 
-        if (
-            name in V.graph.graph_inputs.keys()
-            and V.graph.graph_inputs[name].get_numel() == 1
-            and V.graph.graph_inputs[name].get_device().type == "cpu"
-        ):
+        if V.graph.is_unspec_arg(name):
             line = var
         else:
             line = f"tl.load({var} + {index}, {mask}{ep})"
@@ -1048,12 +1044,7 @@ class TritonKernel(Kernel):
         _, call_args, _ = self.args.python_argdefs()
         # dynamo wraps unspec variable as 1-element tensor on CPU, need to convert to scalar
         for i in range(len(call_args)):
-            x = call_args[i]
-            if (
-                x in V.graph.graph_inputs.keys()
-                and V.graph.graph_inputs[x].get_numel() == 1
-                and V.graph.graph_inputs[x].get_device().type == "cpu"
-            ):
+            if V.graph.is_unspec_arg(call_args[i]):
                 call_args[i] = call_args[i] + ".item()"
 
         grid = []

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -765,12 +765,7 @@ class TritonKernel(Kernel):
             ep = ", eviction_policy='evict_last'"
         else:
             ep = ""
-
-        if V.graph.is_unspec_arg(name):
-            line = var
-        else:
-            line = f"tl.load({var} + {index}, {mask}{ep})"
-
+        line = f"tl.load({var} + {index}, {mask}{ep})"
         if V.graph.get_dtype(name) in (torch.float16, torch.bfloat16):
             line += ".to(tl.float32)"
 

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -190,6 +190,7 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
         return torch.as_strided(buffer, x.size(), x.stride())
 
     assert isinstance(inputs, (list, tuple))
+    # dynamo wraps unspec variable as 0 dim tensor on CPU, need to move to GPU explicitly
     inputs = [
         x.to("cuda") if x.device.type == "cpu" and x.dim() == 0 else x for x in inputs
     ]

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -233,7 +233,6 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
             for idx, (dst, src, expanded_dims) in enumerate(
                 zip(static_inputs, new_inputs, inps_expanded_dims)
             ):
-                # breakpoint()
                 if idx in static_input_idxs:
                     assert dst.data_ptr() == src.data_ptr()
                 else:

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -195,14 +195,10 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
         x.to("cuda") if x.device.type == "cpu" and x.dim() == 0 else x for x in inputs
     ]
 
-    static_inputs = []
-    for idx, x in enumerate(inputs):
-        if idx not in static_input_idxs:
-            static_inputs.append(static_input(x))
-        elif x.device.type == "cpu" and x.dim() == 0:
-            static_inputs.append(x.to("cuda"))
-        else:
-            static_inputs.append(inputs[idx])
+    static_inputs = [
+        static_input(x) if idx not in static_input_idxs else x
+        for idx, x in enumerate(inputs)
+    ]
 
     inps_expanded_dims = [
         get_expanded_dims(x) if idx not in static_input_idxs else []

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -191,7 +191,7 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
 
     assert isinstance(inputs, (list, tuple))
     inputs = [
-        x.to("cuda") if x.dim() == 0 else x for x in inputs
+        x.to("cuda") if x.device.type == "cpu" and x.dim() == 0 else x for x in inputs
     ]
 
     static_inputs = []

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -357,6 +357,8 @@ class GraphLowering(torch.fx.Interpreter):
         ]
 
     def is_unspec_arg(self, name):
+        # dynamo wraps unspec variable as 1-element tensor on CPU,
+        # need to convert to scalar during codegen (triton only)
         return (
             name in self.graph_inputs.keys()
             and self.graph_inputs[name].get_numel() == 1

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -355,3 +355,10 @@ class GraphLowering(torch.fx.Interpreter):
             for node in self.graph_outputs
             if not isinstance(node, ir.NoneAsConstantBuffer)
         ]
+
+    def is_unspec_arg(self, name):
+        return (
+            name in self.graph_inputs.keys()
+            and self.graph_inputs[name].get_numel() == 1
+            and self.graph_inputs[name].get_device().type == "cpu"
+        )

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -225,7 +225,8 @@ class GraphLowering(torch.fx.Interpreter):
         )
         self.graph_inputs[target] = tensor
         self.graph_inputs_original[target] = tensor.data.data
-        self.device_types.add(example.device.type)
+        if example.dim() != 0:
+            self.device_types.add(example.device.type)
         return tensor
 
     def call_function(self, target, args, kwargs):
@@ -355,12 +356,3 @@ class GraphLowering(torch.fx.Interpreter):
             for node in self.graph_outputs
             if not isinstance(node, ir.NoneAsConstantBuffer)
         ]
-
-    def is_unspec_arg(self, name):
-        # dynamo wraps unspec variable as 1-element tensor on CPU,
-        # need to convert to scalar during codegen (triton only)
-        return (
-            name in self.graph_inputs.keys()
-            and self.graph_inputs[name].get_numel() == 1
-            and self.graph_inputs[name].get_device().type == "cpu"
-        )


### PR DESCRIPTION
TorchDynamo wraps unspec variable as 1-element tensor on CPU. It caused error when ops with tensor on GPU. This PR converts the 1-element CPU tensor to scalar during triton codegen.

Fix #1176