### PR TITLE
Find conda from environment

### DIFF
--- a/torchinductor/codecache.py
+++ b/torchinductor/codecache.py
@@ -81,7 +81,7 @@ def install_gcc_via_conda():
         log.info("Downloading GCC via conda")
         subprocess.check_call(
             [
-                "conda",
+                os.environ.get("CONDA_EXE", "conda"),
                 "create",
                 f"--prefix={prefix}",
                 "--channel=conda-forge",


### PR DESCRIPTION
conda sometimes installs itself as a shell function instead of a legit binary, and puts the binary in the CONDA_EXE.  This diff lets us actually find conda in this case.