### PR TITLE
Fix lowering for isinf and isnan for int/bool types

### DIFF
--- a/test/test_torchinductor_opinfo.py
+++ b/test/test_torchinductor_opinfo.py
@@ -360,8 +360,6 @@ inductor_expected_failures_single_sample["cuda"] = {
     "index_copy": {f16, f32, f64},
     "index_reduce": {f16, f32, f64},
     "inner": {f16, f32, f64},
-    "isinf": {b8, i32, i64},
-    "isnan": {b8, i32, i64},
     "istft": {f32, f64},
     "linalg.cholesky": {f32, f64},
     "linalg.cholesky_ex": {f32, f64},

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -493,6 +493,22 @@ def squeeze_(x, dim=None):
     return x
 
 
+@register_lowering(aten.isinf)
+def isinf(x):
+    if is_integer_type(x):
+        return full_like(x, False, dtype=torch.bool)
+    fn = ops_wrapper("isinf")
+    return make_pointwise(fn, override_return_dtype=torch.bool)(x)
+
+
+@register_lowering(aten.isnan)
+def isnan(x):
+    if is_integer_type(x):
+        return full_like(x, False, dtype=torch.bool)
+    fn = ops_wrapper("isnan")
+    return make_pointwise(fn, override_return_dtype=torch.bool)(x)
+
+
 @register_lowering(aten.ceil)
 def ceil(x):
     if is_integer_type(x):
@@ -3163,8 +3179,6 @@ register_pointwise(
 register_pointwise(aten.ceil)
 register_pointwise(aten.fmod)
 register_pointwise(aten.signbit, override_return_dtype=torch.bool)
-register_pointwise(aten.isinf, override_return_dtype=torch.bool)
-register_pointwise(aten.isnan, override_return_dtype=torch.bool)
 
 register_pointwise(aten.le, type_promotion_kind=None, override_return_dtype=torch.bool)
 register_pointwise(aten.lt, type_promotion_kind=None, override_return_dtype=torch.bool)


### PR DESCRIPTION
Ideally, we should implement this as decomp. 

However, we need decomp with precondition to avoid infinite recursive decomp. 