### PR TITLE
make copy_shape kwarg-only in indexing

### DIFF
--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -649,6 +649,7 @@ class TritonKernel(Kernel):
     def indexing(
         self,
         index: sympy.Expr,
+        *,
         copy_shape=None,
         dense_indexing=False,
     ):
@@ -774,7 +775,7 @@ class TritonKernel(Kernel):
 
     def store(self, name, index, value, mode=None):
         var = self.args.output(name)
-        index, mask = self.indexing(index, value, dense_indexing=True)
+        index, mask = self.indexing(index, dense_indexing=True)
         if mode is None:
             line = f"tl.store({var} + ({index}), {value}, {mask})"
         elif mode == "atomic_add":
@@ -856,7 +857,7 @@ class TritonKernel(Kernel):
             var_name = self.cse.reduction_cache[(src_dtype, reduction_type, value)]
             self.suffix.writeline(f"{result_var} = {var_name}")
         self.inside_reduction = False
-        index, mask = self.indexing(index, result_var)
+        index, mask = self.indexing(index)
         assert "rmask" not in index
         self.inside_reduction = True
         self.outside_loop_vars.add(result_var)

--- a/torchinductor/codegen/triton_template.py
+++ b/torchinductor/codegen/triton_template.py
@@ -79,7 +79,7 @@ class TritonTemplateKernel(TritonKernel):
 
     def indexing(self, index: sympy.Expr, copy_shape=None, dense_indexing=True):
         # use dense_indexing for TritonTemplateKernel to avoid map::at error
-        return super().indexing(index, copy_shape, dense_indexing)
+        return super().indexing(index, copy_shape=copy_shape, dense_indexing=dense_indexing)
 
     def codegen_body(
         self, name, fuse, could_remove_kernel_buf, kernel_buf_replace_name


### PR DESCRIPTION
Fixes #1637
We had a bug in `indexing` that accepted positional args and checked arbitrary value sent there for truthiness, and at a couple callsites we sent an unrelated argument (that of course evaluated to True)