### PR TITLE
handle ops that are present inputs but don't exist in core anymore

### DIFF
--- a/benchmarks/microbenchmarks/operator_inp_utils.py
+++ b/benchmarks/microbenchmarks/operator_inp_utils.py
@@ -289,7 +289,12 @@ class OperatorInputsLoader:
 
     def get_all_ops(self):
         for key in self.operator_db.keys():
-            yield eval(key)
+            try:
+                op = eval(key)
+            except AttributeError as ae:
+                log.warning(f"Evaluating an op name into an OpOverload: {ae}")
+                continue
+            yield op
 
     def get_call_frequency(self, op):
         assert (


### PR DESCRIPTION
These two were removed in pytorch:
```
aten.im2col_backward.default
aten.col2im_backward.default
```

https://github.com/pytorch/pytorch/pull/85542

I can also remove them from input files : @eellison  ? 