### PR TITLE
[inductor] Only skip CPU tests when host cpp compiler not found

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -55,7 +55,7 @@ try:
     CppCodeCache.load("")
     HAS_CPU = True
 except (CalledProcessError, OSError):
-    raise unittest.SkipTest("Did not find a working c++ compiler")
+    pass
 
 aten = torch.ops.aten
 


### PR DESCRIPTION
FB-internal build isn't set up to invoke a c++ compiler, just triton/ptxas.  So we can still run the GPU tests even if the CPU is skipped.