### PR TITLE
Fix aten.fmod.Scalar error

### DIFF
--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -172,7 +172,7 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def fmod(a, b):
-        return f"tl.libdevice.fmod({a}, {b})"
+        return f"tl.libdevice.fmod({a}, ({b}).to(tl.float32))"
 
     @staticmethod
     def pow(a, b):


### PR DESCRIPTION
Fix issue #1232.

Triton code after fix:
```
def kernel(in_ptr0, out_ptr0, xnumel, XBLOCK : tl.constexpr):
    xoffset = tl.program_id(0) * XBLOCK
    xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK])
    xmask = xindex < xnumel
    x0 = xindex
    tmp0 = tl.load(in_ptr0 + x0, xmask)
    tmp1 = 2
    tmp2 = tl.libdevice.fmod(tmp0, (tmp1).to(tl.float32))
    tl.store(out_ptr0 + x0 + tl.zeros([XBLOCK], tl.int32), tmp2, xmask)
```