### PR TITLE
Fix AutogradProfilerContextWrapperVariable missing one positional argument error (#1329)

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1316,6 +1316,7 @@ class MiscTests(torchdynamo.testing.TestCase):
         opt_fn = torchdynamo.optimize(cnts)(fn)
         res = opt_fn(x)
         self.assertTrue(same(ref, res))
+        self.assertEqual(cnts.frame_count, 2)
 
     def test_python_slice(self):
         def f1(input):

--- a/torchdynamo/variables/misc.py
+++ b/torchdynamo/variables/misc.py
@@ -358,8 +358,10 @@ class AutocastModeVariable(ContextWrappingVariable):
 
 
 class AutogradProfilerContextWrapperVariable(ContextWrappingVariable):
-    def __init__(self, **kwargs):
-        super(AutogradProfilerContextWrapperVariable, self).__init__(**kwargs)
+    def __init__(self, target_values=None, **kwargs):
+        super(AutogradProfilerContextWrapperVariable, self).__init__(
+            target_values=target_values, **kwargs
+        )
 
     def enter(self, tx):
         return variables.ConstantVariable(None, **VariableTracker.propagate(self))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

