### PR TITLE
Fix #1466

### DIFF
--- a/test/test_repros.py
+++ b/test/test_repros.py
@@ -1155,7 +1155,7 @@ class ReproTests(torchdynamo.testing.TestCase):
         opt_fn = torchdynamo.optimize_assert(cnt)(fn)
         self.assertTrue(same(opt_fn(x), correct))
         self.assertEqual(cnt.frame_count, 1)
-        self.assertEqual(cnt.op_count, ifdyn(29, 14))
+        self.assertEqual(cnt.op_count, ifdyn(28, 14))
 
     def test_recursive_map(self):
         # https://github.com/pytorch/torchdynamo/issues/132

--- a/test/test_repros.py
+++ b/test/test_repros.py
@@ -885,7 +885,7 @@ class ReproTests(torchdynamo.testing.TestCase):
         self.assertTrue(same(opt_model(input), correct))
 
         self.assertEqual(cnt.frame_count, 1)
-        self.assertEqual(cnt.op_count, ifdyn(14, 11))
+        self.assertEqual(cnt.op_count, ifdyn(13, 11))
 
     def test_slicing_dynamic_shape(self):
         def fn(y):
@@ -1155,7 +1155,7 @@ class ReproTests(torchdynamo.testing.TestCase):
         opt_fn = torchdynamo.optimize_assert(cnt)(fn)
         self.assertTrue(same(opt_fn(x), correct))
         self.assertEqual(cnt.frame_count, 1)
-        self.assertEqual(cnt.op_count, ifdyn(28, 14))
+        self.assertEqual(cnt.op_count, ifdyn(36, 14))
 
     def test_recursive_map(self):
         # https://github.com/pytorch/torchdynamo/issues/132

--- a/test/test_repros.py
+++ b/test/test_repros.py
@@ -1608,6 +1608,8 @@ class ReproTests(torchdynamo.testing.TestCase):
         opt_fn(x)
         self.assertEqual(cnt.frame_count, 1)
 
+    # This doesn't work without fake tensors but I don't care
+    @patch.object(torchdynamo.config, "fake_tensor_propagation", True)
     def test_issue1466_size_aot_autograd(self):
         def fn(x):
             # do a tensor op and a size compute

--- a/test/test_repros.py
+++ b/test/test_repros.py
@@ -1155,7 +1155,7 @@ class ReproTests(torchdynamo.testing.TestCase):
         opt_fn = torchdynamo.optimize_assert(cnt)(fn)
         self.assertTrue(same(opt_fn(x), correct))
         self.assertEqual(cnt.frame_count, 1)
-        self.assertEqual(cnt.op_count, ifdyn(36, 14))
+        self.assertEqual(cnt.op_count, ifdyn(29, 14))
 
     def test_recursive_map(self):
         # https://github.com/pytorch/torchdynamo/issues/132

--- a/torchdynamo/variables/lists.py
+++ b/torchdynamo/variables/lists.py
@@ -277,9 +277,12 @@ class SizeVariable(TupleVariable):
             # hand at this point
             return torch.Size([])
         tracer = self.items[0].as_proxy().tracer
-        proxy = tracer.create_proxy("call_function", torch.Size, (self._as_proxy(),), {})
+        proxy = tracer.create_proxy(
+            "call_function", torch.Size, (self._as_proxy(),), {}
+        )
         proxy.node.meta["example_value"] = torch.Size(
-            [p.node.meta["example_value"] for p in self._as_proxy()])
+            [p.node.meta["example_value"] for p in self._as_proxy()]
+        )
         return proxy
 
     def reconstruct(self, codegen):

--- a/torchdynamo/variables/lists.py
+++ b/torchdynamo/variables/lists.py
@@ -1,5 +1,6 @@
 from typing import Dict
 from typing import List
+from typing import Optional
 
 import torch
 import torch.fx
@@ -249,10 +250,22 @@ class TupleVariable(BaseListVariable):
 class SizeVariable(TupleVariable):
     """torch.Size(...)"""
 
+    def __init__(
+        self,
+        items: List[VariableTracker],
+        proxy: Optional[torch.fx.Proxy] = None,
+        **kwargs,
+    ):
+        self.proxy = proxy
+        super().__init__(items, **kwargs)
+
     def python_type(self):
         return torch.Size
 
     def as_proxy(self):
