### PR TITLE
DDPOptimizer: accept list output as compiled submodule output

### DIFF
--- a/torchdynamo/optimizations/distributed.py
+++ b/torchdynamo/optimizations/distributed.py
@@ -140,6 +140,8 @@ class DDPOptimizer:
                         if not isinstance(sn.args[0], tuple):
                             unwrap_singleton_tuple = True
                             sn.args = (sn.args,)
+                submod.recompile()
+
                 wrapper = WrapperModule(
                     self.compiler(submod, args),
                     unwrap_singleton_tuple,

--- a/torchdynamo/optimizations/distributed.py
+++ b/torchdynamo/optimizations/distributed.py
@@ -130,9 +130,7 @@ class DDPOptimizer:
                         # for some reason the isinstance check is necessary if I split one node per submod
                         # - even though I supposedly wrapped the output in a tuple in those cases, the real
                         # compiled module was still returning a tensor
-                        if self.unwrap_singleton_tuple and (
-                            isinstance(x, tuple) or isinstance(x, list)
-                        ):
+                        if self.unwrap_singleton_tuple and isinstance(x, (tuple, list)):
                             return x[0]
                         return x
 

--- a/torchdynamo/optimizations/distributed.py
+++ b/torchdynamo/optimizations/distributed.py
@@ -130,7 +130,9 @@ class DDPOptimizer:
                         # for some reason the isinstance check is necessary if I split one node per submod
                         # - even though I supposedly wrapped the output in a tuple in those cases, the real
                         # compiled module was still returning a tensor
-                        if self.unwrap_singleton_tuple and (isinstance(x, tuple) or isinstance(x, list)):
+                        if self.unwrap_singleton_tuple and (
+                            isinstance(x, tuple) or isinstance(x, list)
+                        ):
                             return x[0]
                         return x
 

--- a/torchdynamo/optimizations/distributed.py
+++ b/torchdynamo/optimizations/distributed.py
@@ -130,7 +130,7 @@ class DDPOptimizer:
                         # for some reason the isinstance check is necessary if I split one node per submod
                         # - even though I supposedly wrapped the output in a tuple in those cases, the real
                         # compiled module was still returning a tensor
-                        if self.unwrap_singleton_tuple and isinstance(x, tuple):
+                        if self.unwrap_singleton_tuple and (isinstance(x, tuple) or isinstance(x, list)):
                             return x[0]
                         return x
 


### PR DESCRIPTION
Not sure why we need to do this, filed an issue to investigate further: https://github.com/pytorch/torchdynamo/issues/1545

Also added a missing recompile, although I don't think it does anything here in the inductor case