### PR TITLE
New way to compile to libdevice calls for f64

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -102,10 +102,6 @@ inductor_skips = defaultdict(dict)
 
 inductor_skips["cpu"] = {
     "linalg.ldl_solve": {b8, f16, f32, f64, i32, i64},  # segfault
-    "linalg.lu_solve": {b8, f16, f32, f64, i32, i64},  # segfault
-    "reciprocal": {b8, i32, i64},  # segfault
-    "lu_solve": {b8, f16, f32, f64, i32, i64},  # segfault
-    "lu_unpack": {b8, f16, f32, f64, i32, i64},  # segfault
     "__rdiv__": {b8, f16, f32, f64, i32, i64},  # flaky
 }
 
@@ -117,29 +113,12 @@ inductor_skips["cuda"] = {
     "sparse.sampled_addmm": {f32, f64},
     "broadcast_tensors": {f16, f32, f64},
     "dsplit": {f16, f32, f64},
-    # Call parameter type does not match function signature!
-    "masked.logsumexp": {f64},
-    "erf": {f64},
-    "logsumexp": {f64},
-    "lu_unpack": {f32, f64},  # RuntimeError: CUDA error
-    "nn.functional.binary_cross_entropy_with_logits": {f64},
-    "nn.functional.gelu": {f64},
-    "nn.functional.glu": {f64},
-    "nn.functional.poisson_nll_loss": {f64},
-    "nn.functional.tanhshrink": {f16, f64},
-    "nn.functional.conv_transpose3d": {f16, f64},
-    "nn.functional._scaled_dot_product_attention": {f64},
-    "nn.functional.triplet_margin_loss": {f16},
-    "special.ndtr": {f64},
     # Jiterator kernel is not expected to work with inductor
     "jiterator_2inputs_2outputs": {b8, f16, f32, f64, i32, i64},
     "jiterator_4inputs_with_extra_args": {b8, f16, f32, f64, i32, i64},
     "jiterator_binary": {b8, f16, f32, f64, i32, i64},
     "jiterator_binary_return_by_ref": {b8, f16, f32, f64, i32, i64},
     "jiterator_unary": {b8, f16, f32, f64, i32, i64},
-    # Triton bug leads to segfault
-    "nn.functional.softplus": {f64},
-    "nn.functional.mish": {f64},
 }
 
 inductor_expected_failures_single_sample = defaultdict(dict)
