### PR TITLE
Fix lowering for scatter_reduce

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -136,12 +136,6 @@ inductor_skips["cuda"] = {
     "nn.functional.triplet_margin_loss": {f16},
     "special.log_ndtr": {f64},
     "special.ndtr": {f64},
-    "scatter_add": {b8, f16, f32, f64, i32, i64},  # segfault
-    "scatter_reduce.amax": {f16, f32, f64, i32, i64},  # segfault
-    "scatter_reduce.amin": {f16, f32, f64, i32, i64},  # segfault
-    "scatter_reduce.mean": {f16, f32, f64, i32, i64},  # segfault
-    "scatter_reduce.prod": {f16, f32, f64, i32, i64},  # segfault
-    "scatter_reduce.sum": {b8, i64},  # segfault
     "softmax.with_dtype": {b8, f16, f32, f64, i32, i64},  # segfault
     "nn.functional.kl_div": {f64},  # segfault
     "log_softmax.dtype": {b8, f16, f32, f64, i32, i64},  # segfault
@@ -263,11 +257,8 @@ inductor_expected_failures_single_sample["cpu"] = {
     "randn_like": {f16, f32, f64},
     "repeat_interleave": {b8, f16, f32, f64, i32, i64},
     "scatter_add": {f16},
-    "scatter_reduce.amax": {b8, f16, f32, f64, i32, i64},
-    "scatter_reduce.amin": {b8, f16, f32, f64, i32, i64},
-    "scatter_reduce.mean": {f16, f32, f64, i32, i64},
-    "scatter_reduce.prod": {b8, f16, f32, f64, i32, i64},
     "scatter_reduce.sum": {f16},
+    "scatter_reduce.prod": {f16, f32, f64},
     "segment_reduce.lengths": {f16, f32, f64},
     "segment_reduce.offsets": {f16, f32, f64},
     "sgn": {f16, f32, f64},
@@ -381,6 +372,7 @@ inductor_expected_failures_single_sample["cuda"] = {
     "randn_like": {f16, f32, f64},
     "repeat_interleave": {b8, f16, f32, f64, i32, i64},
     "round.decimals_3": {f16},
+    "scatter_reduce.prod": {f16, f32, f64},
     "segment_reduce.lengths": {f16, f32, f64},
     "segment_reduce.offsets": {f16, f32, f64},
     "sgn": {f16, f32, f64},

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -415,6 +415,7 @@ inductor_all_samples = {
     "index_add",
     "index_put",
     "index_copy",
+    "scatter_reduce.sum",
 }
 
 

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1789,6 +1789,7 @@ def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = 
     if reduce not in {None, "sum"} or (
         reduce == "sum" and self.get_dtype() in {torch.bool, torch.int64}
     ):
+        self.realize()
         return fallback_scatter_reduce_(
             self, dim, index, src, reduce, include_self=include_self
         )
@@ -1800,10 +1801,10 @@ def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = 
     if ndim == 0:
         self = view(self, [1])
 
-    if len(src.get_size()) == 0:
+    if isinstance(src, TensorBox) and len(src.get_size()) == 0:
         src = view(src, [1])
 
-    if len(index.get_size()) == 0:
+    if isinstance(index, TensorBox) and len(index.get_size()) == 0:
         index = view(index, [1])
 
     assert -len(self.get_size()) <= dim < len(self.get_size())

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1779,17 +1779,33 @@ def scatter_reduce(x, dim: int, index, src, reduction_type, **kwargs):
 
 fallback_scatter_reduce_ = fallback_handler(aten.scatter_reduce_)
 
+
 @register_lowering(aten.scatter_reduce_, type_promotion_kind=None)
 def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = True):
     assert reduce in {None, "sum", "prod", "mean", "amax", "amin"}
 
     # TODO: Need to support more reduction type
     # For reduction of "sum", tl.atomic_add doesn't support bool or int64
-    if reduce not in {None, "sum"} or (reduce == "sum" and self.get_dtype() in {torch.bool, torch.int64}):
-        return fallback_scatter_reduce_(self, dim, index, src, reduce, include_self=include_self)
+    if reduce not in {None, "sum"} or (
+        reduce == "sum" and self.get_dtype() in {torch.bool, torch.int64}
+    ):
+        return fallback_scatter_reduce_(
+            self, dim, index, src, reduce, include_self=include_self
+        )
 
     assert isinstance(self, TensorBox)
     assert "int" in str(index.get_dtype())
+
+    ndim = len(self.get_size())
+    if ndim == 0:
+        self = view(self, [1])
+
+    if len(src.get_size()) == 0:
+        src = view(src, [1])
+
+    if len(index.get_size()) == 0:
+        index = view(index, [1])
+
     assert -len(self.get_size()) <= dim < len(self.get_size())
 
     self.realize()
@@ -1851,6 +1867,9 @@ def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = 
         scatter,
     )
     buffer.name = V.graph.register_buffer(buffer)
+
+    if ndim == 0:
+        self = view(self, [])
     return self
 
 

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1737,7 +1737,6 @@ def scatter_(self, dim: int, index, src, *, reduce: str = None):
     if reduce == "add":
         reduce = "sum"
     elif reduce == "multiply":
-        assert False, "TODO: multiply not supported"
         reduce = "prod"
     else:
         assert reduce is None
@@ -1759,10 +1758,17 @@ def scatter_reduce(x, dim: int, index, src, reduction_type, **kwargs):
     return scatter_reduce_(clone(x), dim, index, src, reduction_type, **kwargs)
 
 
+fallback_scatter_reduce_ = fallback_handler(aten.scatter_reduce_)
+
 @register_lowering(aten.scatter_reduce_, type_promotion_kind=None)
 def scatter_reduce_(self, dim: int, index, src, reduce, *, include_self: bool = True):
+    assert reduce in {None, "sum", "prod", "mean", "amax", "amin"}
+
     # TODO: Need to support more reduction type
-    assert reduce is None or reduce in {"sum"}
+    # For reduction of "sum", tl.atomic_add doesn't support bool or int64
+    if reduce not in {None, "sum"} or (reduce == "sum" and self.get_dtype() in {torch.bool, torch.int64}):
+        return fallback_scatter_reduce_(self, dim, index, src, reduce, include_self=include_self)
+
     assert isinstance(self, TensorBox)
     assert "int" in str(index.get_dtype())
     assert -len(self.get_size()) <= dim < len(self.get_size())


### PR DESCRIPTION
- Fallback to aten for unsupported reduction types
- Handle 0-dim tensors 