### PR TITLE
add benchmarking utility + remove condition for reduction dim to be an integer for us to unroll

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -205,8 +205,6 @@ inductor_expected_failures_single_sample["cpu"] = {
     "masked_fill": {f16},
     "masked_scatter": {f16, f32, f64},
     "masked_select": {b8, f16, f32, f64, i32, i64},
-    "max.reduction_no_dim": {f16},
-    "max.reduction_with_dim": {b8, f16},
     "min.reduction_no_dim": {f16},
     "min.reduction_with_dim": {b8, f16},
     "multinomial": {f32, f64},

--- a/torchinductor/ir.py
+++ b/torchinductor/ir.py
@@ -711,8 +711,7 @@ class Reduction(Loops):
             return Pointwise.create(device, dst_dtype, fn, ranges)
 
         if (
-            isinstance(reduction_numel, sympy.Integer)
-            and V.graph.sizevars.size_hint(reduction_numel)
+            V.graph.sizevars.size_hint(reduction_numel)
             < config.unroll_reductions_threshold
             and sympy_product(ranges) != 1
         ):

--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -262,6 +262,7 @@ def fresh_triton_cache(cache_entries=None):
                     }
                 )
 
+
 def bench_fn(f, name=None, iters=100):
     for _ in range(5):
         f()
@@ -270,7 +271,7 @@ def bench_fn(f, name=None, iters=100):
     for _ in range(iters):
         f()
     torch.cuda.synchronize()
-    us_per_iter = (time.time()-begin)*1e6/iters
+    us_per_iter = (time.time() - begin) * 1e6 / iters
     if name is None:
         print(us_per_iter)
     else:

--- a/torchinductor/utils.py
+++ b/torchinductor/utils.py
@@ -261,3 +261,17 @@ def fresh_triton_cache(cache_entries=None):
                         if ".lock" not in f
                     }
                 )
+
+def bench_fn(f, name=None, iters=100):
+    for _ in range(5):
+        f()
+    torch.cuda.synchronize()
+    begin = time.time()
+    for _ in range(iters):
+        f()
+    torch.cuda.synchronize()
+    us_per_iter = (time.time()-begin)*1e6/iters
+    if name is None:
+        print(us_per_iter)
+    else:
+        print(f"{name}: {us_per_iter}us")


### PR DESCRIPTION
We're already guarding on the reduction ranges, so we might as well lift the requirement that it's an integer.