### PR TITLE
Added softplus and softplus_backwards to decomps

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -137,6 +137,8 @@ inductor_skips["cuda"] = {
     "jiterator_binary": {b8, f16, f32, f64, i32, i64},
     "jiterator_binary_return_by_ref": {b8, f16, f32, f64, i32, i64},
     "jiterator_unary": {b8, f16, f32, f64, i32, i64},
+    # Triton bug leads to segfault
+    "nn.functional.softplus": {f64},
 }
 
 inductor_expected_failures_single_sample = defaultdict(dict)

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -139,6 +139,7 @@ inductor_skips["cuda"] = {
     "jiterator_unary": {b8, f16, f32, f64, i32, i64},
     # Triton bug leads to segfault
     "nn.functional.softplus": {f64},
+    "nn.functional.mish": {f64},
 }
 
 inductor_expected_failures_single_sample = defaultdict(dict)

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -97,6 +97,8 @@ decompositions = get_decompositions(
         aten.tril.default,
         aten.upsample_bilinear2d.vec,
         aten.upsample_nearest2d_backward,
+        aten.softplus,
+        aten.softplus_backward,
     ]
 )
 


### PR DESCRIPTION
Turns out the decomps had been in pytorch for a while, and benchmarks look good.

<details><summary>Benchmarks compared to eager</summary>

```
[--------------------------- softplus ---------------------------]
                                               |  eager  |  decomp
32 threads: ------------------------------------------------------
      (torch.Size([1024]),), (2.0, 20.0)       |      6  |      8
      (torch.Size([1048576]),), (2.0, 20.0)    |     31  |     31
      (torch.Size([33554432]),), (2.0, 20.0)   |    925  |    948
      (torch.Size([67108864]),), (2.0, 20.0)   |   1848  |   1900
      (torch.Size([134217728]),), (2.0, 20.0)  |   3691  |   3783
      (torch.Size([268435456]),), (2.0, 20.0)  |   7380  |   7540

[---------------------------------- softplus_backward -----------------------------------]
                                                                       |  eager  |  decomp
32 threads: ------------------------------------------------------------------------------
      (torch.Size([1024]), torch.Size([1024])), (2.0, 20.0)            |      6  |      9
      (torch.Size([1048576]), torch.Size([1048576])), (2.0, 20.0)      |     45  |     45
      (torch.Size([33554432]), torch.Size([33554432])), (2.0, 20.0)    |   1351  |   1388
      (torch.Size([67108864]), torch.Size([67108864])), (2.0, 20.0)    |   2699  |   2771
      (torch.Size([134217728]), torch.Size([134217728])), (2.0, 20.0)  |   5397  |   5533
      (torch.Size([268435456]), torch.Size([268435456])), (2.0, 20.0)  |  10790  |  11080
```

</details>

For future reference, filed an issue with triton about this: https://github.com/openai/triton/issues/773