### PR TITLE
Fix torch.zeros error: inner() got an unexpected keyword argument 'names'

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -1916,6 +1916,7 @@ class CommonTemplate:
                     dtype=torch.float32,
                     device=a.device,
                 ),
+                torch.zeros(2, 3, names=None),
                 a + torch.ones(8, device=a.device),
                 torch.full((2, 3), 3.1416, device=a.device),
             )

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1321,8 +1321,15 @@ def full_like(x, fill_value, **kwargs):
 def tensor_constructor(fill_value):
     # torch.zeros, torch.ones, etc
     def inner(
-        *size, dtype=None, device=None, layout=0, pin_memory=False, memory_format=None
+        *size,
+        names=None,
+        dtype=None,
+        device=None,
+        layout=0,
+        pin_memory=False,
+        memory_format=None,
     ):
+        assert names is None
         assert not pin_memory
         assert layout in (0, torch.strided)
         assert memory_format in (None, torch.contiguous_format)


### PR DESCRIPTION
Fix #1269

