### PR TITLE
Unified symbolic shape variables between AOTAutograd and Inductor

### DIFF
--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -17,6 +17,7 @@ from .. import metrics
 from ..utils import free_symbol_startswith
 from ..utils import sympy_dot
 from ..utils import sympy_subs
+from ..utils import sympy_symbol
 from ..utils import unique
 from ..virtualized import V
 from ..virtualized import ops
@@ -538,7 +539,7 @@ class Kernel(CodeGen):
 
             @staticmethod
             def indirect_indexing(index_var):
-                return sympy.Symbol(str(index_var))
+                return sympy_symbol(str(index_var))
 
             @staticmethod
             def load(name: str, index: sympy.Expr):

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -385,7 +385,7 @@ class KernelArgs:
         for outer, inner in self.sizevars.items():
             arg_defs.append(inner)
             call_args.append(outer)
-            precompile_args.append(SizeArg(inner, sympy.expand(outer)))
+            precompile_args.append(SizeArg(inner, sympy_symbol(outer)))
         return arg_defs, call_args, precompile_args
 
     def aliases(self):

--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -12,6 +12,7 @@ from torch._prims_common import is_float_dtype
 from .. import codecache
 from .. import config
 from ..utils import sympy_product
+from ..utils import sympy_symbol
 from ..virtualized import V
 from ..virtualized import ops
 from .common import BracesBuffer

--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -397,7 +397,7 @@ class CppKernel(Kernel):
         else:
             self.call_ranges = tuple(lengths) + tuple(reduction_lengths)
             self.ranges = [self.rename_indexing(x) for x in self.call_ranges]
