### PR TITLE
Graph Break for Unsupported Fake Tensor Instead of Throwing

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1535,14 +1535,12 @@ class MiscTests(torchdynamo.testing.TestCase):
     @patch.object(torchdynamo.config, "fake_tensor_propagation", True)
     def test_unsupported_fake_tensor(self):
         def f(x):
-            return torch.quantize_per_tensor(
-                torch.tensor([-1.0, 0.0, 1.0, 2.0]), 0.1, 10, torch.quint8
-            )
+            return torch.quantize_per_tensor(x, 0.1, 10, torch.quint8)
 
         x = torch.randn(2, 2)
-        with self.assertRaises(RuntimeError):
-            opt_f = torchdynamo.optimize_assert(torchdynamo.testing.CompileCounter())(f)
-            opt_f(x)
+        cnts = torchdynamo.testing.CompileCounter()
+        opt_f = torchdynamo.optimize(cnts)(f)
+        self.assertEqual(cnts.op_count, 0)
 
         torchdynamo.reset()
         with patch.object(torchdynamo.config, "fake_tensor_propagation", False):

--- a/torchdynamo/exc.py
+++ b/torchdynamo/exc.py
@@ -1,4 +1,3 @@
-import dataclasses
 import os
 import textwrap
 
@@ -23,11 +22,6 @@ class SkipFrame(TorchDynamoException):
 
 class TorchRuntimeError(TorchDynamoException):
     pass
-
-
-@dataclasses.dataclass
-class FakeTensorError(TorchDynamoException):
-    reason: str
 
 
 class ResetRequired(TorchDynamoException):

--- a/torchdynamo/utils.py
+++ b/torchdynamo/utils.py
@@ -712,12 +712,13 @@ try:
         try:
             return fn()
         except UnsupportedFakeTensorException as e:
-            from .exc import FakeTensorError
+            from .exc import unimplemented
 
-            raise FakeTensorError(
+            log.warning(
                 f"Unsupported: {e.reason} with fake tensor propagation. "
                 "Run with config.fake_tensor_propagation=False"
-            ) from e
+            )
+            raise unimplemented(f"Unsupported: {e.reason} with fake tensor propagation")
 
     def wrap_to_fake_tensor(e, fake_mode):
         if type(e) in (torch.Tensor, torch.nn.Parameter):

--- a/torchdynamo/variables/tensor.py
+++ b/torchdynamo/variables/tensor.py
@@ -27,6 +27,7 @@ from torch.utils._pytree import tree_map
 from .. import config
 from .. import variables
 from ..exc import TorchRuntimeError
+from ..exc import Unsupported
 from ..exc import unimplemented
 from ..guards import GuardBuilder
 from ..source import AttrSource
@@ -136,6 +137,8 @@ class TensorVariable(VariableTracker):
                         example_value = wrap_fake_exception(
                             lambda: cls.run_proxy(proxy, args, kwargs, nnmodule)
                         )
+                except Unsupported:
+                    raise
                 except RuntimeError as e:
                     if use_fake_tensors and isinstance(e, DataDependentOutputException):
                         if (


### PR DESCRIPTION
Previously we would propagate an error to the user if Fake Tensor didn't support some pytorch feature - say, quantization. This caused @mlazos to disable some pytorch tests with torchdynamo.

I think we should just log a warning and graph break instead of the hard error. 