### PR TITLE
Fix AutogradProfilerContextWrapperVariable missing one positional argument error

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1316,6 +1316,7 @@ class MiscTests(torchdynamo.testing.TestCase):
         opt_fn = torchdynamo.optimize(cnts)(fn)
         res = opt_fn(x)
         self.assertTrue(same(ref, res))
+        self.assertEqual(cnts.frame_count, 2)
 
     def test_python_slice(self):
         def f1(input):

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -358,8 +358,10 @@ class AutocastModeVariable(ContextWrappingVariable):
 
 
 class AutogradProfilerContextWrapperVariable(ContextWrappingVariable):
-    def __init__(self, **kwargs):
-        super(AutogradProfilerContextWrapperVariable, self).__init__(**kwargs)
+    def __init__(self, target_values=None, **kwargs):
+        super(AutogradProfilerContextWrapperVariable, self).__init__(
+            target_values=target_values, **kwargs
+        )
 
     def enter(self, tx):
         return variables.ConstantVariable(None, **VariableTracker.propagate(self))


### PR DESCRIPTION
Error
```
Traceback (most recent call last):
  File "/scratch/ybliang/work/repos/torchdynamo/torchdynamo/convert_frame.py", line 313, in _convert_frame_assert
    code = transform_code_object(frame.f_code, transform)
  File "/scratch/ybliang/work/repos/torchdynamo/torchdynamo/bytecode_transformation.py", line 338, in transform_code_object
    transformations(instructions, code_options)
  File "/scratch/ybliang/work/repos/torchdynamo/torchdynamo/convert_frame.py", line 301, in transform
    tracer.run()
  File "/scratch/ybliang/work/repos/torchdynamo/torchdynamo/symbolic_convert.py", line 338, in run
    and self.step()
  File "/scratch/ybliang/work/repos/torchdynamo/torchdynamo/symbolic_convert.py", line 311, in step
    getattr(self, inst.opname)(inst)
  File "/scratch/ybliang/work/repos/torchdynamo/torchdynamo/symbolic_convert.py", line 162, in wrapper
    return inner_fn(self, inst)
  File "/scratch/ybliang/work/repos/torchdynamo/torchdynamo/symbolic_convert.py", line 713, in CALL_FUNCTION
    self.call_function(fn, args, {})
  File "/scratch/ybliang/work/repos/torchdynamo/torchdynamo/symbolic_convert.py", line 248, in call_function
    self.push(fn.call_function(self, args, kwargs))
  File "/scratch/ybliang/work/repos/torchdynamo/torchdynamo/variables/torch.py", line 218, in call_function
    return AutogradProfilerContextWrapperVariable(**options)
  File "/scratch/ybliang/work/repos/torchdynamo/torchdynamo/variables/misc.py", line 362, in __init__
    super(AutogradProfilerContextWrapperVariable, self).__init__(**kwargs)
TypeError: __init__() missing 1 required positional argument: 'target_values'
```

I think this is because of #1289 which removing ```ContextManagerVariable```, and the unit test missing frame count check. cc @voznesenskym 