@@ -200,6 +179,9 @@ inductor_expected_failures_single_sample["cpu"] = {
     "linalg.matrix_rank": {f32, f64},
     "linalg.matrix_rank.hermitian": {f32, f64},
     "linalg.svd": {f32, f64},
+    "linalg.lu_solve": {f32, f64},
+    "lu_solve": {f32, f64},
+    "lu_unpack": {f32, f64},
     "logdet": {f32, f64},
     "masked.norm": {f16},
     "masked_fill": {f16},
@@ -277,7 +259,6 @@ inductor_expected_failures_single_sample["cuda"] = {
     "corrcoef": {f16, f32, f64, i32, i64},
     "cov": {f16, f32, f64, i32, i64},
     "equal": {b8, f16, f32, f64, i32, i64},
-    "erf": {b8},
     "fft.fft": {f16, f32, f64},
     "fft.fft2": {b8, f16, f32, f64, i32, i64},
     "fft.fftn": {b8, f16, f32, f64, i32, i64},
@@ -312,6 +293,7 @@ inductor_expected_failures_single_sample["cuda"] = {
     "linalg.matrix_rank.hermitian": {f32, f64},
     "linalg.pinv.hermitian": {f32, f64},
     "linalg.svd": {f32, f64},
+    "lu_unpack": {f32, f64},
     "masked.argmax": {f16, f32, f64, i32},
     "masked.argmin": {f16, f32, f64, i32},
     "masked_scatter": {f16, f32, f64},
@@ -320,7 +302,6 @@ inductor_expected_failures_single_sample["cuda"] = {
     "min.reduction_with_dim": {b8, i32, i64},
     "multinomial": {f16, f32, f64},
     "nn.functional.adaptive_avg_pool2d": {f16},
-    "nn.functional._scaled_dot_product_attention": {f64},
     "nn.functional.ctc_loss": {f32, f64},
     "nn.functional.grid_sample": {f16},
     "nn.functional.gaussian_nll_loss": {f16, f32, f64},
@@ -353,6 +334,11 @@ inductor_expected_failures_single_sample["cuda"] = {
     "unique": {b8, f16, f32, f64, i32, i64},
     "unique_consecutive": {b8, f16, f32, f64, i32, i64},
     "view_as_complex": {f16, f32, f64},
+    # AssertionError: Tensor-likes are not close!
+    "erf": {b8, f64},
+    "nn.functional.gelu": {f64},
+    "nn.functional.conv_transpose3d": {f16},
+    "nn.functional.triplet_margin_loss": {f16},
 }
 
 inductor_gradient_expected_failures_single_sample = defaultdict(dict)

--- a/torchinductor/codegen/common.py
+++ b/torchinductor/codegen/common.py
@@ -84,15 +84,6 @@ class OpOverrides:
         return repr(value)
 
     @staticmethod
-    def sigmoid(x):
-        x = ops.exp(f"-{x}")
-        return f"1 / (1 + {x})"
-
-    @staticmethod
-    def silu(x):
-        return f"{x} * {ops.sigmoid(x)}"
-
-    @staticmethod
     def reciprocal(x):
         return ops.div("1", x)
 

--- a/torchinductor/codegen/cpp.py
+++ b/torchinductor/codegen/cpp.py
@@ -307,6 +307,11 @@ class CppOverrides(OpOverrides):
     def randn(seed: sympy.Expr, offset: sympy.Expr, dtype):
         return f"static_cast<{DTYPE_TO_CPP[dtype]}>(randn_cpu({seed}, {offset}));"
 
+    @staticmethod
+    def sigmoid(x):
+        x = ops.exp(f"-{x}")
+        return f"1 / (1 + {x})"
+
 
 class CppKernel(Kernel):
     overrides = CppOverrides

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -113,15 +113,27 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def abs(x):
-        return f"tl.libdevice.abs({x}) if ({x}).dtype is tl.float64 else tl.abs({x})"
+        return f"tl.abs({x})"
+
+    @staticmethod
+    def libdevice_abs(x):
+        return f"tl.libdevice.abs({x})"
 
     @staticmethod
     def exp(x):
-        return f"tl.libdevice.exp({x}) if ({x}).dtype is tl.float64 else tl.exp({x})"
+        return f"tl.exp({x})"
+
+    @staticmethod
+    def libdevice_exp(x):
+        return f"tl.libdevice.exp({x})"
 
     @staticmethod
     def sqrt(x):
-        return f"tl.libdevice.sqrt({x}) if ({x}).dtype is tl.float64 else tl.sqrt({x})"
+        return f"tl.sqrt({x})"
+
+    @staticmethod
+    def libdevice_sqrt(x):
+        return f"tl.libdevice.sqrt({x})"
 
     @staticmethod
     def relu(x):
@@ -153,11 +165,19 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def cos(x):
-        return f"tl.libdevice.cos({x}) if ({x}).dtype is tl.float64 else tl.cos({x})"
+        return f"tl.cos({x})"
+
+    @staticmethod
+    def libdevice_cos(x):
+        return f"tl.libdevice.cos({x})"
 
     @staticmethod
     def sin(x):
-        return f"tl.libdevice.sin({x}) if ({x}).dtype is tl.float64 else tl.sin({x})"
+        return f"tl.sin({x})"
+
+    @staticmethod
+    def libdevice_sin(x):
+        return f"tl.libdevice.sin({x})"
 
     @staticmethod
     def index_expr(expr, dtype):
@@ -210,7 +230,11 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def log(x):
-        return f"tl.libdevice.log({x}) if ({x}).dtype is tl.float64 else tl.log({x})"
+        return f"tl.log({x})"
+
+    @staticmethod
+    def libdevice_log(x):
+        return f"tl.libdevice.log({x})"
 
     @staticmethod
     def isinf(x):

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -216,6 +216,14 @@ class TritonOverrides(OpOverrides):
         return f"tl.libdevice.rsqrt({x})"
 
     @staticmethod
+    def sigmoid(x):
+        return f"tl.sigmoid({x})"
+
+    @staticmethod
+    def libdevice_sigmoid(x):
+        return f"1/(1 + tl.libdevice.exp(-({x})))"
+
+    @staticmethod
     def signbit(x):
         # XX: This is wrong for the value -0.0 in floating point
         return f"tl.libdevice.signbitf({x}) if ({x}).dtype is tl.float32 else {x} < 0"

--- a/torchinductor/decomposition.py
+++ b/torchinductor/decomposition.py
@@ -99,6 +99,7 @@ decompositions = get_decompositions(
         aten.upsample_nearest2d_backward,
         aten.softplus,
         aten.softplus_backward,
+        aten.silu,
     ]
 )
 

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -312,7 +312,7 @@ def make_pointwise(
             assert len(index) == len(ranges), f"wrong ndim {index} {ranges}"
             if dtype == torch.bool and override_fn_when_input_bool is not None:
                 return override_fn_when_input_bool(*[load(index) for load in loaders])
-            elif override_fn_when_cuda_float64 and is_cuda and dtype  == torch.float64:
+            elif override_fn_when_cuda_float64 and is_cuda and dtype == torch.float64:
                 return override_fn_when_cuda_float64(*[load(index) for load in loaders])
             else:
                 return fn(*[load(index) for load in loaders])
@@ -3223,26 +3223,31 @@ add = register_pointwise(
     aten.add, allow_alpha=True, override_fn_when_input_bool="logical_or"
 )
 exp = register_pointwise(
-    aten.exp, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT, use_libdevice_for_f64=True
+    aten.exp,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    use_libdevice_for_f64=True,
 )
 relu = register_pointwise(aten.relu)
 sigmoid = register_pointwise(
     aten.sigmoid, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
 )
 sqrt = register_pointwise(
-    aten.sqrt, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
-    use_libdevice_for_f64=True
+    aten.sqrt,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    use_libdevice_for_f64=True,
 )
 square = register_pointwise(aten.square)
 sub = register_pointwise(aten.sub, allow_alpha=True)
 
 register_pointwise(
-    aten.cos, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
-    use_libdevice_for_f64=True
+    aten.cos,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    use_libdevice_for_f64=True,
 )
 register_pointwise(
-    aten.sin, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
-    use_libdevice_for_f64=True
+    aten.sin,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    use_libdevice_for_f64=True,
 )
 register_pointwise(aten.abs, use_libdevice_for_f64=True)
 register_pointwise(aten.bitwise_and)
@@ -3253,8 +3258,9 @@ register_pointwise(
     aten.lgamma, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
 )
 register_pointwise(
-    aten.log, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
-    use_libdevice_for_f64=True
+    aten.log,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    use_libdevice_for_f64=True,
 )
 register_pointwise(aten.logical_not, convert_input_to_bool=True)
 register_pointwise(aten.maximum)

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -287,6 +287,7 @@ def make_pointwise(
     override_return_dtype=None,
     override_device=None,
     override_fn_when_input_bool=None,
+    override_fn_when_cuda_float64=None,
     allow_alpha=False,
 ):
     def inner(*inputs: List[TensorBox], alpha=None):
@@ -300,6 +301,7 @@ def make_pointwise(
         loaders = [x.make_loader() for x in inputs]
         ranges = inputs[0].get_size()
         dtype = override_return_dtype or inputs[0].get_dtype()
+        is_cuda = decode_device(inputs[0].get_device()).type == "cuda"
 
         for other in inputs[1:]:
             assert isinstance(other, ir.BaseConstant) or len(ranges) == len(
@@ -310,6 +312,8 @@ def make_pointwise(
             assert len(index) == len(ranges), f"wrong ndim {index} {ranges}"
             if dtype == torch.bool and override_fn_when_input_bool is not None:
                 return override_fn_when_input_bool(*[load(index) for load in loaders])
+            elif override_fn_when_cuda_float64 and is_cuda and dtype  == torch.float64:
+                return override_fn_when_cuda_float64(*[load(index) for load in loaders])
             else:
                 return fn(*[load(index) for load in loaders])
 
@@ -412,10 +416,13 @@ def register_pointwise(
     override_return_dtype=None,
     override_fn_when_input_bool=None,
     allow_alpha=False,
+    use_libdevice_for_f64=False,
 ):
     """A pointwise function that maps ops.{name} to inputs"""
     name = name or aten_fn.__name__
     fn = ops_wrapper(name)
+    if use_libdevice_for_f64:
+        fn_libdevice = ops_wrapper("libdevice_" + name)
     if override_fn_when_input_bool is not None:
         override_fn_when_input_bool = ops_wrapper(override_fn_when_input_bool)
 
@@ -423,6 +430,7 @@ def register_pointwise(
         fn,
         override_return_dtype=override_return_dtype,
         override_fn_when_input_bool=override_fn_when_input_bool,
+        override_fn_when_cuda_float64=fn_libdevice if use_libdevice_for_f64 else None,
         allow_alpha=allow_alpha,
     )
     fn = register_lowering(
@@ -3215,25 +3223,28 @@ add = register_pointwise(
     aten.add, allow_alpha=True, override_fn_when_input_bool="logical_or"
 )
 exp = register_pointwise(
-    aten.exp, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+    aten.exp, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT, use_libdevice_for_f64=True
 )
 relu = register_pointwise(aten.relu)
 sigmoid = register_pointwise(
     aten.sigmoid, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
 )
 sqrt = register_pointwise(
-    aten.sqrt, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+    aten.sqrt, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    use_libdevice_for_f64=True
 )
 square = register_pointwise(aten.square)
 sub = register_pointwise(aten.sub, allow_alpha=True)
 
 register_pointwise(
-    aten.cos, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+    aten.cos, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    use_libdevice_for_f64=True
 )
 register_pointwise(
-    aten.sin, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+    aten.sin, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    use_libdevice_for_f64=True
 )
-register_pointwise(aten.abs)
+register_pointwise(aten.abs, use_libdevice_for_f64=True)
 register_pointwise(aten.bitwise_and)
 register_pointwise(aten.bitwise_not, override_fn_when_input_bool="logical_not")
 register_pointwise(aten.bitwise_or)
@@ -3242,7 +3253,8 @@ register_pointwise(
     aten.lgamma, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
 )
 register_pointwise(
-    aten.log, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+    aten.log, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    use_libdevice_for_f64=True
 )
 register_pointwise(aten.logical_not, convert_input_to_bool=True)
 register_pointwise(aten.maximum)

--- a/torchinductor/lowering.py
+++ b/torchinductor/lowering.py
@@ -3229,7 +3229,9 @@ exp = register_pointwise(
 )
 relu = register_pointwise(aten.relu)
 sigmoid = register_pointwise(
-    aten.sigmoid, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+    aten.sigmoid,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    use_libdevice_for_f64=True,
 )
 sqrt = register_pointwise(
     aten.sqrt,
@@ -3249,7 +3251,7 @@ register_pointwise(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
     use_libdevice_for_f64=True,
 )
-register_pointwise(aten.abs, use_libdevice_for_f64=True)
+register_pointwise(aten.abs)
 register_pointwise(aten.bitwise_and)
 register_pointwise(aten.bitwise_not, override_fn_when_input_bool="logical_not")
 register_pointwise(aten.bitwise_or)
@@ -3271,9 +3273,6 @@ register_pointwise(
 )
 register_pointwise(aten.remainder)
 register_pointwise(aten.sign, override_fn_when_input_bool="identity")
-register_pointwise(
-    aten.silu, type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
-)
 register_pointwise(aten.ceil)
 register_pointwise(aten.fmod)
 register_pointwise(aten.signbit, override_return_dtype=torch.bool)


### PR DESCRIPTION
This is partly to generate cleaner triton code,
and partly to workaround a triton bug.

See https://github.com/pytorch/torchdynamo/pull/1605
