### PR TITLE
Fix an issue that does not vectorize the most outer parallel loop

### DIFF
--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -651,7 +651,7 @@ class LoopLevel:
         simd = f"simd simdlen({config.cpp.simdlen})"
         if self.parallel:
             # TODO(jansel): look into chunk size and other schedules
-            line1 = f"#pragma omp for{reduction}"
+            line1 = f"#pragma omp for{reduction} "
             if self.parallel > 1:
                 line1 += f" collapse({self.parallel})"
             if self.simd:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1449

Current logic replaces [` for ` with ` for {simd}`](https://github.com/pytorch/torchdynamo/blob/main/torchinductor/codegen/cpp.py#L658). But the literal will miss the end [whitespace character](https://github.com/pytorch/torchdynamo/blob/main/torchinductor/codegen/cpp.py#L654) if no reduction and the parallel is not greater than [1](https://github.com/pytorch/torchdynamo/blob/main/torchinductor/codegen/cpp.py#L655).
