### PR TITLE
Use Fake Tensors For Shape/Stride Propagation

### DIFF
--- a/torchinductor/compile_fx.py
+++ b/torchinductor/compile_fx.py
@@ -8,7 +8,6 @@ import functorch
 import torch.fx
 from functorch.compile import min_cut_rematerialization_partition
 from torch._subclasses.fake_tensor import FakeTensor
-from torch.utils._mode_utils import no_dispatch
 
 from . import config
 from . import overrides
@@ -73,7 +72,7 @@ def _step_logger():
 
 
 @DebugContext.wrap
-@no_dispatch()
+@dynamo_utils.disable_current_modes()
 def compile_fx_inner(
     gm: torch.fx.GraphModule,
     example_inputs: List[torch.Tensor],

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -27,6 +27,7 @@ from sympy import Expr
 from sympy import Integer
 from torch._prims_common import is_boolean_dtype
 from torch._prims_common import is_float_dtype
+from torch._subclasses.fake_tensor import FakeTensorMode
 
 from . import config
 from . import dependencies
@@ -2866,17 +2867,18 @@ class FallbackKernel(ExternKernelAlloc):
         # We don't have generic shape formulas, so just burn in the
         # shapes and run an example input.
         # TODO(jansel): replace this with dynamic shape formulas
-        example_args = [
-            torch.zeros(
-                [V.graph.sizevars.guard_static_shape(s) for s in x.get_size()],
-                dtype=x.get_dtype(),
-                device=x.get_device(),
+        with FakeTensorMode():
+            example_args = [
+                torch.zeros(
+                    [V.graph.sizevars.guard_static_shape(s) for s in x.get_size()],
+                    dtype=x.get_dtype(),
+                    device=x.get_device(),
+                )
+                for x in tensor_args
+            ]
+            example_output = kernel(
+                *unflatten_args(example_args, non_tensor_args), **kwargs
             )
-            for x in tensor_args
-        ]
-        example_output = kernel(
-            *unflatten_args(example_args, non_tensor_args), **kwargs
-        )
 
         if isinstance(example_output, (list, tuple)):
             packed = FallbackKernel(


### PR DESCRIPTION
@Chillee observed peak memory increase from this invocation which I have been unable to repro upon rebase.. Nevertheless, we should do this anyway because it will be necessary in the dynamic shapes case, and I think we have some other issues today with running kernels like `lu_solve` which will error on inputs being zero. 