### PR TITLE
Remap copy.copy/copy.deepcopy only if argument really is a Tensor

### DIFF
--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -734,9 +734,6 @@ class FunctionTests(torchdynamo.testing.TestCase):
         with self.assertRaises(torchdynamo.exc.Unsupported):
             h(torch.rand(10))
 
-    # test does not work with fake_tensor_propagation set to False since
-    # the Parameter gets silently converted to a tensor before the deepcopy call
-    @patch.object(torchdynamo.config, "fake_tensor_propagation", True)
     def test_copy_parameter(self):
         import copy
 

--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -732,3 +732,14 @@ class FunctionTests(torchdynamo.testing.TestCase):
 
         with self.assertRaises(torchdynamo.exc.Unsupported):
             h(torch.rand(10))
+
+    def test_copy_parameter(self):
+        import copy
+
+        @torchdynamo.optimize(nopython=True)
+        def f(x):
+            y = copy.deepcopy(x)
+            return y
+
+        with self.assertRaises(torchdynamo.exc.Unsupported):
+            f(torch.nn.Parameter(torch.zeros(10)))

--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -5,7 +5,6 @@ import inspect
 import itertools
 import operator
 from typing import Any
-from unittest.mock import patch
 
 import torch
 from torch import sub

--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -736,10 +736,8 @@ class FunctionTests(torchdynamo.testing.TestCase):
     def test_copy_parameter(self):
         import copy
 
-        @torchdynamo.optimize(nopython=True)
+        @torchdynamo.optimize("eager", nopython=True)
         def f(x):
-            y = copy.deepcopy(x)
-            return y
+            return copy.deepcopy(x)
 
-        with self.assertRaises(torchdynamo.exc.Unsupported):
-            f(torch.nn.Parameter(torch.zeros(10)))
+        f(torch.nn.Parameter(torch.zeros(10)))

--- a/torchdynamo/variables/functions.py
+++ b/torchdynamo/variables/functions.py
@@ -184,7 +184,10 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         if self.fn is copy.copy or self.fn is copy.deepcopy:
             if len(args) != 1:
                 unimplemented("copy.copy/copy.deepcopy does not have 1 argument")
-            if isinstance(args[0], variables.TensorVariable):
+            if (
+                isinstance(args[0], variables.TensorVariable)
+                and args[0].class_type is torch.Tensor
+            ):
                 if self.fn is copy.copy:
                     return args[0]
                 elif self.fn is copy.deepcopy:

--- a/torchdynamo/variables/functions.py
+++ b/torchdynamo/variables/functions.py
@@ -178,7 +178,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         pass
 
     @staticmethod
-    def _copy_parameter(tx, param):
+    def _deepcopy_parameter(tx, param):
         # equivalent to
         # torch.nn.Parameter(
         #     args[0].clone(memory_format=torch.preserve_format)), args[0].requires_grad)
@@ -213,7 +213,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
                     return args[0]
                 elif self.fn is copy.deepcopy:
                     if type(args[0].parameter_value) is torch.nn.Parameter:
-                        return self._copy_parameter(tx, args[0])
+                        return self._deepcopy_parameter(tx, args[0])
                     elif args[0].class_type is torch.Tensor:
                         return args[0].call_method(tx, "clone", [], {})
             unimplemented("copy.copy/copy.deepcopy called on non-tensor")

--- a/torchdynamo/variables/functions.py
+++ b/torchdynamo/variables/functions.py
@@ -212,10 +212,10 @@ class UserFunctionVariable(BaseUserFunctionVariable):
                 if self.fn is copy.copy:
                     return args[0]
                 elif self.fn is copy.deepcopy:
-                    if args[0].class_type is torch.Tensor:
-                        return args[0].call_method(tx, "clone", [], {})
-                    elif args[0].class_type is torch.nn.Parameter:
+                    if type(args[0].parameter_value) is torch.nn.Parameter:
                         return self._copy_parameter(tx, args[0])
+                    elif args[0].class_type is torch.Tensor:
+                        return args[0].call_method(tx, "clone", [], {})
             unimplemented("copy.copy/copy.deepcopy called on non-tensor")
 
         return super(UserFunctionVariable, self).call_function(tx, args, kwargs)

--- a/torchdynamo/variables/functions.py
+++ b/torchdynamo/variables/functions.py
@@ -16,7 +16,6 @@ from ..exc import unimplemented
 from ..source import AttrSource
 from ..source import GetItemSource
 from ..utils import make_cell
-from .base import MutableLocal
 from .base import VariableTracker
 from .base import typestr
 
@@ -192,7 +191,10 @@ class UserFunctionVariable(BaseUserFunctionVariable):
                     if args[0].class_type is torch.Tensor:
                         return args[0].call_method(tx, "clone", [], {})
                     elif args[0].class_type is torch.nn.Parameter:
-                        # equivalent to torch.nn.Parameter(args[0].clone(memory_format=torch.preserve_format)), args[0].requires_grad))
+                        # equivalent to
+                        # torch.nn.Parameter(
+                        #     args[0].clone(memory_format=torch.preserve_format)), args[0].requires_grad)
+                        # )
                         return variables.TorchVariable(
                             torch.nn.Parameter
                         ).call_function(


### PR DESCRIPTION
Fix case where `copy.copy`/`copy.deepcopy` is called on a `TensorVariable` but the wrapped value is not exactly a `torch.Tensor`, e.g. a `nn.Parameter`.

Fixes this test failure (`PYTORCH_TEST_WITH_DYNAMO=1 pytest test/test_subclass.py -k test_deepcopy `): https://github.com/pytorch/pytorch/blob/207a5a8fa9bfd9361038d46636c0440290c171bb/test/test_subclass.py#L48-L59