### PR TITLE
[Triton] Update `triton.codegen` in autotune

### DIFF
--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -25,7 +25,7 @@ from .conv_perf_model import estimate_conv_time
 log = logging.getLogger(__name__)
 
 
-class CachingAutotuner(triton.code_gen.Autotuner):
+class CachingAutotuner(triton.runtime.autotuner.Autotuner):
     """
     Simplified version of Triton autotuner that has no invalidation key
     and caches the best config to disk.


### PR DESCRIPTION
`triton.code_gen` has been split into triton.compiler and triton.runtime. Related issue: https://github.com/openai/triton/issues/690