### PR TITLE
Fix autograd alias error

### DIFF
--- a/torchdynamo/variables/builder.py
+++ b/torchdynamo/variables/builder.py
@@ -401,6 +401,7 @@ class VariableBuilder:
             and type(getattr(value, "__self__", None))
             is torch.autograd.function.FunctionMeta
             and getattr(value, "__name__", "") == "apply"
+            and value == getattr(value.__self__, "apply", None)
         ):
             # handle aliased autograd function `apply` calls
             return GetAttrVariable(


### PR DESCRIPTION
Handle the case where we call an alias to a custom autograd function's original apply method, but the `apply` attribute in the custom function has been patched after assigning an alias to it.