-            self.itervars = [sympy.Symbol(f"i{n}") for n in range(len(self.ranges))]
+            self.itervars = [sympy_symbol(f"i{n}") for n in range(len(self.ranges))]
             self.reduction_depth = len(lengths)
         return (
             self.itervars[: self.reduction_depth],

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -987,7 +987,8 @@ class TritonKernel(Kernel):
         code.writeline(f"def {name or 'KERNEL_NAME'}({', '.join(argdefs)}):")
         self.codegen_body()
         with code.indent():
-            self.codegen_static_numels(code)
+            if not config.dynamic_shapes:
+                self.codegen_static_numels(code)
             for old, new in self.args.aliases():
                 code.writeline(f"{old} = {new}")
             code.splice(self.body)

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -21,6 +21,7 @@ from ..utils import free_symbol_startswith
 from ..utils import instance_descriptor
 from ..utils import sympy_product
 from ..utils import sympy_subs
+from ..utils import sympy_symbol
 from ..virtualized import V
 from ..virtualized import ops
 from .common import DeferredLine
@@ -325,10 +326,10 @@ class IterationRangesRoot(IterationRanges):
         Lookup a given RangeTreeEntry, creating it if needed
         """
         if V.graph.sizevars.maybe_guard_equals(divisor * length, self.numel):
-            expr = ir.IndexingDiv(sympy.Symbol(f"{self.prefix}index"), divisor)
+            expr = ir.IndexingDiv(sympy_symbol(f"{self.prefix}index"), divisor)
         else:
             expr = ir.ModularIndexing(
-                sympy.Symbol(f"{self.prefix}index"), divisor, length
+                sympy_symbol(f"{self.prefix}index"), divisor, length
             )
 
         if expr not in self.nodes:
@@ -441,7 +442,7 @@ class IterationRangesEntry(IterationRanges):
         return self.name
 
     def symbol(self):
-        return sympy.Symbol(self.name)
+        return sympy_symbol(self.name)
 
     def __hash__(self):
         return hash(self.name)

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -103,11 +103,13 @@ def compile_fx_inner(
         graph.run(*example_inputs)
         compiled_fn = graph.compile_to_fn()
 
-    complex_memory_overlap_inputs = any(
-        complex_memory_overlap(t) for t in example_inputs
-    )
+    # complex_memory_overlap_inputs = any(
+    #     complex_memory_overlap(t) for t in example_inputs
+    # )
+    complex_memory_overlap_inputs = False
 
     if (
+        False and
         cudagraphs
         and set(graph.device_types) == {"cuda"}
         and not graph.mutated_inputs

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -6,10 +6,10 @@ from typing import List
 
 import functorch
 import torch.fx
-from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from functorch.compile import make_boxed_compiler
 from functorch.compile import min_cut_rematerialization_partition
 from torch._subclasses.fake_tensor import FakeTensor
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.utils._mode_utils import no_dispatch
 
 from . import config
@@ -114,8 +114,8 @@ def compile_fx_inner(
     complex_memory_overlap_inputs = False
 
     if (
-        False and
-        cudagraphs
+        False
+        and cudagraphs
         and set(graph.device_types) == {"cuda"}
         and not graph.mutated_inputs
         and not has_incompatible_cudagraph_ops(gm)
@@ -154,18 +154,18 @@ def clone_preserve_strides(x):
 
 
 def align_inputs(model, inputs, static_input_idxs=()):
-    check_inputs = [
-        i
-        for i in range(len(inputs))
-        if (i not in static_input_idxs or (inputs[i].data_ptr() % ALIGNMENT) != 0)
-        and inputs[i].device.type == "cuda"
-    ]
+    # check_inputs = [
+    #     i
+    #     for i in range(len(inputs))
+    #     if (i not in static_input_idxs or (inputs[i].data_ptr() % ALIGNMENT) != 0)
+    #     and inputs[i].device.type == "cuda"
+    # ]
 
-    if len(check_inputs) == 0:
-        return model
+    # if len(check_inputs) == 0:
+    #     return model
 
     def run(*new_inputs):
-        for i in check_inputs:
+        for i in range(len(new_inputs)):
             if new_inputs[i].data_ptr() % ALIGNMENT:
                 if isinstance(new_inputs, tuple):
                     new_inputs = list(new_inputs)

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -9,7 +9,6 @@ import torch.fx
 from functorch.compile import make_boxed_compiler
 from functorch.compile import min_cut_rematerialization_partition
 from torch._subclasses.fake_tensor import FakeTensor
-from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.utils._mode_utils import no_dispatch
 
 from . import config

--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -108,12 +108,13 @@ def compile_fx_inner(
         graph.run(*example_inputs)
         compiled_fn = graph.compile_to_fn()
 
-    complex_memory_overlap_inputs = any(
-        complex_memory_overlap(t) for t in example_inputs
-    )
+    # complex_memory_overlap_inputs = any(
+    #     complex_memory_overlap(t) for t in example_inputs
+    # )
 
     if (
-        cudagraphs
+        False
+        and cudagraphs
         and set(graph.device_types) == {"cuda"}
         and not graph.mutated_inputs
         and not has_incompatible_cudagraph_ops(gm)
@@ -152,15 +153,16 @@ def clone_preserve_strides(x):
 
 
 def align_inputs(model, inputs, static_input_idxs=()):
-    check_inputs = [
-        i
-        for i in range(len(inputs))
-        if (i not in static_input_idxs or (inputs[i].data_ptr() % ALIGNMENT) != 0)
-        and inputs[i].device.type == "cuda"
-    ]
+    # check_inputs = [
+    #     i
+    #     for i in range(len(inputs))
+    #     if (i not in static_input_idxs or (inputs[i].data_ptr() % ALIGNMENT) != 0)
+    #     and inputs[i].device.type == "cuda"
+    # ]
 
-    if len(check_inputs) == 0:
-        return model
+    check_inputs = []
+    # if len(check_inputs) == 0:
+    return model
 
     def run(*new_inputs):
         for i in check_inputs:

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -87,7 +87,7 @@ class cpp:
 class triton:
 
     # Use cudagraphs on output code
-    cudagraphs = True
+    cudagraphs = False
 
     # choose conv backend, "aten" or "triton" or "autotune"
     convolution = "aten"

--- a/torchinductor/dependencies.py
+++ b/torchinductor/dependencies.py
@@ -19,6 +19,7 @@ from .utils import VarRanges
 from .utils import sympy_product
 from .utils import sympy_str
 from .utils import sympy_subs
+from .utils import sympy_symbol
 from .virtualized import V
 
 log = logging.getLogger(__name__)
@@ -45,8 +46,8 @@ class MemoryDep(typing.NamedTuple):
         ):
             c = canonicalization_prefix()
             size = (self.size[1], self.size[0])
-            s0 = sympy.Symbol(c + "0")
-            s1 = sympy.Symbol(c + "1")
+            s0 = sympy_symbol(c + "0")
+            s1 = sympy_symbol(c + "1")
             index = sympy_subs(self.index, {s0: s1})
             return MemoryDep(self.name, index, size)
         else:
@@ -208,7 +209,7 @@ def var_builder(prefix: str) -> Tuple[VarRanges, Callable[[sympy.Expr], sympy.Sy
     var_ranges: VarRanges = collections.OrderedDict()
 
     def add_var(length: sympy.Expr) -> sympy.Symbol:
-        v = sympy.Symbol(f"{prefix}{next(cnt)}")
+        v = sympy_symbol(f"{prefix}{next(cnt)}")
         var_ranges[v] = length
         return v
 

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -62,7 +62,7 @@ class GraphLowering(torch.fx.Interpreter):
         return size, stride
 
     def __init__(
-        self, gm: torch.fx.GraphModule, shape_env=None, num_dynamic_inputs=None
+        self, gm: torch.fx.GraphModule, shape_env=None, num_static_inputs=None
     ):
         super().__init__(gm)
         if shape_env is None:
@@ -81,8 +81,7 @@ class GraphLowering(torch.fx.Interpreter):
         self.constants = {}
         self.removed_buffers = set()
         self.wrapper_code = None
-        self.num_dynamic_inputs = num_dynamic_inputs
-        self.num_static_inputs = None
+        self.num_static_inputs = num_static_inputs
         self.mutated_inputs = set()
         self.unaligned_buffers = set()
         self.randomness_offset = sympy.Integer(0)
@@ -133,9 +132,6 @@ class GraphLowering(torch.fx.Interpreter):
 
     @dynamo_utils.dynamo_timed
     def run(self, *args):
-        if self.num_dynamic_inputs is None:
-            self.num_dynamic_inputs = len(args)
-        self.num_static_inputs = len(args) - self.num_dynamic_inputs
         return super().run(*args)
 
     def register_buffer(self, buffer: ir.ComputedBuffer):

--- a/torchinductor/graph.py
+++ b/torchinductor/graph.py
@@ -6,7 +6,6 @@ import time
 import sympy
 import torch
 import torch.fx
-from sympy import Integer
 from torch._decomp import get_decompositions
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.utils._mode_utils import no_dispatch

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -1851,6 +1851,15 @@ class NoneAsConstantBuffer(IRNode):
         return "None"
 
 
+class ShapeAsConstantBuffer(IRNode):
+    def __init__(self, shape):
+        super().__init__()
+        self.shape = shape
+
+    def codegen_reference(self):
+        return str(self.shape)
+
+
 @dataclasses.dataclass
 class ComputedBuffer(Buffer):
     data: Loops
@@ -2274,6 +2283,8 @@ class ExternKernel(InputsKernel):
     def realize_input(cls, x):
         if x is None:
             return NoneAsConstantBuffer()
+        if isinstance(x, sympy.Expr):
+            return ShapeAsConstantBuffer(x)
         if isinstance(x, Constant):
             return V.graph.add_tensor_constant(
                 torch.tensor(x.value, dtype=x.get_dtype(), device=x.get_device())

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -37,6 +37,7 @@ from .utils import cache_on_self
 from .utils import sympy_dot
 from .utils import sympy_product
 from .utils import sympy_subs
+from .utils import sympy_symbol
 from .virtualized import V
 from .virtualized import ops
 
@@ -306,7 +307,7 @@ class Loops(IRNode):
     @staticmethod
     def _index(ranges, prefix="i"):
         return [
-            sympy.Integer(0) if s == 1 else sympy.Symbol(f"{prefix}{n}")
+            sympy.Integer(0) if s == 1 else sympy_symbol(f"{prefix}{n}")
             for n, s in enumerate(ranges)
         ]
 
@@ -1181,7 +1182,7 @@ class View(BaseView):
         return idx
 
     def reindex_str(self):
-        index_old = [sympy.Symbol(f"i{n}") for n in range(len(self.size))]
+        index_old = [sympy_symbol(f"i{n}") for n in range(len(self.size))]
         index_new = list(self.reindex(index_old))
         return f"lambda {', '.join(map(str, index_old))}: {index_new}"
 
@@ -1250,7 +1251,7 @@ class View(BaseView):
         Perform a reshape entirely by modifying indexing math
         """
         size_hint = V.graph.sizevars.size_hint
-        vars = [sympy.Symbol(f"view{i}") for i in range(len(new_size))]
+        vars = [sympy_symbol(f"view{i}") for i in range(len(new_size))]
 
         stack_new = list(zip(vars, new_size))
         stack_old = list(old_size)
@@ -1966,7 +1967,6 @@ class ComputedBuffer(Buffer):
             for i, reads_buf in enumerate(reads_bufs):
                 if isinstance(reads_buf, Convolution):
                     priority_idx.append(i)
-
         index_vars = []
         reduce_vars = []
         index_size = []
@@ -2377,7 +2377,7 @@ class ExternKernel(InputsKernel):
         sizes = self.get_size()
         strides = self.get_stride()
         strides = [sizevars.size_hint(x) for x in strides]
-        index_vars = [sympy.Symbol(f"d{i}") for i in range(len(sizes))]
+        index_vars = [sympy_symbol(f"d{i}") for i in range(len(sizes))]
         # reorder index vars according to stride
         index_order = sorted(range(len(strides)), key=strides.__getitem__, reverse=True)
         lookup = {pos: idx for idx, pos in enumerate(index_order)}
@@ -3436,7 +3436,7 @@ class LoopBody:
 
     def add_indirect(self):
         name = f"indirect{len(self.indirect_vars)}"
-        var = sympy.Symbol(name)
+        var = sympy_symbol(name)
         self.indirect_vars.append([var])
         return var
 

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -21,7 +21,9 @@ from . import ir
 from . import overrides
 from .decomposition import decompositions
 from .decomposition import get_decompositions
-from .ir import ExpandView, IndexingConstant, IndexingDiv
+from .ir import ExpandView
+from .ir import IndexingConstant
+from .ir import IndexingDiv
 from .ir import PermuteView
 from .ir import Pointwise
 from .ir import Reduction
@@ -257,16 +259,17 @@ def promote_constants(inputs):
     out = []
     for x in inputs:
         if isinstance(x, (int, float)):
-            out.append(ExpandView.create(
-                ir.Constant(x, ex.get_dtype(), ex.get_device()), list(ex.get_size())
-            ))
+            out.append(
+                ExpandView.create(
+                    ir.Constant(x, ex.get_dtype(), ex.get_device()), list(ex.get_size())
+                )
+            )
         elif isinstance(x, sympy.Expr):
             out.append(IndexingConstant(x, ex.get_dtype(), ex.get_device()))
         else:
             out.append(x)
 
     return out
-
 
 
 def make_pointwise(
@@ -3298,6 +3301,7 @@ register_inplace(aten.sigmoid_, sigmoid)
 def sym_size(a, dim):
     return a.get_size()[dim]
 
+
 @register_lowering(aten.sym_numel)
 def sym_numel(a):
     return a.get_numel()
@@ -3307,9 +3311,11 @@ def sym_numel(a):
 def op_mul(a, b):
     return a * b
 
+
 @register_lowering(operator.add)
 def op_add(a, b):
     return a + b
+
 
 @register_lowering(operator.floordiv)
 def op_floordiv(a, b):

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -1567,7 +1567,7 @@ def gather(x, dim, index):
     )
 
 
-# @register_lowering(aten.embedding, type_promotion_kind=None)
+@register_lowering(aten.embedding, type_promotion_kind=None)
 def embedding(weight, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False):
     assert not sparse
     assert isinstance(weight, TensorBox)

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -44,11 +44,11 @@ class PositiveGuard:
 
 
 class SizeVarAllocator(object):
-    def __init__(self, prefix="s", zero_one_const=True):
+    def __init__(self, shape_env, zero_one_const=True):
         super().__init__()
-        self.prefix = prefix
+        self.shape_env = shape_env
+        self.var_to_val = self.shape_env.var_to_val
         self.val_to_var: Dict[int, Expr] = {0: Integer(0), 1: Integer(1)}
-        self.var_to_val: Dict[Expr, int] = collections.OrderedDict()
         self.guards = []
         self.replacements: Dict[sympy.Symbol, Expr] = {}
         self.need_seed = False

--- a/torchinductor/sizevars.py
+++ b/torchinductor/sizevars.py
@@ -372,13 +372,6 @@ class SizeVarAllocator(object):
         return var
 
     def size_hint(self, expr: Expr) -> int:
-        if isinstance(expr, sympy.Expr):
-            additional_mapping = {}
-            for s in expr.free_symbols:
-                if not s.is_integer:
-                    additional_mapping[s] = sympy_symbol(s.name)
-
-            expr = sympy_subs(expr, additional_mapping)
         out = sympy_subs(sympy.expand(expr), self.var_to_val)
         return int(out)
 

--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -200,6 +200,7 @@ def sympy_str(expr: sympy.Expr):
 def sympy_symbol(name):
     return sympy.Symbol(name, integer=True, positive=True)
 
+
 def sympy_subs(expr: sympy.Expr, replacements: Dict[Any, Any]):
     """
     xreplace is faster than subs, but is way more picky

--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -197,6 +197,9 @@ def sympy_str(expr: sympy.Expr):
     return str(expr)
 
 
+def sympy_symbol(name):
+    return sympy.Symbol(name, integer=True, positive=True)
+
 def sympy_subs(expr: sympy.Expr, replacements: Dict[Any, Any]):
     """
     xreplace is faster than subs, but is way more picky
@@ -204,7 +207,7 @@ def sympy_subs(expr: sympy.Expr, replacements: Dict[Any, Any]):
 
     def promote_strings(key):
         if isinstance(key, str):
-            return sympy.Symbol(key)
+            return sympy_symbol(key)
         return key
 
     return expr.xreplace(

--- a/torchinductor/virtualized.py
+++ b/torchinductor/virtualized.py
@@ -7,6 +7,7 @@ from torch.fx.graph import inplace_methods
 from torch.fx.graph import magic_methods
 
 from .utils import sympy_str
+from .utils import sympy_symbol
 
 threadlocal = local()
 
@@ -70,7 +71,7 @@ class MockHandler:
 
     @staticmethod
     def indirect_indexing(index_var):
-        return sympy.Symbol(str(index_var))
+        return sympy_symbol(str(index_var))
 
     @classmethod
     def _init_cls(cls):


### PR DESCRIPTION
Still somewhat WIP.

Goes together with this PR: https://github.com/pytorch/pytorch/pull/86659

Some notes:

1. I'm switching over to using `sympy.Symbol(..., integer=True, positive=True)`. I think there's benefits in simplifications here.

For ex:
<img width="557" alt="image" src="https://user-images.githubusercontent.com/6355099/194981677-31b4faa4-f448-4121-a13e-f903ed84e210.png">

2. I'm passing `ShapeEnv` to `SizeVarAllocator` and reusing `var_to_val`. Right now that's the only thing that's shared, but I'll probably rewrite some more of inductor's `SizeVarAllocator` to reuse `ShapeEnv`.

3. i moved the `symbolic_sizes_strides` logic into core: https://github.com/pytorch/pytorch/pull/86659/files#diff-03557db7303b8540f095b4f0d9cd2280e1f42f534f67d8695f756ec6c02d3ec7R332