### PR TITLE
GradModeVariable should guard on the initial grad state

### DIFF
--- a/torchdynamo/convert_frame.py
+++ b/torchdynamo/convert_frame.py
@@ -72,6 +72,9 @@ input_codes = Tracker()
 output_codes = Tracker()
 
 
+initial_grad_state = None
+
+
 @functools.wraps(original_forward_from_src)
 def fx_forward_from_src_skip_result(*args, **kwargs):
     # we monkey patch FX to prevent infinite loop of trying to convert
@@ -315,6 +318,9 @@ def convert_frame_assert(
 
         if not has_tensor_in_frame(frame):
             return None
+
+        global initial_grad_state
+        initial_grad_state = torch.is_grad_enabled()
 
         return _compile(
             frame.f_code,

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -53,6 +53,7 @@ null_context = contextlib.nullcontext
 unset = object()
 compile_lock = threading.RLock()
 most_recent_backend = None
+initial_grad_state = None
 
 
 def remove_from_cache(f):
@@ -190,6 +191,8 @@ class OptimizeContext(_TorchDynamoContext):
     def __init__(self, callback, backend_ctx_ctor):
         def on_enter():
             global most_recent_backend
+            global initial_grad_state
+            initial_grad_state = torch.is_grad_enabled()
             if (
                 most_recent_backend is not None
                 and most_recent_backend is not compiler_fn

--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -53,7 +53,6 @@ null_context = contextlib.nullcontext
 unset = object()
 compile_lock = threading.RLock()
 most_recent_backend = None
-initial_grad_state = None
 
 
 def remove_from_cache(f):
@@ -191,8 +190,6 @@ class OptimizeContext(_TorchDynamoContext):
     def __init__(self, callback, backend_ctx_ctor):
         def on_enter():
             global most_recent_backend
-            global initial_grad_state
-            initial_grad_state = torch.is_grad_enabled()
             if (
                 most_recent_backend is not None
                 and most_recent_backend is not compiler_fn

--- a/torchdynamo/guards.py
+++ b/torchdynamo/guards.py
@@ -20,6 +20,8 @@ from typing import Set
 import numpy as np
 import torch
 
+from torchdynamo import eval_frame
+
 from . import config
 from . import mutation_guard
 from ._guards import TensorGuards
@@ -36,7 +38,6 @@ from .utils import orig_code_map
 from .utils import rename_implicit
 from .utils import tuple_iterator_getitem
 from .utils import tuple_iterator_len
-from torchdynamo import eval_frame
 
 log = logging.getLogger(__name__)
 

--- a/torchdynamo/guards.py
+++ b/torchdynamo/guards.py
@@ -20,7 +20,7 @@ from typing import Set
 import numpy as np
 import torch
 
-from torchdynamo import eval_frame
+from torchdynamo import convert_frame
 
 from . import config
 from . import mutation_guard
@@ -410,7 +410,7 @@ class GuardBuilder:
         assert guard.name == ""
         assert guard.source is GuardSource.GLOBAL
         code = None
-        if eval_frame.initial_grad_state:
+        if convert_frame.initial_grad_state:
             code = "___is_grad_enabled()"
         else:
             code = "not ___is_grad_enabled()"

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -105,11 +105,7 @@ class NewGlobalVariable(VariableTracker):
         super(NewGlobalVariable, self).__init__(**kwargs)
 
 
-class ContextManagerVariable(VariableTracker):
-    pass
-
-
-class ContextWrappingVariable(ContextManagerVariable):
+class ContextWrappingVariable(VariableTracker):
     def __init__(self, target_values, initial_values=None, **kwargs):
         super(ContextWrappingVariable, self).__init__(**kwargs)
         self.target_values = target_values

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -110,12 +110,10 @@ class ContextManagerVariable(VariableTracker):
 
 
 class ContextWrappingVariable(ContextManagerVariable):
-    def __init__(self, target_value, initial_value=None, **kwargs):
+    def __init__(self, target_values, initial_values=None, **kwargs):
         super(ContextWrappingVariable, self).__init__(**kwargs)
-        self.target_value = target_value
-        if initial_value is None:
-            initial_value = self._initial_value()
-        self.initial_value = initial_value
+        self.target_values = target_values
+        self.initial_values = initial_values
 
     def enter(self, tx):
         self._call_func(tx, self.target_values)


### PR DESCRIPTION
This bug was found when I run training loss benchmark, where ```GRAD_MODE``` guard keeps failing and hits cache limit.

```GradModeVariable``` has a singleton guard on the grad state, but the state was decided when ```GuardBuilder.GRAD_MODE``` was called. It was after the code object transformation, where the grad state may be changed. 

The fix is to use the grad state at the entry of the frame execution.