### PR TITLE
DDPOptimizer: recompile graph after replacing subgraphs

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -137,6 +137,28 @@ class TestDistributed(torchdynamo.testing.TestCase):
         reason="requires pytorch landing in parallel",
     )
     @patch.object(config, "optimize_ddp", True)
+    def test_graph_split_inductor(self):
+        """
+        Same as above, but using inductor backend.
+        We observed issues with inductor/fx interface in the past.
+        """
+        m, inputs, correct_outputs = self.get_model()
+        ddp_m = DDP(m, device_ids=self.device_ids, bucket_cap_mb=25)
+
+        check_splits_compiler = CheckSplitsCompiler()
+
+        @torchdynamo.optimize("inductor")
+        def opt_fn(inputs):
+            return ddp_m(inputs)
+
+        opt_outputs = opt_fn(inputs)
+        self.assertTrue(same(correct_outputs, opt_outputs))
+
+    @pytest.mark.skipif(
+        not hasattr(DDP, "_get_active_ddp_module"),
+        reason="requires pytorch landing in parallel",
+    )
+    @patch.object(config, "optimize_ddp", True)
     def test_no_split(self):
         """
         Ensures the DDPOptimizer returns a correct, compiled module without

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -145,8 +145,6 @@ class TestDistributed(torchdynamo.testing.TestCase):
         m, inputs, correct_outputs = self.get_model()
         ddp_m = DDP(m, device_ids=self.device_ids, bucket_cap_mb=25)
 
-        check_splits_compiler = CheckSplitsCompiler()
-
         @torchdynamo.optimize("inductor")
         def opt_fn(inputs):
             return ddp_m(inputs)

--- a/torchdynamo/optimizations/distributed.py
+++ b/torchdynamo/optimizations/distributed.py
@@ -163,8 +163,8 @@ class DDPOptimizer:
                                 dump_file.write(f"\n---{n.target} graph---")
                                 dump_file.write(str(submod.graph))
                         compiled_submod = self.compile_submod(submod, args, kwargs)
-                        n.target = "compiled_" + n.target
                         self.module.delete_submodule(n.target)
+                        n.target = "compiled_" + n.target
                         self.module.add_submodule(n.target, compiled_submod)
 
                     # then we execute the modified node using the usual logic
@@ -172,6 +172,7 @@ class DDPOptimizer:
 
         submod_compiler = SubmodCompiler(split_gm, self.backend_compile_fn, self.debug)
         submod_compiler.run(*example_inputs)
+        split_gm.recompile()
 
         if self.debug:
             with open("debug_ddp_optimizer.log", "a") as dump_file:


### PR DESCRIPTION
DDPOptimizer does the following:
1. split up the graph into submodules
2. replace each of the submodules with a compiled submodule

After step 2, we weren't calling `graph_module.recompile()`, which caused us to call the old submodules. The old submodules didn't have the step that unwraps tuples, which caused type errors, described below.

The old submodules will wrap outputs in tuples, even if there's only a single output. So we might have submodule1 which should output a tensor that is consumed by submodule2. In this case we need to unwrap the output tuple from submodule 1; that's what WrapperModule does. But since we weren't recompiling, the graph_module was still calling the old submodules.

For some reason, this issue only occurred when using inductor backend.

I verified locally that the new test passes.