### PR TITLE
Share Aot Autograd workaround for aot_eager and inductor backend

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -68,6 +68,7 @@ CI_SKIP_AOT_EAGER_TRAINING = [
     "pytorch_struct",
     "speech_transformer",
     "vision_maskrcnn",
+    "moco",
     # Huggingface
     "AlbertForMaskedLM",  # OOM
     "AlbertForQuestionAnswering",  # OOM

--- a/test/test_aot_autograd.py
+++ b/test/test_aot_autograd.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env pytest
+import functools
+
+import torch
+from torch.nn import *
+
+import torchdynamo
+from torchdynamo.optimizations.training import is_aot_autograd_safe_to_run
+from torchdynamo.testing import rand_strided
+
+
+def compiler_safe_fn(gm, example_inputs, is_safe):
+    is_safe[0] = is_aot_autograd_safe_to_run(gm, example_inputs)
+    return gm.forward
+
+
+class AotAutogradFallbackTests(torchdynamo.testing.TestCase):
+    def test_LSTM(self):
+        # https://github.com/pytorch/torchdynamo/issues/1147
+        class Repro(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.self_mod_model_lstm_lstm = LSTM(
+                    2048, 2048, num_layers=2, bidirectional=True
+                )
+
+            def forward(self, permute: torch.Tensor):
+                self_mod_model_lstm_lstm = self.self_mod_model_lstm_lstm(permute)
+                return (self_mod_model_lstm_lstm,)
+
+        is_safe = [True]
+        mod = Repro()
+        compiler_fn = functools.partial(compiler_safe_fn, is_safe=is_safe)
+        aot_mod = torchdynamo.optimize(compiler_fn)(mod)
+
+        args = [((92, 4, 2048), (1, 188416, 92), torch.float32, "cpu", False)]
+        args = [
+            rand_strided(sh, st, dt, dev).requires_grad_(rg)
+            for (sh, st, dt, dev, rg) in args
+        ]
+
+        aot_mod(*args)
+        self.assertTrue(not is_safe[0])
+
+    def test_set_grad_enabled(self):
+        # https://github.com/pytorch/torchdynamo/issues/1301
+        def fn(param, y):
+            prev_grad = torch.is_grad_enabled()
+            try:
+                torch.set_grad_enabled(False)
+                param.add_(y)
+            finally:
+                torch.set_grad_enabled(prev_grad)
+            return y
+
+        y = torch.randn(4)
+        x = torch.nn.Parameter(torch.randn(4))
+        is_safe = [True]
+        compiler_fn = functools.partial(compiler_safe_fn, is_safe=is_safe)
+        aot_fn = torchdynamo.optimize(compiler_fn)(fn)
+        aot_fn(x, y)
+        self.assertTrue(not is_safe[0])
+
+    def test_negative_testing(self):
+        def fn(x, y):
+            return torch.sin(x).add_(y)
+
+        y = torch.randn(4)
+        x = torch.randn(4)
+        is_safe = [True]
+        compiler_fn = functools.partial(compiler_safe_fn, is_safe=is_safe)
+        aot_fn = torchdynamo.optimize(compiler_fn)(fn)
+        aot_fn(x, y)
+        self.assertTrue(is_safe[0])

--- a/test/test_aot_autograd.py
+++ b/test/test_aot_autograd.py
@@ -2,7 +2,6 @@
 import functools
 
 import torch
-from torch.nn import *
 
 import torchdynamo
 from torchdynamo.optimizations.training import is_aot_autograd_safe_to_run
@@ -20,7 +19,7 @@ class AotAutogradFallbackTests(torchdynamo.testing.TestCase):
         class Repro(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.self_mod_model_lstm_lstm = LSTM(
+                self.self_mod_model_lstm_lstm = torch.nn.LSTM(
                     2048, 2048, num_layers=2, bidirectional=True
                 )
 

--- a/test/test_torchinductor_opinfo.py
+++ b/test/test_torchinductor_opinfo.py
@@ -3,6 +3,7 @@ import os
 from collections import defaultdict
 from enum import Enum
 from functools import partial
+from unittest.mock import patch
 
 import torch
 from torch.testing._internal.common_device_type import OpDTypes
@@ -478,6 +479,7 @@ class TestInductorOpInfo(TestCase):
         True
     )  # inductor kernels failing this test intermittently
     @_ops(op_db[START:END])
+    @patch("torchdynamo.config.raise_on_unsafe_aot_autograd", True)
     def test_comprehensive(self, device, dtype, op):
         torchdynamo.reset()
         with torch.no_grad():

--- a/torchdynamo/config.py
+++ b/torchdynamo/config.py
@@ -145,6 +145,9 @@ optimize_ddp = False
 # If True, raises exception if TorchDynamo is called with a context manager
 raise_on_ctx_manager_usage = True
 
+# If True, raise when aot autograd is unsafe to use
+raise_on_unsafe_aot_autograd = False
+
 
 class _AccessLimitingConfig(ModuleType):
     def __setattr__(self, name, value):

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -34,8 +34,7 @@ def is_aot_autograd_safe_to_run(gm, example_inputs):
     Issues
     1) LSTM - https://github.com/pytorch/torchdynamo/issues/1147
     2) LSTM - https://github.com/pytorch/functorch/issues/586
-    3) TODO - Add an issue for set_grad_enabled
-    4) Input mutation - https://github.com/pytorch/torchdynamo/issues/1301
+    3) Input mutation - https://github.com/pytorch/torchdynamo/issues/1301
     """
 
     def raise_or_warn(reason):
@@ -53,12 +52,7 @@ def is_aot_autograd_safe_to_run(gm, example_inputs):
         if submod.__class__.__name__ == "LSTM":
             return raise_or_warn("LSTM")
 
-    # 2) set_grad_enabled
-    for node in gm.graph.nodes:
-        if node.target == torch._C._set_grad_enabled:
-            return raise_or_warn("set_grad_enabled")
-
-    # 3) Mutation in the graph
+    # 2) Mutation in the graph
     if functorch.compile.config.use_functionalize:
         # There are two problematic classes we still exclude for now with
         # functionalization:

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -38,8 +38,6 @@ def is_aot_autograd_safe_to_run(gm, example_inputs):
     4) Input mutation - https://github.com/pytorch/torchdynamo/issues/1301
     """
 
