### PR TITLE
Fix triton dependency issue

### DIFF
--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -26,6 +26,8 @@ dynamo_utils = import_module(f"{config.dynamo_import}.utils")
 
 @functools.lru_cache(None)
 def has_triton():
+    if not torch.cuda.is_available():
+        return False
     try:
         import triton
 


### PR DESCRIPTION
From #1501.

Fixes issue where CPU-torchinductor requires triton if any version of it (including wrong ones) is installed.