### PR TITLE
Don't use decomp for index_{add,add_}

### DIFF
--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -47,8 +47,6 @@ decompositions = get_decompositions(
         aten.hardtanh,
         aten.hardtanh_backward,
         aten.im2col,
-        aten.index_add,
-        aten.index_add_,
         aten.index_select,
         aten.l1_loss,
         aten.leaky_relu,


### PR DESCRIPTION
Fix #1356 

As the decomp for ```index_{add,add_}``` is not correct when ```dim > 0```, so we should not use them.