+        if self.proxy is not None:
+            return self.proxy
+
         # torch.Size needs special handling.  Normally, we pun a list-like
         # container to directly contain Proxy/Node objects from FX, and FX
         # knows to look inside containers (via map_aggregate).  But torch.Size

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -187,7 +187,7 @@ class TensorVariable(VariableTracker):
                 proxy_i = proxy[i]
                 proxy_i.node.meta["example_value"] = v
                 sizes.append(DynamicShapeVariable(proxy_i, int))
-            return SizeVariable(sizes, **options)
+            return SizeVariable(sizes, proxy, **options)
         elif istype(example_value, int) and proxy.node.target in (
             torch.seed,
             operator.mod,

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -177,14 +177,14 @@ class TensorVariable(VariableTracker):
 
             options.update(specialized_props)
             return cls(proxy, **options)
-        elif (
-            istype(example_value, (int, bool, float))
-            and config.dynamic_shapes
-        ):
+        elif istype(example_value, (int, bool, float)) and config.dynamic_shapes:
             proxy.node.meta["example_value"] = example_value
             return DynamicShapeVariable(proxy, type(example_value), **options)
         elif istype(example_value, torch.Size) and config.dynamic_shapes:
-            sizes = [DynamicShapeVariable(proxy[i], int) for i in range(len(example_value))]
+            proxy.node.meta["example_value"] = example_value
+            sizes = [
+                DynamicShapeVariable(proxy[i], int) for i in range(len(example_value))
+            ]
             return SizeVariable(sizes, **options)
         elif istype(example_value, int) and proxy.node.target in (
             torch.seed,
@@ -503,22 +503,18 @@ class TensorVariable(VariableTracker):
 
 
 class DynamicShapeVariable(TensorVariable):
-    def __init__(self, proxy, dyn_shape_cls, dyn_shape_len=None, **kwargs):
+    """
+    Represents a symbolic size, e.g., as returned by tensor.size(0)
+    """
+
+    def __init__(self, proxy, dyn_shape_cls, **kwargs):
         super(DynamicShapeVariable, self).__init__(proxy, **kwargs)
         self.dyn_shape_cls = dyn_shape_cls
-        self.dyn_shape_len = dyn_shape_len
 
     def python_type(self):
         return self.dyn_shape_cls
 
     def unpack_var_sequence(self, tx):
-        if self.dyn_shape_len is not None:
-            return [
-                variables.BuiltinVariable(
-                    operator.getitem, **VariableTracker.propagate(self)
-                ).call_function(tx, [self, variables.ConstantVariable(i)], {})
-                for i in range(self.dyn_shape_len)
-            ]
         super(DynamicShapeVariable, self).unpack_var_sequence(tx)
 
 

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -178,13 +178,14 @@ class TensorVariable(VariableTracker):
             options.update(specialized_props)
             return cls(proxy, **options)
         elif (
-            istype(example_value, (torch.Size, int, bool, float))
+            istype(example_value, (int, bool, float))
             and config.dynamic_shapes
         ):
             proxy.node.meta["example_value"] = example_value
-            if isinstance(example_value, torch.Size):
-                options["dyn_shape_len"] = len(example_value)
             return DynamicShapeVariable(proxy, type(example_value), **options)
+        elif istype(example_value, torch.Size) and config.dynamic_shapes:
+            sizes = [DynamicShapeVariable(proxy[i], int) for i in range(len(example_value))]
+            return SizeVariable(sizes, **options)
         elif istype(example_value, int) and proxy.node.target in (
             torch.seed,
             operator.mod,

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -182,9 +182,11 @@ class TensorVariable(VariableTracker):
             return DynamicShapeVariable(proxy, type(example_value), **options)
         elif istype(example_value, torch.Size) and config.dynamic_shapes:
             proxy.node.meta["example_value"] = example_value
-            sizes = [
-                DynamicShapeVariable(proxy[i], int) for i in range(len(example_value))
-            ]
+            sizes = []
+            for i, v in enumerate(example_value):
+                proxy_i = proxy[i]
+                proxy_i.node.meta["example_value"] = v
+                sizes.append(DynamicShapeVariable(proxy_i, int))
             return SizeVariable(sizes, **options)
         elif istype(example_value, int) and proxy.node.target in (
             torch.seed,


### PR DESCRIPTION
The general strategy is to represent each Size of a torch.Size individually, rather than also having a variable that collects everything. However, we have to workaround problems with torch.Size not accepting Node/Proxy as members. There's also an optimization to directly use a torch.Size proxy if we have one (which sometimes we do.)