### PR TITLE
Adding aot_inductor_debug backend to isolate decomps vs inductor issues

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -1177,7 +1177,7 @@ class BenchmarkRunner:
                 print(
                     "TorchDynamo optimized model failed to run because of following error"
                 )
-                print(e)
+                log.exception(e)
                 return record_status(accuracy_status)
 
             if not same(

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -752,7 +752,7 @@ def same(
                     exact_dtype=exact_dtype,
                 )
             ):
-                log.info("Accuracy failed for key name", k)
+                log.error(f"Accuracy failed for key name {k}")
                 return False
         return True
     elif isinstance(ref, torch.Tensor):


### PR DESCRIPTION
As title. While diagnosing https://github.com/pytorch/torchdynamo/issues/1235, I found that inductor was not really causing problems. So, I added a new debug backend to help debug such issues.