### PR TITLE
Catch InvalidCxxCompiler when starting tests

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -54,7 +54,7 @@ try:
 
     CppCodeCache.load("")
     HAS_CPU = True
-except (CalledProcessError, OSError):
+except (CalledProcessError, OSError, torchinductor.exc.InvalidCxxCompiler):
     pass
 
 aten = torch.ops.aten


### PR DESCRIPTION
This happens when we try to run tests in a "sandboxed" environment that only contains specifically listed dependences (which currently don't include a c++ compiler).