### PR TITLE
fix negative indexing value for select_scatter

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -403,6 +403,7 @@ inductor_all_samples = {
     "index_put",
     "index_copy",
     "scatter_reduce.sum",
+    "select_scatter"
 }
 
 

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -403,7 +403,7 @@ inductor_all_samples = {
     "index_put",
     "index_copy",
     "scatter_reduce.sum",
-    "select_scatter"
+    "select_scatter",
 }
 
 

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1207,6 +1207,12 @@ def select_scatter(x, src, dim: int, index: int):
     assert x.get_dtype() == src.get_dtype()
     x_loader = x.make_loader()
     dim = _validate_dim(x, dim, 0)
+    # to check that index is valid we need to freeze the size
+    size_hint = V.graph.sizevars.size_hint(x.get_size()[dim])
+    V.graph.sizevars.guard_equals(x.get_size()[dim], size_hint)
+    if index < 0:
+        index = index + size_hint
+    assert 0 <= index and index < size_hint
     src = expand(unsqueeze(src, dim), x.get_size())
     src_loader = src.make_loader()
 


### PR DESCRIPTION
Fixes #1567
However, this creates a guard on the indexed dimension - don't see a way of fixing it otherwise, symbolic ops fail. My attempts to leave only symbolic manipulation led to 
```
  File "/scratch/ngimel/work/pytorch/torch/fx/_symbolic_trace.py", line 344, in create_arg
    return super().create_arg(a)
  File "/scratch/ngimel/work/pytorch/torch/fx/proxy.py", line 140, in create_arg
    return type(a)(self.create_arg(elem) for elem in a)
  File "/scratch/ngimel/work/pytorch/torch/fx/proxy.py", line 140, in <genexpr>
    return type(a)(self.create_arg(elem) for elem in a)
  File "/scratch/ngimel/work/pytorch/torch/fx/_symbolic_trace.py", line 344, in create_arg
    return super().create_arg(a)
  File "/scratch/ngimel/work/pytorch/torch/fx/proxy.py", line 165, in create_arg
    raise NotImplementedError(f"argument of type: {type(a)}")
NotImplementedError: argument of type: <class 'sympy.core.add.Add'>
```
in inductor compilation.
cc @chillee, this will be problematic for dynamic shapes. 