### PR TITLE
don't codegen constexpr for xnumel and rnumel

### DIFF
--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -934,11 +934,7 @@ class TritonKernel(Kernel):
 
         argdefs, _ = self.args.python_argdefs()
 
-        if config.dynamic_shapes:
-            maybe_const = ""
-        else:
-            maybe_const = ": tl.constexpr"
-
+        maybe_const = ""
         for tree in self.range_trees:
             if tree.prefix != "r" or self.inside_reduction:
                 argdefs.append(f"{tree.prefix}numel{maybe_const}")

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -934,6 +934,8 @@ class TritonKernel(Kernel):
 
         argdefs, _ = self.args.python_argdefs()
 
+        # we used to put tl.constexpr annotations for rnumel and xnumel for static shapes,
+        # but looks like it sometimes lead to triton codegen bugs, so pass xnumel and rnumel as vars
         maybe_const = ""
         for tree in self.range_trees:
             if tree.prefix != "r" or self.inside_reduction:


### PR DESCRIPTION
Tentative fix for #1358, that looks like triton bug. The same kernel either works or doesn't, depending on whether xnumel and rnumel are annotated as tl.constexpr. Note, this regresses perf a bit for static shapes (e.g. hf_Bert goes from 1.131 to 1.125) but correctness is more important, and we'd move to dynamic shapes soon anyway. 
Triton issue https://github.com/openai/triton/issues/714