### PR TITLE
DDPOptimizer: register_attr_or_module -> add_submodule

### DIFF
--- a/torchdynamo/optimizations/distributed.py
+++ b/torchdynamo/optimizations/distributed.py
@@ -165,7 +165,7 @@ class DDPOptimizer:
                         compiled_submod = self.compile_submod(submod, args, kwargs)
                         n.target = "compiled_" + n.target
                         self.module.delete_submodule(n.target)
-                        self.module.register_attr_or_module(n.target, compiled_submod)
+                        self.module.add_submodule(n.target, compiled_submod)
 
                     # then we execute the modified node using the usual logic
                     return getattr(self, n.op)(n.target, args, kwargs)


### PR DESCRIPTION
self.module is a raw torch.fx.GraphModule, not an OutputModule. So register_attr_or_module doesn't exist on self.module.