### PR TITLE
Timm models - Keep loss value small

### DIFF
--- a/benchmarks/timm_models.py
+++ b/benchmarks/timm_models.py
@@ -10,7 +10,6 @@ import warnings
 import torch
 from common import BenchmarkRunner
 from common import main
-from torch._subclasses import FakeTensor
 
 from torchdynamo.testing import collect_results
 from torchdynamo.utils import clone_inputs
@@ -297,10 +296,9 @@ class TimmRunnner(BenchmarkRunner):
         )
 
     def compute_loss(self, pred):
-        if isinstance(pred, FakeTensor) and not isinstance(self.target, FakeTensor):
-            return self.loss(pred, torch.ops.aten.lift_fresh_copy(self.target))
-        else:
-            return self.loss(pred, self.target)
+        # High loss values make gradient checking harder, as small changes in
+        # accumulation order upsets accuracy checks.
+        return self.loss(pred, self.target) / 10.0
 
     def forward_pass(self, mod, inputs, collect_outputs=True):
         return mod(*inputs)

--- a/torchdynamo/testing.py
+++ b/torchdynamo/testing.py
@@ -1,6 +1,7 @@
 import contextlib
 import dis
 import functools
+import logging
 import os.path
 import types
 import unittest
@@ -24,6 +25,8 @@ from .utils import same
 unsupported = torchdynamo.eval_frame.unsupported
 three = 3
 
+log = logging.getLogger(__name__)
+
 
 def clone_me(x):
     if x is None:
@@ -35,6 +38,11 @@ def collect_results(model, prediction, loss, example_inputs):
     results = []
     results.append(prediction)
     results.append(loss)
+    if isinstance(loss, torch.Tensor) and loss.item() > 1:
+        log.warning(
+            f"High loss value alert - {loss:.2f}. Can result in unstable gradients."
+        )
+
     grads = dict()
     for name, param in model.named_parameters():
         grad = clone_me(param.grad)


### PR DESCRIPTION
For the TIMM models that are failing accuracy with TorchInductor, I found the loss value is quite high (spasnet - 8, pnasnet - 7). Few months ago, we observed a behavior that for large loss values, small changes in the order of accumulation of gradients (fan-out in the forward pass means accumulation in the backward pass) can lead to accuracy deviations.

In our benchmarking infra, we use random input values, while the models are trained with pre-processed data, which could explain these high loss values.

This PR tries to lower the loss value. I tried locally and it passes accuracy checks for many Inductor models.