### PR TITLE
Re enable batch norm decomp on cpu

### DIFF
--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -67,7 +67,7 @@ decompositions = get_decompositions(
         aten.mse_loss_backward,
         aten.mv,
         aten.narrow,
-        # aten.native_batch_norm, TODO - fix cpu error and enable
+        aten.native_batch_norm,
         aten.native_batch_norm_backward,
         aten.native_dropout_backward,
         aten.native_group_norm,
@@ -116,26 +116,6 @@ def clamp(x, min=None, max=None):
     if max is not None:
         x = torch.minimum(x, torch.tensor(max, dtype=x.dtype, device=x.device))
     return x
-
-
-# temporary workaround until https://github.com/pytorch/torchdynamo/issues/1215
-# is fixed - fails on cpu
-@register_decomposition([aten.native_batch_norm])
-def native_batch_norm(
-    input: Tensor,
-    weight: Optional[Tensor],
-    bias: Optional[Tensor],
-    running_mean: Optional[Tensor],
-    running_var: Optional[Tensor],
-    training: bool,
-    momentum: float,
-    eps: float,
-) -> Tuple[Tensor, Tensor, Tensor]:
-    if input.device.type == "cpu":
-        return NotImplemented
-    return torch._decomp.decompositions.native_batch_norm(
-        input, weight, bias, running_mean, running_var, training, momentum, eps
-    )
 
 
 @register_decomposition([aten.tanh])

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -2,8 +2,6 @@ import functools
 import logging
 import math
 import numbers
-from typing import Optional
-from typing import Tuple
 
 import torch
 import torch._decomp as decomp

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -770,12 +770,11 @@ def fallback_handler(kernel):
     return handler
 
 
-# https://github.com/pytorch/torchdynamo/issues/1215 to remove native_batch_norm
 def make_fallback(kernel):
     assert (
-        kernel not in decompositions or kernel is aten.native_batch_norm.default
+        kernel not in decompositions
     ), f"both a fallback and a decomp for same kernel: {kernel}"
-    if get_decompositions([kernel]) and kernel is not aten.native_batch_norm.default:
+    if get_decompositions([kernel]):
         log.warning(
             f"make_fallback({kernel}): a decomposition exists, we should switch to it"
         )


### PR DESCRIPTION
Previously I had to disable the decomp because of a FakeTensor bug. That has since been fixed (I think - double checking with this PR, works locally).