### PR TITLE
Logging nit

### DIFF
--- a/torchdynamo/logging.py
+++ b/torchdynamo/logging.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import os
 
@@ -23,7 +24,7 @@ LOGGING_CONFIG = {
     "version": 1,
     "formatters": {
         "torchdynamo_format": {
-            "format": "%(name)s: [%(levelname)s] [%(asctime)s] %(message)s"
+            "format": "[%(asctime)s] %(name)s: [%(levelname)s] %(message)s"
         },
     },
     "handlers": {
@@ -74,13 +75,11 @@ def init_logging(log_level, log_file_name=None):
 # def fn():
 #     _step_logger()(logging.INFO, "msg")
 
-_step_counter = 1
+_step_counter = itertools.count(1)
 
 
 def get_step_logger(logger):
-    global _step_counter
-    step = _step_counter
-    _step_counter += 1
+    step = next(_step_counter)
 
     def log(level, msg):
         logger.log(level, f"Step {step}: {msg}")

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -1,5 +1,6 @@
 import dataclasses
 import functools
+import itertools
 import logging
 from typing import List
 
@@ -304,7 +305,7 @@ def count_tangents(fx_g: torch.fx.GraphModule):
     return len(static_arg_idxs)
 
 
-_graph_counter = 0
+_graph_counter = itertools.count(0)
 
 
 def compile_fx(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]):
@@ -323,9 +324,7 @@ def compile_fx(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]
     num_example_inputs = len(example_inputs_)
     cudagraphs = BoxedBool(config.triton.cudagraphs)
 
-    global _graph_counter
-    graph_id = _graph_counter
-    _graph_counter += 1
+    graph_id = next(_graph_counter)
 
     @dynamo_utils.dynamo_timed
     def fw_compiler(model: torch.fx.GraphModule, example_inputs):


### PR DESCRIPTION
Move logging timestamp to beginning of log, e.g.
```
[2022-10-08 01:22:11,883] torchdynamo.eval_frame: [INFO] Step 1: torchdynamo begin tracing
[2022-10-08 01:22:11,914] torchdynamo.symbolic_convert: [WARNING] Graph break: call_function BuiltinVariable(print) [ConstantVariable(str)] {} from user code at   File "test_steps.py", line 21, in f
    print("running")

[2022-10-08 01:22:11,915] torchdynamo.output_graph: [INFO] Step 2: calling compiler function
[2022-10-08 01:22:11,918] torchdynamo.output_graph: [INFO] Step 2: done compiler function
[2022-10-08 01:22:11,978] torchinductor.compile_fx: [INFO] Step 3: torchinductor compiling FORWARDS graph 0
[2022-10-08 01:22:12,717] torchinductor.compile_fx: [INFO] Step 3: torchinductor done compiling FORWARDS graph 0
running
[2022-10-08 01:22:12,776] torchdynamo.symbolic_convert: [WARNING] Graph break: Tensor.backward from user code at   File "test_steps.py", line 23, in <graph break in f>
    z.backward()

[2022-10-08 01:22:12,777] torchdynamo.output_graph: [INFO] Step 2: calling compiler function
[2022-10-08 01:22:12,780] torchdynamo.output_graph: [INFO] Step 2: done compiler function
[2022-10-08 01:22:12,795] torchinductor.compile_fx: [INFO] Step 3: torchinductor compiling FORWARDS graph 1
[2022-10-08 01:22:12,801] torchinductor.compile_fx: [INFO] Step 3: torchinductor done compiling FORWARDS graph 1
[2022-10-08 01:22:12,802] torchinductor.compile_fx: [INFO] Step 3: torchinductor compiling BACKWARDS graph 1
[2022-10-08 01:22:12,803] torchinductor.compile_fx: [INFO] Step 3: torchinductor done compiling BACKWARDS graph 1
[2022-10-08 01:22:12,803] torchinductor.compile_fx: [INFO] Step 3: torchinductor compiling BACKWARDS graph 0
[2022-10-08 01:22:12,807] torchinductor.compile_fx: [INFO] Step 3: torchinductor done compiling BACKWARDS graph 0
[2022-10-08 01:22:12,808] torchdynamo.eval_frame: [INFO] Step 1: torchdynamo done tracing
```

Also replace use of globals for counters by using `itertools.count`.