### PR TITLE
Delaying reinplacing-decomps to lowering

### DIFF
--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -282,31 +282,6 @@ def baddbmm(self, batch1, batch2, beta=1, alpha=1):
     return self + result
 
 
-@register_decomposition([aten.index_put])
-def index_put(self, indices, values, accumulate=False):
-    return aten.index_put_(self.clone(), indices, values, accumulate)
-
-
-@register_decomposition([aten.scatter])
-def scatter(self, dim: int, index, src, **kwargs):
-    return self.clone().scatter_(dim, index, src, **kwargs)
-
-
-@register_decomposition([aten.scatter_add])
-def scatter_add(self, dim: int, index, src):
-    return self.clone().scatter_add_(dim, index, src)
-
-
-@register_decomposition([aten.scatter_add_])
-def scatter_add_(self, dim: int, index, src):
-    return self.scatter_reduce_(dim, index, src, "sum")
-
-
-@register_decomposition([aten.scatter_reduce])
-def scatter_reduce(self, dim: int, index, src, reduction_type, **kwargs):
-    return self.clone().scatter_reduce_(dim, index, src, reduction_type, **kwargs)
-
-
 @register_decomposition([aten.conj_physical])
 def conj_physical(self):
     assert not self.is_complex(), "TODO: implement this"

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1560,6 +1560,11 @@ def index(x, indices):
     )
 
 
+@register_lowering([aten.index_put])
+def index_put(x, indices, values, accumulate=False):
+    return index_put_(clone(x), indices, values, accumulate)
+
+
 @register_lowering(aten.index_put_, type_promote=False)
 def index_put_(self, indices, values, accumulate=False):
     values = to_dtype(values, self.get_dtype())
@@ -1608,6 +1613,11 @@ def index_put_(self, indices, values, accumulate=False):
     return self
 
 
+@register_lowering(aten.scatter, type_promote=False)
+def scatter(x, dim: int, index, src, **kwargs):
+    return scatter_(clone(x), dim, index, src, **kwargs)
+
+
 @register_lowering(aten.scatter_, type_promote=False)
 def scatter_(self, dim: int, index, src, *, reduce: str = None):
     if reduce == "add":
@@ -1618,6 +1628,21 @@ def scatter_(self, dim: int, index, src, *, reduce: str = None):
     else:
         assert reduce is None
     return scatter_reduce_(self, dim, index, src, reduce)
+
+
+@register_lowering(aten.scatter_add, type_promote=False)
+def scatter_add(x, dim: int, index, src):
+    return scatter_add_(clone(x), dim, index, src)
+
+
+@register_lowering(aten.scatter_add_, type_promote=False)
+def scatter_add_(x, dim: int, index, src):
+    return scatter_reduce_(clone(x), dim, index, src, "sum")
+
+
+@register_lowering(aten.scatter_reduce, type_promote=False)
+def scatter_reduce(x, dim: int, index, src, reduction_type, **kwargs):
+    return scatter_reduce_(clone(x), dim, index, src, reduction_type, **kwargs)
 
 
 @register_lowering(aten.scatter_reduce_, type_promote=False)

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1560,6 +1560,13 @@ def index(x, indices):
     )
 
 
+# This is moved from decomposition to lowering because this decomp introduced
+# mutation in the graph, which is bad for Aot Autograd. Aot Autograd runs dead
+# code elimination and common subexpression elimination optimizations, which
+# assume graphs to be side-effect free. More details at
+# https://github.com/pytorch/torchdynamo/issues/1235.
+# Moving such reinplacing type of decomps to lowering ensures that AotAutograd
+# gets good graphs.
 @register_lowering([aten.index_put])
 def index_put(x, indices, values, accumulate=False):
     return index_put_(clone(x), indices, values, accumulate)


### PR DESCRIPTION
Currently few of the reinplacing-like decomps introduce mutation in the graph. This upsets dce and cse optimizations in Aot Autograd. So, moving such transformations from decomps to lowering.

Pending - tests. Not sure if op-level testing is done here.