### PR TITLE
Convolution(_backward) bias decomposition for nvprims

### DIFF
--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -12,7 +12,7 @@ from torch.fx.passes.backends.cudagraphs import partition_cudagraphs
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.nn import Module
 from torch.utils._pytree import tree_map
-from torch._deomp import register_decomposition
+from torch._decomp import register_decomposition
 
 from .. import config
 from ..debug_utils import wrap_compiler_debug

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -364,9 +364,7 @@ def convolution(
             True,
             False,
             True,
-            True,
-        )
-    )
+            True)
     if bias is not None:
         #kernel_dims = len(weight.get_size()) - 2
         #out_chan = result.get_size()[-1 - kernel_dims]

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -421,7 +421,7 @@ def convolution_backward(
     # remove bias output from convolution_backward
     output_mask[2] = False
     result = torch.ops.aten.convolution_backward(
-            grad_output
+            grad_output,
             x,
             weight,
             None,

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -363,10 +363,10 @@ def convolution(
             transposed,
             output_padding,
             groups,
-            True,
-            False,
-            True,
-            True)
+            torch._C._get_cudnn_benchmark(),
+            torch._C._get_cudnn_deterministic() or torch._C._get_deterministic_algorithms(),
+            torch._C._get_cudnn_enabled(),
+            torch._C._get_cudnn_allow_tf32())
     if bias is not None:
         bias = bias.view([-1] + (x.dim() - 2) * [1])
         result = result.add(bias)

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -406,8 +406,7 @@ def convolution_backward(
     assert result[2] is None
     reduction_axes = [i for i in range(x.dim()) if i != 1]
     bias_grad = grad_output.sum(reduction_axes)
-    result[2] = bias_grad
-    return result
+    return (result[0], result[1], bias_grad)
 
 def create_nvprims_backend(*, executor):
     class NvPrims(AotAutogradStrategy):

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -350,9 +350,8 @@ def convolution(
     output_padding: List[int],
     groups: int,
 ):
-    result =
-        # TODO: pass in extra flags
-        torch._convolution(
+    # TODO: pass in extra flags
+    result = torch._convolution(
             x,
             weight,
             None,  # bias handled below

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -23,6 +23,8 @@ from .analysis import has_mutation
 from .backends import BACKENDS
 from .normalize import normalize_ir
 
+from typing import List
+
 log = logging.getLogger(__name__)
 
 

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -368,8 +368,8 @@ def convolution(
     if bias is not None:
         #kernel_dims = len(weight.get_size()) - 2
         #out_chan = result.get_size()[-1 - kernel_dims]
-        #bias = view(bias, [out_chan] + kernel_dims * [1])
-        result = add(result, bias)
+        bias = view(bias, [-1] + (x.dim() - 2) * [1])
+        result = result.add(bias)
     return result
 
 

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -23,7 +23,7 @@ from .analysis import has_mutation
 from .backends import BACKENDS
 from .normalize import normalize_ir
 
-from typing import List
+from typing import List, Optional
 
 log = logging.getLogger(__name__)
 

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -357,35 +357,6 @@ def convolution(
     if bias is None:
         return NotImplemented
 
-    result = torch.ops.aten.convolution(
-            x,
-            weight,
-            None,  # bias handled below
-            stride,
-            padding,
-            dilation,
-            transposed,
-            output_padding,
-            groups)
-    bias = bias.view([-1] + (x.dim() - 2) * [1])
-    result = result.add(bias)
-    return result
-
-@register_decomposition(torch.ops.aten.convolution)
-def convolution(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-    stride: List[int],
-    padding: List[int],
-    dilation: List[int],
-    transposed: bool,
-    output_padding: List[int],
-    groups: int,
-):
-    if bias is None:
-        return NotImplemented
-
     # remove bias output from convolution
     result = torch.ops.aten.convolution(
             x,

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -368,9 +368,7 @@ def convolution(
             True,
             True)
     if bias is not None:
-        #kernel_dims = len(weight.get_size()) - 2
-        #out_chan = result.get_size()[-1 - kernel_dims]
-        bias = view(bias, [-1] + (x.dim() - 2) * [1])
+        bias = bias.view([-1] + (x.dim() - 2) * [1])
         result = result.add(bias)
     return result
 

--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -12,7 +12,7 @@ from torch.fx.passes.backends.cudagraphs import partition_cudagraphs
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.nn import Module
 from torch.utils._pytree import tree_map
-from torch._decomp import register_decomposition
+from torch._decomp import register_decomposition, get_decompositions
 
 from .. import config
 from ..debug_utils import wrap_compiler_debug


### PR DESCRIPTION
Added a decomposition in nvprims code path, so we'll have bias/sum detached from convolution(_backward) op where more fusion opportunity is exposed.