### PR TITLE
Adding test for #1368

### DIFF
--- a/benchmarks/common.py
+++ b/benchmarks/common.py
@@ -68,7 +68,6 @@ CI_SKIP_AOT_EAGER_TRAINING = [
     "pytorch_struct",
     "speech_transformer",
     "vision_maskrcnn",
-    "moco",
     # Huggingface
     "AlbertForMaskedLM",  # OOM
     "AlbertForQuestionAnswering",  # OOM


### PR DESCRIPTION
Leaving a PR so that we don't forget to add a test when #1368 gets fixed in PyTorch core.

It will fail for a few days until we fix the error and also PyTorch pin gets updated.