### PR TITLE
[Inductor] Support aten.index_put_ with bool index

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -2679,12 +2679,22 @@ class CommonTemplate:
 
         self.common(
             fn,
-            [
+            (
+                torch.randn([1024, 4, 2]),
+                torch.randn([1024, 4, 2]) > 0,
+                torch.randn([]),
+                False,
+            ),
+        )
+
+        self.common(
+            fn,
+            (
                 torch.randn([1024, 4, 2]),
                 torch.randn([1024, 4, 2]) > 0,
                 torch.randn([]),
                 True,
-            ],
+            ),
         )
 
     def test_index_put_fallback1(self):
@@ -2695,12 +2705,22 @@ class CommonTemplate:
 
         self.common(
             fn,
-            [
+            (
                 torch.randn([3]),
                 torch.as_tensor([True, True, False]),
                 torch.randn([2]),
-                random.choice([True, False]),
-            ],
+                False,
+            ),
+        )
+
+        self.common(
+            fn,
+            (
+                torch.randn([3]),
+                torch.as_tensor([True, True, False]),
+                torch.randn([2]),
+                True,
+            ),
         )
 
     def test_index_put_fallback2(self):
@@ -2711,13 +2731,23 @@ class CommonTemplate:
 
         self.common(
             fn,
-            [
+            (
                 torch.randn([1, 2, 3]),
                 torch.as_tensor([0, 1]),
                 torch.as_tensor([True, True, False]),
                 torch.randn([]),
-                random.choice([True, False]),
-            ],
+                False,
+            ),
+        )
+        self.common(
+            fn,
+            (
+                torch.randn([1, 2, 3]),
+                torch.as_tensor([0, 1]),
+                torch.as_tensor([True, True, False]),
+                torch.randn([]),
+                True,
+            ),
         )
 
     @patch.object(config, "fallback_random", True)

--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -2671,6 +2671,55 @@ class CommonTemplate:
             ],
         )
 
+    def test_index_put_as_masked_fill(self):
+        def fn(a, b, c, d):
+            a = a.clone()
+            torch.ops.aten.index_put_(a, [b], c, d)
+            return a
+
+        self.common(
+            fn,
+            [
+                torch.randn([1024, 4, 2]),
+                torch.randn([1024, 4, 2]) > 0,
+                torch.randn([]),
+                True,
+            ],
+        )
+
+    def test_index_put_fallback1(self):
+        def fn(a, b, c, d):
+            a = a.clone()
+            torch.ops.aten.index_put_(a, [b], c, d)
+            return a
+
+        self.common(
+            fn,
+            [
+                torch.randn([3]),
+                torch.as_tensor([True, True, False]),
+                torch.randn([2]),
+                random.choice([True, False]),
+            ],
+        )
+
+    def test_index_put_fallback2(self):
+        def fn(a, b, c, d, e):
+            a = a.clone()
+            torch.ops.aten.index_put_(a, [None, b, c], d, e)
+            return a
+
+        self.common(
+            fn,
+            [
+                torch.randn([1, 2, 3]),
+                torch.as_tensor([0, 1]),
+                torch.as_tensor([True, True, False]),
+                torch.randn([]),
+                random.choice([True, False]),
+            ],
+        )
+
     @patch.object(config, "fallback_random", True)
     def test_bernoulli1(self):
         def fn(a):

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1578,8 +1578,34 @@ def index_put(x, indices, values, accumulate=False):
     return index_put_(clone(x), indices, values, accumulate)
 
 
+def index_put_as_masked_fill(self, indices, value, accumulate):
+    if value.get_device() != self.get_device():
+        value = to_device(value, self.get_device())
+    if accumulate:
+        value = add(self, value)
+    return mutate_to(self, where(indices[0], value, self))
+
+
+def index_put_fallback(self, indices, values, accumulate):
+    ir.IndexPutFallback(self, indices, values, accumulate)
+    return self
+
+
 @register_lowering(aten.index_put_, type_promote=False)
 def index_put_(self, indices, values, accumulate=False):
+    # Dispatch to masked fill for single boolean index with single value
+    if (
+        values.get_numel() == 1
+        and len(indices) == 1
+        and indices[0].get_dtype() in {torch.bool, torch.uint8}
+    ):
+        return index_put_as_masked_fill(self, indices, values, accumulate)
+
+    # Fallback if there is a boolean index
+    for index in indices:
+        if index is not None and index.get_dtype() in {torch.bool, torch.uint8}:
+            return index_put_fallback(self, indices, values, accumulate)
+
     values = to_dtype(values, self.get_dtype())
     indices, start_offset, end_offset = check_and_broadcast_indices(indices)
     indices_sizes = [i.get_size() for i in indices if i is not None]


### PR DESCRIPTION
When the index list is just a single bool index and the value to assign has only one element, we dispatch `aten.index_put_` as masked fill. Otherwise, we fallback.

See the discussion in issue #1267.

Test plan:
- Unit tests
- `PYTORCH_TEST_WITH_INDUCTOR=1   pytest test/test_indexing.py -k test_empty_index_cuda`