### PR TITLE
Fix DDPOptimizer for custom layers

### DIFF
--- a/test/dynamo/test_distributed.py
+++ b/test/dynamo/test_distributed.py
@@ -181,7 +181,6 @@ class TestDistributed(torchdynamo.testing.TestCase):
         opt_outputs.sum().backward()
         self.assertTrue(same(correct_outputs, opt_outputs))
 
-
     @pytest.mark.skipif(
         not hasattr(DDP, "_get_active_ddp_module"),
         reason="requires pytorch landing in parallel",
@@ -240,7 +239,6 @@ class TestDistributed(torchdynamo.testing.TestCase):
         self.assertTrue(same(correct_outputs, opt_outputs))
         self.assertEqual(check_splits_compiler.compiler_called, 3)
 
-
     def test_empty_graph(self):
         def fn():
             get_world_size = torch.distributed.distributed_c10d.get_world_size()
@@ -253,4 +251,3 @@ class TestDistributed(torchdynamo.testing.TestCase):
         except Exception:
             pass
         self.assertEqual(res, 1)
-

--- a/test/dynamo/test_distributed.py
+++ b/test/dynamo/test_distributed.py
@@ -195,3 +195,61 @@ class TestDistributed(torchdynamo.testing.TestCase):
         opt_outputs = opt_fn(inputs)
         opt_outputs.sum().backward()
         self.assertTrue(same(correct_outputs, opt_outputs))
+
+    @pytest.mark.skipif(
+        not hasattr(DDP, "_get_active_ddp_module"),
+        reason="requires pytorch landing in parallel",
+    )
+    @patch.object(config, "optimize_ddp", True)
+    def test_custom_layer(self):
+        """
+        Just ensures that the appropriate number of splits happen (based on
+        bucket size and model parameters) - verifies the number of times
+        the user-provided compiler is called by the DDPOptimizer which is
+        doing the graph splitting
+        """
+
+        class MyCustomLinear(torch.nn.Module):
+            def __init__(self):
+                super(MyCustomLinear, self).__init__()
+                self.weight = nn.Parameter(torch.randn(512, 512))
+
+            def forward(self, x):
+                return torch.mm(x, self.weight.t())
+
+        class MyLinear(torch.nn.Module):
+            def __init__(self):
+                super(MyLinear, self).__init__()
+                self.linear = torch.nn.Linear(512, 512)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                mods = [
+                    (MyLinear(), torch.nn.ReLU()),
+                    # sandwitch the custom in the middle so it comes before and after
+                    (MyCustomLinear(), torch.nn.ReLU()),
+                    (MyLinear(), torch.nn.ReLU()),
+                ]
+                self.seq = torch.nn.Sequential(*[x for items in mods for x in items])
+
+            def forward(self, x):
+                return self.seq(x)
+
+        m = MyModule().to(self.device)
+        inputs = torch.randn((512, 512)).to(self.device)
+        correct_outputs = m(inputs)
+        ddp_m = DDP(m, device_ids=self.device_ids, bucket_cap_mb=1)
+
+        check_splits_compiler = CheckSplitsCompiler()
+
+        @torchdynamo.optimize(check_splits_compiler.compile_fn)
+        def opt_fn(inputs):
+            return ddp_m(inputs)
+
+        opt_outputs = opt_fn(inputs)
+        self.assertTrue(same(correct_outputs, opt_outputs))
+        self.assertEqual(check_splits_compiler.compiler_called, 3)

--- a/torchdynamo/optimizations/distributed.py
+++ b/torchdynamo/optimizations/distributed.py
@@ -44,13 +44,13 @@ class DDPOptimizer:
         bucket_actual_sizes = []
         node_splits = [[]]
         for node in reversed(gm.graph.nodes):
+            if node.op == "output" or node.op == "placeholder":
+                continue
+
             if bucket_bytes >= self.bucket_bytes_cap:
                 bucket_actual_sizes.insert(0, bucket_bytes)
                 bucket_bytes = 0
                 node_splits.insert(0, [])
-
-            if node.op == "output" or node.op == "placeholder":
-                continue
 
             elif node.op == "call_module":
                 target = gm.get_submodule(node.target)
@@ -63,6 +63,10 @@ class DDPOptimizer:
                 )
                 bucket_bytes += params_size_b
                 # print(f"accumulated {params_size_b} b from {node}")
+            elif node.op == "get_attr":
+                maybe_param = getattr(gm, node.target)
+                if maybe_param.requires_grad:
+                    bucket_bytes += maybe_param.storage().nbytes()
             else:
                 # TODO(whc) confirm this:
                 # (e.g. call_method, call_function aren't expected to 'have' parameters)


### PR DESCRIPTION
- attribute storage used by params that are accessed via get_attr nodes and require grad. These would be the case for params of custom layers that are traced through instead of captured as top level modules
- cosmetic fix for recording an empty graph of size 0 params before the real graphs in the splitter
- add a test for the custom layer and confirm it failed before the change