### PR TITLE
Fixes unsound indexing simplification

### DIFF
--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -717,7 +717,11 @@ class Reduction(Loops):
                 reduction_type,
                 reduction_numel,
             )
-            reduction_hint = hint if hint != ReductionHint.DEFAULT else reduction_hint
+            # intermediate reduction in split can contain complex indexing,
+            # and num_splits will fail to correctly set the hint
+            # reuse the passed hint if available
+            if reduction_hint == ReductionHint.DEFAULT:
+                reduction_hint = hint
             if split > 1:
                 # triton doesn't support reduce to single element well, so break it up
                 return cls.create_multilayer(

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -130,11 +130,14 @@ class SizeVarAllocator(object):
             for v in base.free_symbols:
                 if v in var_ranges:
                     # var smaller than divisor can be removed
+                    # if the rest is guaranteed to be multiple of divisor
                     rest = sympy.Wild("_rest", exclude=[v])
                     m = base.match(v + rest)
                     if m and v not in m[rest].free_symbols:
-                        if self.maybe_guard_leq(var_ranges[v], divisor):
-                            base = m[rest]
+                        gcd = sympy.gcd(m[rest], divisor)
+                        if gcd == divisor:
+                            if self.maybe_guard_leq(var_ranges[v], divisor):
+                                base = m[rest]
             return base
 
         def visit_indexing_div(base, divisor):


### PR DESCRIPTION
fixes #1233
`remove_zero_terms` removed a bit too much, producing incorrect results (even indexing simplification tests were expecting incorrect results). 