### PR TITLE
torchinductor:fix conv2d channels_last issue for CPU backend

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1376,6 +1376,30 @@ class CommonTemplate:
             check_lowp=False,
         )
 
+    def test_conv2d_channels_last(self):
+        m = torch.nn.Sequential(
+            torch.nn.Conv2d(3, 3, 1, 1),
+            ToTuple(),
+        )
+        m = m.to(memory_format=torch.channels_last)
+        x = torch.randn([2, 3, 16, 16]).to(memory_format=torch.channels_last)
+        self.common(
+            m,
+            (torch.randn([2, 3, 16, 16]),),
+        )
+
+    def test_conv3d_channels_last(self):
+        m = torch.nn.Sequential(
+            torch.nn.Conv3d(3, 3, 1, 1),
+            ToTuple(),
+        )
+        m = m.to(memory_format=torch.channels_last_3d)
+        x = torch.randn([2, 3, 16, 16, 16]).to(memory_format=torch.channels_last_3d)
+        self.common(
+            m,
+            (x,),
+        )
+
     def test_adaptive_avg_pool2d1(self):
         def fn(x):
             return aten._adaptive_avg_pool2d(x, (6, 6)), aten._adaptive_avg_pool2d(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -68,6 +68,7 @@ if torch.cuda.is_available():
         pass
 
 requires_cuda = functools.partial(unittest.skipIf, not HAS_CUDA, "requires cuda")
+
 torchinductor.config.triton.autotune = False  # too slow
 
 
@@ -1376,28 +1377,48 @@ class CommonTemplate:
             check_lowp=False,
         )
 
+    @unittest.skipIf(HAS_CUDA, "only support cpu channels_last")
     def test_conv2d_channels_last(self):
         m = torch.nn.Sequential(
             torch.nn.Conv2d(3, 3, 1, 1),
             ToTuple(),
         )
-        m = m.to(memory_format=torch.channels_last)
-        x = torch.randn([2, 3, 16, 16]).to(memory_format=torch.channels_last)
+        # only weight is channels_last
         self.common(
-            m,
+            m.to(memory_format=torch.channels_last),
             (torch.randn([2, 3, 16, 16]),),
         )
+        # only activation is channels_last
+        self.common(
+            m,
+            (torch.randn([2, 3, 16, 16]).to(memory_format=torch.channels_last),),
+        )
+        # activation and weight are all channels_last
+        self.common(
+            m.to(memory_format=torch.channels_last),
+            (torch.randn([2, 3, 16, 16]).to(memory_format=torch.channels_last),),
+        )
 
+    @unittest.skipIf(HAS_CUDA, "only support cpu channels_last")
     def test_conv3d_channels_last(self):
         m = torch.nn.Sequential(
             torch.nn.Conv3d(3, 3, 1, 1),
             ToTuple(),
         )
-        m = m.to(memory_format=torch.channels_last_3d)
-        x = torch.randn([2, 3, 16, 16, 16]).to(memory_format=torch.channels_last_3d)
+        # only weight is channels_last
+        self.common(
+            m.to(memory_format=torch.channels_last_3d),
+            (torch.randn([2, 3, 16, 16, 16]),),
+        )
+        # only activation is channels_last
         self.common(
             m,
-            (x,),
+            (torch.randn([2, 3, 16, 16, 16]).to(memory_format=torch.channels_last_3d),),
+        )
+        # activation and weight are all channels_last
+        self.common(
+            m.to(memory_format=torch.channels_last_3d),
+            (torch.randn([2, 3, 16, 16, 16]).to(memory_format=torch.channels_last_3d),),
         )
 
     def test_adaptive_avg_pool2d1(self):

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -3109,13 +3109,21 @@ class Convolution(ExternKernelAlloc):
                 x.get_dtype(),
             )
         else:
-            # if x or weight have one channels_last format, it will call channels_last path,
-            # which align with aten.convolutuion path(only support 2d case).
-            if len(x.get_size()) == 4 and (x.get_layout().is_channels_last_stride_ordered() or \
-                weight.get_layout().is_channels_last_stride_ordered()):
+            output_layout_str = "torch.contiguous_format"
+            # If x or weight have one channels_last(2d or 3d) format, it will call channels_last path,
+            # which align with aten.convolutuion path(cpu only support 2d case now).
+            # TODO: after cpu 3d convolution support channels_last path, the size check can be removed.
+            # TODO: the gpu channels_last path depend on cudnn version, see
+            # https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/ConvUtils.h.
+            if (
+                x.get_device().type == "cpu"
+                and len(x.get_size()) == 4
+                and (
+                    x.get_layout().is_channels_last_stride_ordered()
+                    or weight.get_layout().is_channels_last_stride_ordered()
+                )
+            ):
                 output_layout_str = "torch.channels_last"
-            else:
-                output_layout_str = "torch.contiguous_format"
 
         if output_layout_str == "torch.channels_last":
             stride_order = [0] + list(reversed(range(1, len(kernel_size) + 1)))


### PR DESCRIPTION
For torchinductor CPU path, there set a wrong layout format for conv2d channels_last path, which will assert stride mismatch error:
```
    def call(primals_1, primals_2, primals_3):
        primals_1_size = primals_1.size()
        s0 = primals_1_size[0]
        primals_3_size = primals_3.size()
        s1 = primals_3_size[0]
        s2 = primals_3_size[2]
        buf0 = aten.convolution(primals_3, primals_1, None, (1, 1), (0, 0), (1, 1), False, (0, 0), 1)
        assert buf0.size() == (s1, 3, 16, 16)
>       assert buf0.stride() == (768, 256, 16, 1)
E       AssertionError
```
This PR will fix https://github.com/pytorch/torchdynamo/issues/1353