### PR TITLE
Don't realize reduction if we've unrolled it.

### DIFF
--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -2733,7 +2733,10 @@ def make_reduction(reduction_type: str, override_dtype=None):
                 reduction_type, reduction_type
             ),
         )
-        result.realize()
+        if isinstance(
+            result.data.data, Reduction
+        ):  # Only realize if reduction isn't unrolled
+            result.realize()
         return result
 
     return inner


### PR DESCRIPTION
A couple thoughts here

1. I think this makes sense, irregardless of other things.
2. But, the reason I came to this is that the KeOps pattern doesn't work if we have a reduction in the middle.

i.e. we fuse both `((a - b) ** 2).sum(dim=1)` and `((a - b) ** 2).sum(dim=2).sum(dim=1)` into a single kernel, but in the second case, we also materialize a massive intermediate in global memory that we pass into the Triton kernel.

I'm not totally sure what the right way of handling that is.