### PR TITLE
Update CI for TIMM models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,7 +499,7 @@ jobs:
           command: |
             source .circleci/setup_env.sh
             make develop
-            python benchmarks/timm_models.py --accuracy --ci --skip-accuracy-check -d cuda --inductor --float32 --training \
+            python benchmarks/timm_models.py --accuracy --ci -d cuda --inductor --float32 --training \
               --total-partitions 6 --partition-id 0 --output=inductor_timm_training_0.csv
       - store_artifacts:
           path: inductor_timm_training_0.csv
@@ -522,7 +522,7 @@ jobs:
           command: |
             source .circleci/setup_env.sh
             make develop
-            python benchmarks/timm_models.py --accuracy --ci --skip-accuracy-check -d cuda --inductor --float32 --training \
+            python benchmarks/timm_models.py --accuracy --ci -d cuda --inductor --float32 --training \
               --total-partitions 6 --partition-id 1 --output=inductor_timm_training_1.csv
       - store_artifacts:
           path: inductor_timm_training_1.csv
@@ -545,7 +545,7 @@ jobs:
           command: |
             source .circleci/setup_env.sh
             make develop
-            python benchmarks/timm_models.py --accuracy --ci --skip-accuracy-check -d cuda --inductor --float32 --training \
+            python benchmarks/timm_models.py --accuracy --ci -d cuda --inductor --float32 --training \
               --total-partitions 6 --partition-id 2 --output=inductor_timm_training_2.csv
       - store_artifacts:
           path: inductor_timm_training_2.csv
@@ -568,7 +568,7 @@ jobs:
           command: |
             source .circleci/setup_env.sh
             make develop
-            python benchmarks/timm_models.py --accuracy --ci --skip-accuracy-check -d cuda --inductor --float32 --training \
+            python benchmarks/timm_models.py --accuracy --ci -d cuda --inductor --float32 --training \
               --total-partitions 6 --partition-id 3 --output=inductor_timm_training_3.csv
       - store_artifacts:
           path: inductor_timm_training_3.csv
@@ -592,7 +592,7 @@ jobs:
           command: |
             source .circleci/setup_env.sh
             make develop
-            python benchmarks/timm_models.py --accuracy --ci --skip-accuracy-check -d cuda --inductor --float32 --training \
+            python benchmarks/timm_models.py --accuracy --ci -d cuda --inductor --float32 --training \
               --total-partitions 6 --partition-id 4 --output=inductor_timm_training_4.csv
       - store_artifacts:
           path: inductor_timm_training_4.csv
@@ -615,7 +615,7 @@ jobs:
           command: |
             source .circleci/setup_env.sh
             make develop
-            python benchmarks/timm_models.py --accuracy --ci --skip-accuracy-check -d cuda --inductor --float32 --training \
+            python benchmarks/timm_models.py --accuracy --ci -d cuda --inductor --float32 --training \
               --total-partitions 6 --partition-id 5 --output=inductor_timm_training_5.csv
       - store_artifacts:
           path: inductor_timm_training_5.csv

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -169,9 +169,12 @@ CI_SKIP_INDUCTOR_TRAINING = [
     # TIMM
     "cait_m36_384",  # fp64_OOM
     "coat_lite_mini",  # time out
+    "convit_base",  # fp64_OOM
     "rexnet_100",  # accuracy
     "swin_base_patch4_window7_224",
     "twins_pcpvt_base",  # time out
+    "volo_d1_224",  # accuracy
+    "xcit_large_24_p8_224",  # fp64_OOM
 ]
 
 

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -168,27 +168,6 @@ CI_SKIP_INDUCTOR_TRAINING = [
     "AlbertForQuestionAnswering",
     # TIMM
     "cait_m36_384",  # fp64_OOM
-    "convit_base",
-    "coat_lite_mini",
-    "convnext_base",
-    "deit_base_distilled_patch16_224",
-    "dla102",
-    "dpn107",
-    "levit_128",
-    "mobilevit_s",
-    "rexnet_100",
-    "swin_base_patch4_window7_224",
-    "twins_pcpvt_base",
-    # OOM with batch_size = 2
-    "swsl_resnext101_32x16d",
-    # https://github.com/pytorch/torchdynamo/issues/1135
-    "gmixer_24_224",
-    "gmlp_s16_224",
-    "jx_nest_base",
-    "mixer_b16_224",
-    "tnt_s_patch16_224",
-    "volo_d1_224",
-    "xcit_large_24_p8_224",
 ]
 
 

--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -168,6 +168,10 @@ CI_SKIP_INDUCTOR_TRAINING = [
     "AlbertForQuestionAnswering",
     # TIMM
     "cait_m36_384",  # fp64_OOM
+    "coat_lite_mini",  # time out
+    "rexnet_100",  # accuracy
+    "swin_base_patch4_window7_224",
+    "twins_pcpvt_base",  # time out
 ]
 
 

--- a/benchmarks/timm_models.py
+++ b/benchmarks/timm_models.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 import time
 import warnings
-from urllib.error import HTTPError
 
 import torch
 from common import BenchmarkRunner
@@ -216,7 +215,7 @@ class TimmRunnner(BenchmarkRunner):
                     # drop_block_rate=kwargs.pop('drop_block', None),
                 )
                 success = True
-            except HTTPError:
+            except Exception:
                 wait = retries * 30
                 time.sleep(wait)
                 retries += 1


### PR DESCRIPTION
Summary:
1) Relax the exception check for retry when pretrain model download fails; 
2) Enable accuracy checking for inductor training as we are over 90% passing on TIMM