### PR TITLE
fix timed() when cuda is not available

### DIFF
--- a/test/test_torchinductor.py
+++ b/test/test_torchinductor.py
@@ -18,6 +18,7 @@ from torch.utils._pytree import tree_unflatten
 import torchdynamo
 from torchdynamo.testing import rand_strided
 from torchdynamo.testing import same
+from torchinductor.utils import timed
 
 try:
     import sympy
@@ -3576,6 +3577,10 @@ if HAS_CPU:
             x = torch.randn((10, 20))
             assert same(x, forward(x))
 
+        @patch('torch.cuda.is_available')
+        def test_timed_cpu_only(self, cuda_available):
+            cuda_available.return_value = False
+            timed(lambda: torch.randn(10), ())
 
 if HAS_CUDA:
 

--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -94,12 +94,14 @@ def gen_gm_and_inputs(target, args, kwargs):
 
 
 def timed(model, example_inputs, times=1):
-    synchronize()
+    if torch.cuda.is_available():
+        synchronize()
     torch.manual_seed(1337)
     t0 = time.perf_counter()
     for _ in range(times):
         result = model(*example_inputs)
-        synchronize()
+        if torch.cuda.is_available():
+            synchronize()
     t1 = time.perf_counter()
     # GC the result after timing
     assert result is not None


### PR DESCRIPTION
`timed(...)` calls `synchronize` without checking CUDA availability, which breaks CPU when CUDA is not available. This PR fixed the problem.