### PR TITLE
torchinductor/codegen -> torchinductor.codegen in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     install_requires=["torch>=1.12.0", "numpy", "tabulate", "pyyaml", "sympy"],
     packages=find_packages(include=package_include),
     package_data={
-        "torchinductor/codegen": ["*.h", "*.j2"],
+        "torchinductor.codegen": ["*.h", "*.j2"],
     },
     zip_safe=False,
     ext_modules=[


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1426

before:
```
$ python setup.py bdist_wheel | grep cpp_prefix.h
(returns nothing)
```

now:
```
$ python setup.py bdist_wheel | grep cpp_prefix.h
copying torchinductor/codegen/cpp_prefix.h -> build/lib.linux-x86_64-3.9/torchinductor/codegen
copying build/lib.linux-x86_64-3.9/torchinductor/codegen/cpp_prefix.h -> build/bdist.linux-x86_64/wheel/torchinductor/codegen
adding 'torchinductor/codegen/cpp_prefix.h'
```

(repro requires you to manually `rm -r torchdynamo.egg-info` first)