-    print(gm)
-
     def raise_and_false():
         if config.raise_on_unsafe_aot_autograd:
             raise NotImplementedError("Aot Autograd is unsafe")

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -34,7 +34,8 @@ def is_aot_autograd_safe_to_run(gm, example_inputs):
     Issues
     1) LSTM - https://github.com/pytorch/torchdynamo/issues/1147
     2) LSTM - https://github.com/pytorch/functorch/issues/586
-    3) Input mutation - https://github.com/pytorch/torchdynamo/issues/1301
+    3) New op - https://github.com/pytorch/torchdynamo/issues/1448
+    4) Input mutation - https://github.com/pytorch/torchdynamo/issues/1301
     """
 
     def raise_or_warn(reason):
@@ -51,6 +52,11 @@ def is_aot_autograd_safe_to_run(gm, example_inputs):
     for submod in gm.modules():
         if submod.__class__.__name__ == "LSTM":
             return raise_or_warn("LSTM")
+
+    # 2) new does not work with fake tensor and aot autograd
+    for node in gm.graph.nodes:
+        if node.op == "call_method" and node.target == "new":
+            return raise_or_warn("new operator")
 
     # 2) Mutation in the graph
     mutated = False

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -26,6 +26,51 @@ from .normalize import normalize_ir
 log = logging.getLogger(__name__)
 
 
+def is_aot_autograd_safe_to_run(gm, example_inputs):
+    """
+    There are some known issues with Aot Autograd. This is a workaround to catch
+    such cases, and fallback to eager. We should fix these quickly.
+
+    Issues
+    1) LSTM - https://github.com/pytorch/torchdynamo/issues/1147
+    2) LSTM - https://github.com/pytorch/functorch/issues/586
+    3) TODO - Add an issue for set_grad_enabled
+    4) Input mutation - https://github.com/pytorch/torchdynamo/issues/1301
+    """
+    import functorch.compile
+
+    safe = True
+    # 1) LSTM module (tts_angular) - https://github.com/pytorch/functorch/issues/586
+    for submod in gm.modules():
+        if submod.__class__.__name__ == "LSTM":
+            safe = False
+
+    # 2) set_grad_enabled
+    has_set_grad_enabled = False
+    for node in gm.graph.nodes:
+        if node.target == torch._C._set_grad_enabled:
+            has_set_grad_enabled = True
+
+    if functorch.compile.config.use_functionalize:
+        # There are two problematic classes we still exclude for now with
+        # functionalization:
+        #   - data mutation of inputs (fixed when we stop recording the
+        #   copy_ directly into the graph)
+        #   - metadata mutation of inputs (fixed if we do an extra partition
+        #   to avoid AotAutograd on the mutated inputs, or if we some how
+        #   get custom autograd function to reflect metadata changes to the
+        #   original tensor)
+        mutated = has_mutation(gm, example_inputs, inputs_only=True)
+    else:
+        mutated = has_mutation(gm, example_inputs)
+
+    gm_inputs = list(filter(lambda x: x.op == "placeholder", gm.graph.nodes))
+
+    if mutated or len(gm_inputs) == 0 or has_set_grad_enabled:
+        safe = False
+    return safe
+
+
 class AotAutogradStrategy(object):
     """Base class for backend strategies that use AOT Autograd"""
 
@@ -55,33 +100,7 @@ class AotAutogradStrategy(object):
                 self.use_fallback = True
                 pass
 
-        gm_inputs = list(filter(lambda x: x.op == "placeholder", gm.graph.nodes))
-
-        # 1) LSTM module (tts_angular) - https://github.com/pytorch/functorch/issues/586
-        for submod in self.gm.modules():
-            if submod.__class__.__name__ == "LSTM":
-                self.use_fallback = True
-
-        # 2) set_grad_enabled
-        has_set_grad_enabled = False
-        for node in self.gm.graph.nodes:
-            if node.target == torch._C._set_grad_enabled:
-                has_set_grad_enabled = True
-
-        if functorch.compile.config.use_functionalize:
-            # There are two problematic classes we still exclude for now with
-            # functionalization:
-            #   - data mutation of inputs (fixed when we stop recording the
-            #   copy_ directly into the graph)
-            #   - metadata mutation of inputs (fixed if we do an extra partition
-            #   to avoid AotAutograd on the mutated inputs, or if we some how
-            #   get custom autograd function to reflect metadata changes to the
-            #   original tensor)
-            mutated = has_mutation(self.gm, self.example_inputs, inputs_only=True)
-        else:
-            mutated = has_mutation(self.gm, self.example_inputs)
-
-        if mutated or len(gm_inputs) == 0 or has_set_grad_enabled:
+        if not is_aot_autograd_safe_to_run(gm, example_inputs):
             self.use_fallback = True
 
     @property

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -53,18 +53,29 @@ def is_aot_autograd_safe_to_run(gm, example_inputs):
             return raise_or_warn("LSTM")
 
     # 2) Mutation in the graph
-    if functorch.compile.config.use_functionalize:
-        # There are two problematic classes we still exclude for now with
-        # functionalization:
-        #   - data mutation of inputs (fixed when we stop recording the
-        #   copy_ directly into the graph)
-        #   - metadata mutation of inputs (fixed if we do an extra partition
-        #   to avoid AotAutograd on the mutated inputs, or if we some how
-        #   get custom autograd function to reflect metadata changes to the
-        #   original tensor)
-        mutated = has_mutation(gm, example_inputs, inputs_only=True)
-    else:
-        mutated = has_mutation(gm, example_inputs)
+    mutated = False
+    try:
+        if functorch.compile.config.use_functionalize:
+            # There are two problematic classes we still exclude for now with
+            # functionalization:
+            #   - data mutation of inputs (fixed when we stop recording the
+            #   copy_ directly into the graph)
+            #   - metadata mutation of inputs (fixed if we do an extra partition
+            #   to avoid AotAutograd on the mutated inputs, or if we some how
+            #   get custom autograd function to reflect metadata changes to the
+            #   original tensor)
+            mutated = has_mutation(gm, example_inputs, inputs_only=True)
+        else:
+            mutated = has_mutation(gm, example_inputs)
+    except NotImplementedError as e:
+        if "SparseTensorImpl" not in str(e):
+            # TODO - TorchDynamo mutation analysis cannot handle sparse tensors.
+            # So, there is a chance that we could call Aot Autograd when it is
+            # unsafe.
+            # The exception is fairly guarded with string check, so any other
+            # mutation analysis bugs will raise exceptions and will be caught.
+            raise e
+        pass
 
     if mutated:
         return raise_or_warn("mutation")

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -277,7 +277,7 @@ def compile_fx(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]
     """Main entrypoint to a compile given FX graph"""
 
     if not is_aot_autograd_safe_to_run(model_, example_inputs_):
-        log.debug("Aot Autograd is not safe to run, so falling back to eager")
+        log.warning("Aot Autograd is not safe to run, so falling back to eager")
         return model_
 
     functorch.compile.config.use_functionalize = True

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -12,6 +12,7 @@ from torch.utils._mode_utils import no_dispatch
 
 from torchdynamo.optimizations.backends import aot_autograd
 from torchdynamo.optimizations.normalize import normalize_ir
+from torchdynamo.optimizations.training import is_aot_autograd_safe_to_run
 from torchdynamo.utils import dynamo_timed
 from torchdynamo.utils import preserve_rng_state
 
@@ -274,6 +275,11 @@ def count_tangents(fx_g: torch.fx.GraphModule):
 
 def compile_fx(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]):
     """Main entrypoint to a compile given FX graph"""
+
+    if not is_aot_autograd_safe_to_run(model_, example_inputs_):
+        log.debug("Aot Autograd is not safe to run, so falling back to eager")
+        return model_
+
     functorch.compile.config.use_functionalize = True
     functorch.compile.config.use_fake_tensor = True
 


### PR DESCRIPTION
This shares the known aot autograd workarounds between inductor and aot_eager. It fixes the problem in https://github.com/pytorch/torchdynamo/issues/1147 but by falling back to eager.

cc @Chillee @jansel 