### PR TITLE
Update the naming convention for module_key for easier parsing

### DIFF
--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -529,7 +529,6 @@ class OutputGraph(fx.Tracer):
         msgs = traceback.StackSummary.from_list(frame_summaries).format()
 
         # Carry module_stack along with node.stack_trace for reusing stacktrace propagation infra
-
         nn_module_stack_str = f"Module stack: {nn_module_stack}\n"
         rv.node.stack_trace = nn_module_stack_str + " | ".join(msgs)
 

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -238,7 +238,7 @@ class OutputGraph(fx.Tracer):
         # create a new unique name
         name = "_".join(map(str, names))
         # e.g. repalce abc.xyz[123].qkv with abc.xyz_123.qkv
-        name = re.sub(r"\[(\d+)\]", '_\g<1>', name)
+        name = re.sub(r"\[(\d+)\]", "_\g<1>", name)
         # e.g. replace abc.xyz_123.qkv with abc_xyz_123_qkv
         name = re.sub(r"[^a-zA-Z0-9]", "_", name)
 

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -238,7 +238,7 @@ class OutputGraph(fx.Tracer):
         # create a new unique name
         name = "_".join(map(str, names))
         # e.g. repalce abc.xyz[123].qkv with abc.xyz_123.qkv
-        name = re.sub(r"\[(\d+)\]", "_\g<1>", name)
+        name = re.sub(r"\[(\d+)\]", r"_\g<1>", name)
         # e.g. replace abc.xyz_123.qkv with abc_xyz_123_qkv
         name = re.sub(r"[^a-zA-Z0-9]", "_", name)
 

--- a/torchdynamo/output_graph.py
+++ b/torchdynamo/output_graph.py
@@ -236,7 +236,12 @@ class OutputGraph(fx.Tracer):
                 return wrap_name(k)
 
         # create a new unique name
-        name = re.sub(r"[^a-zA-Z0-9]", "_", "_".join(map(str, names)))
+        name = "_".join(map(str, names))
+        # e.g. repalce abc.xyz[123].qkv with abc.xyz_123.qkv
+        name = re.sub(r"\[(\d+)\]", '_\g<1>', name)
+        # e.g. replace abc.xyz_123.qkv with abc_xyz_123_qkv
+        name = re.sub(r"[^a-zA-Z0-9]", "_", name)
+
         if not name or not name[0].isalpha():
             name = "sub" + name
         base = name
@@ -524,6 +529,7 @@ class OutputGraph(fx.Tracer):
         msgs = traceback.StackSummary.from_list(frame_summaries).format()
 
         # Carry module_stack along with node.stack_trace for reusing stacktrace propagation infra
+
         nn_module_stack_str = f"Module stack: {nn_module_stack}\n"
         rv.node.stack_trace = nn_module_stack_str + " | ".join(msgs)
 


### PR DESCRIPTION
Quantization team is paring the module structure. 

This change produces  `'self_convs_0_conv': 'Conv2d'` instead of `'self_convs_0__conv': 'Conv2d'`