### PR TITLE
Add a upload_tar functionality for inductor debug trace

### DIFF
--- a/torchdynamo/debug_utils.py
+++ b/torchdynamo/debug_utils.py
@@ -169,7 +169,7 @@ COMPILER_REPRO_OPTIONS = {
 
 
 def dump_compiler_graph_state(gm, args, compiler_name):
-    subdir = f"{minifier_dir()}/checkpoints"
+    subdir = os.path.join(minifier_dir(), "checkpoints")
     if not os.path.exists(subdir):
         os.makedirs(subdir, exist_ok=True)
     file_name = os.path.join(subdir, f"{len(gm.graph.nodes)}.py")
@@ -449,7 +449,7 @@ def dump_backend_repro_as_file(gm, args, compiler_name):
     """
     Saves the repro to a repro.py file
     """
-    subdir = f"{minifier_dir()}/checkpoints"
+    subdir = os.path.join(minifier_dir(), "checkpoints")
     if not os.path.exists(subdir):
         os.makedirs(subdir, exist_ok=True)
     file_name = os.path.join(subdir, f"{len(gm.graph.nodes)}.py")
@@ -473,7 +473,7 @@ def dump_backend_repro_as_tarfile(gm, args, compiler_name):
     """
     import tarfile
 
-    subdir = f"{minifier_dir()}/checkpoints"
+    subdir = os.path.join(minifier_dir(), "checkpoints")
     if not os.path.exists(subdir):
         os.makedirs(subdir, exist_ok=True)
 

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -129,3 +129,7 @@ class trace:
 
     # Store cProfile (see snakeviz to view)
     compile_profile = False
+
+    # Upload the .tar.gz file
+    # Needs to be overriden based on specific environment needs
+    upload_tar = None

--- a/torchinductor/debug.py
+++ b/torchinductor/debug.py
@@ -216,6 +216,18 @@ class DebugContext:
     def filename(self, suffix):
         return os.path.join(self._path, suffix)
 
+    def upload_tar(self):
+        if config.trace.upload_tar is not None:
+            import tarfile
+
+            assert self._path
+            tar_file = os.path.join(
+                self._path, f"{os.path.basename(self._path)}.tar.gz"
+            )
+            with tarfile.open(tar_file, "w:gz") as tar:
+                tar.add(self._path, arcname=os.path.basename(self._path))
+            config.trace.upload_tar(tar_file)
+
     def __enter__(self):
         log = logging.getLogger("torchinductor")
         if not log.handlers:
@@ -257,6 +269,7 @@ class DebugContext:
             self._save_profile_data()
 
         if self._path:
+            self.upload_tar()
             log.warning("%s debug trace: %s", get_graph_being_compiled(), self._path)
         self._stack.close()
 


### PR DESCRIPTION
Summary: Provide an interface for user to upload generated debugging files

Test Plan:
Define torchinductor.config.trace.upload_tar as
torchinductor.config.trace.upload_tar = lambda x : print(f"UPLOADING {x}") , and test with TORCHINDUCTOR_TRACE=1