### PR TITLE
Lowerings upsample_bicubic2d

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -2184,6 +2184,15 @@ class CommonTemplate:
             check_lowp=False,
         )
 
+    def test_upsample_bicubic2d(self):
+        def fn(a):
+            return (
+                aten.upsample_bicubic2d(a, (128, 128), True),
+                aten.upsample_bicubic2d(a, (128, 256), False),
+            )
+
+        self.common(fn, (torch.randn([4, 3, 64, 32], dtype=torch.float32),))
+
     def test_sort(self):
         def fn(a):
             return torch.sort(a)

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1737,6 +1737,11 @@ def upsample_bicubic2d(x, output_size, align_corners, scales_h=None, scales_w=No
     iH = V.graph.sizevars.guard_static_shape(iH)
     iW = V.graph.sizevars.guard_static_shape(iW)
 
+    def get_int_dtype(maxval):
+        if maxval > torch.iinfo(torch.int32).max:
+            return torch.int64
+        return torch.int32
+
     def compute_scale(in_size, out_size, align_corners, scale=None):
         if align_corners:
             return (in_size - 1) / (out_size - 1) if out_size > 1 else 0
@@ -1810,8 +1815,8 @@ def upsample_bicubic2d(x, output_size, align_corners, scales_h=None, scales_w=No
             ix = ops.indirect_indexing(clamp(fx, 0, iW - 1))
             return x_loader([n, c, iy, ix])
 
-        iy = ops.to_dtype(in_y, torch.int32)
-        ix = ops.to_dtype(in_x, torch.int32)
+        iy = ops.to_dtype(in_y, get_int_dtype(iH + 1))
+        ix = ops.to_dtype(in_x, get_int_dtype(iW + 1))
         iys_ofs = tuple((ops.add(iy, ofs) for ofs in (-1, 0, 1, 2)))
         ixs_ofs = tuple((ops.add(ix, ofs) for ofs in (-1, 0, 1, 2)))
 


### PR DESCRIPTION
This is a follow up to https://github.com/pytorch/torchdynamo/pull/1270, that fixes issue with missing overload for `upsample_bicubic2d`