### PR TITLE
Use ProcessPoolExecutor for triton compiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ setup_nightly:
 setup_nightly_gpu:
 	conda install -y -c pytorch magma-cuda116 cudatoolkit=11.6 -c conda-forge
 	$(PIP) install --pre torch==1.14.0.$(PYTORCH_VERSION) \
-                      torchvision==0.15.0.$(PYTORCH_VERSION) \
                       torchtext==0.14.0.$(PYTORCH_VERSION) \
                       --extra-index-url https://download.pytorch.org/whl/nightly/cu116
 	$(PIP) install ninja

--- a/torchinductor/codecache.py
+++ b/torchinductor/codecache.py
@@ -11,8 +11,10 @@ import sysconfig
 import tempfile
 import types
 from concurrent.futures import Future
+from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
 from ctypes import cdll
+from time import time
 from typing import Any
 from typing import Dict
 
@@ -23,6 +25,26 @@ from . import config
 from . import exc
 
 LOCK_TIMEOUT = 600
+
+# timing metrics for time spent in the compilation
+_cumulative_compile_time = 0
+_t0 = None
+
+
+def _compile_start():
+    global _t0
+    if _t0 is None:
+        _t0 = time()
+
+
+def _compile_end():
+    global _cumulative_compile_time, _t0
+    if _t0 is not None:
+        t1 = time()
+        _cumulative_compile_time += t1 - _t0
+        _t0 = None
+        # print("CUMULATIVE COMPILE TIME", _cumulative_compile_time)
+
 
 log = logging.getLogger(__name__)
 logging.getLogger("filelock").setLevel(logging.DEBUG if config.debug else logging.INFO)
@@ -217,6 +239,32 @@ class TritonCodeCache:
         return getattr(mod, cls.get_name(mod))
 
 
+def _worker_compile(source_code, cc):
+    kernel = TritonCodeCache.load(source_code)
+    kernel.precompile(warm_cache_only_with_cc=cc)
+
+
+def _load_kernel(source_code):
+    kernel = TritonCodeCache.load(source_code)
+    kernel.precompile()
+    return kernel
+
+
+class TritonFuture:
+    def __init__(self, source_code, future):
+        self.source_code = source_code
+        self.future = future
+
+    def result(self):
+        if hasattr(self, "kernel"):
+            return self.kernel
+        # If the worker failed this will throw an exception.
+        self.future.result()
+        kernel = self.kernel = _load_kernel(self.source_code)
+        del self.source_code, self.future
+        return kernel
+
+
 class AsyncCompile:
     def __init__(self):
         self._context_keepalive = None
@@ -226,6 +274,41 @@ class AsyncCompile:
     def pool():
         assert config.compile_threads > 1
         return ThreadPoolExecutor(config.compile_threads)
+
+    @staticmethod
+    @functools.lru_cache(1)
+    def process_pool():
+        assert config.compile_threads > 1
+        return ProcessPoolExecutor(config.compile_threads)
+
+    @classmethod
+    def warm_pool(cls):
+        if config.compile_threads <= 1:
+            return
+        _compile_start()
+        pool = cls.process_pool()
+
+        # We have to fork processes for compiler workers, but the more memory and other resources that are loaded, the
+        # slower the os.fork time is, quite drastically. It also holds the GIL so we can't put it on another thread.
+
+        # Examples:
+        # A simple x + x + x script: 10ms seconds in the middle of the program, 2ms at startup
+        # tf_efficientnet_b0 benchmark: 50ms! in the middle of the program , 3ms at startup
+
+        # So we want to start the workers early when it is still cheap, and also to allow the workers to get
+        # ready before we have work for them.
+
+        # ProcessPoolExecutor also does not launch the workers until it finds a point when all the workers are idle.
+        # But if we waited until then fork time will be long and we will be waiting for the processes to initialize.
+
+        # We force them to start here with some YOLOing of the internal methods.
+        if hasattr(pool, "_start_queue_management_thread"):
+            pool._start_queue_management_thread()
+        else:
+            for i in range(config.compile_threads):
+                pool._adjust_process_count()
+            pool._start_executor_manager_thread()
+        _compile_end()
 
     @classmethod
     def submit(cls, task):
@@ -240,16 +323,18 @@ class AsyncCompile:
         return [t.result() for t in [cls.pool().submit(fn, x) for x in seq]]
 
     def triton(self, source_code):
+        _compile_start()
         if self._context_keepalive is None:
             # Workaround `CUDA: Error- context is destroyed`
             self._context_keepalive = torch.tensor([1], device="cuda")
-        kernel = TritonCodeCache.load(source_code)
 
-        def task():
-            kernel.precompile()
-            return kernel
-
-        return self.submit(task)
+        if config.compile_threads > 1:
+            major, minor = torch.cuda.get_device_capability()
+            cc = major * 10 + minor
+            future = self.process_pool().submit(_worker_compile, source_code, cc)
+            return TritonFuture(source_code, future)
+        else:
+            return _load_kernel(source_code)
 
     def cpp(self, source_code):
         def task():
@@ -260,5 +345,10 @@ class AsyncCompile:
     def wait(self, scope: Dict[str, Any]):
         if config.compile_threads > 1:
             for key, result in list(scope.items()):
-                if isinstance(result, Future):
+                if isinstance(result, (Future, TritonFuture)):
                     scope[key] = result.result()
+
+        _compile_end()
+
+
+AsyncCompile.warm_pool()

--- a/torchinductor/config.py
+++ b/torchinductor/config.py
@@ -51,7 +51,7 @@ unroll_reductions_threshold = 8
 
 comment_origin = False
 
-compile_threads = 1
+compile_threads = min(32, os.cpu_count())
 
 # How to import torchinductor, either torchinductor or torch.inductor
 inductor_import = __name__.replace(".config", "")

--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -63,9 +63,7 @@ class CachingAutotuner(KernelInterface):
             ]
             self.configs = None
 
-    def _precompile_config(
-        self, cfg: Config, warm_cache_only_with_cc: int
-    ):
+    def _precompile_config(self, cfg: Config, warm_cache_only_with_cc: int):
         """Ahead of time compile a given autotuner config."""
         compile_meta = copy.deepcopy(self.meta)
         for k, v in cfg.kwargs.items():

--- a/torchinductor/triton_ops/autotune.py
+++ b/torchinductor/triton_ops/autotune.py
@@ -3,7 +3,6 @@ import copy
 import hashlib
 import json
 import logging
-import multiprocessing
 import os.path
 import re
 import threading
@@ -12,7 +11,6 @@ from typing import List
 import torch
 
 from .. import config
-from ..codecache import AsyncCompile
 from ..ir import ReductionHint
 from ..triton_ops.mm_perf_model import estimate_matmul_time
 from ..utils import conditional_product
@@ -55,36 +53,36 @@ class CachingAutotuner(KernelInterface):
         self.launchers = []
         self.lock = threading.Lock()
 
-    def precompile(self):
+    def precompile(self, warm_cache_only_with_cc=None):
         with self.lock:
             if self.launchers:
                 return
-            self.launchers = AsyncCompile.map(self._precompile_config, self.configs)
+            self.launchers = [
+                self._precompile_config(c, warm_cache_only_with_cc)
+                for c in self.configs
+            ]
             self.configs = None
 
-    def _precompile_config(self, cfg: Config):
+    def _precompile_config(
+        self, cfg: Config, warm_cache_only_with_cc: int
+    ):
         """Ahead of time compile a given autotuner config."""
-        torch.cuda.set_device(torch.cuda.current_device())
         compile_meta = copy.deepcopy(self.meta)
         for k, v in cfg.kwargs.items():
             compile_meta["constants"][self.fn.arg_names.index(k)] = v
         compile_meta["num_warps"] = cfg.num_warps
         compile_meta["num_stages"] = cfg.num_stages
 
-        if config.compile_threads > 1:
-            major, minor = torch.cuda.get_device_capability(compile_meta["device"])
-            compile_meta["cc"] = major * 10 + minor
-            try:
-                p = multiprocessing.Process(
-                    target=triton.compile,
-                    args=(self.fn,),
-                    kwargs={**compile_meta, "warm_cache_only": True},
-                )
-                p.start()
-                p.join()
-            except Exception:
-                log.exception("Error in async Triton compile")
-                # continue on to hopefully get a better error message below
+        if warm_cache_only_with_cc:
+            triton.compile(
+                self.fn,
+                warm_cache_only=True,
+                cc=warm_cache_only_with_cc,
+                **compile_meta,
+            )
+            return
+
+        torch.cuda.set_device(torch.cuda.current_device())
 
         binary = triton.compile(
             self.fn,


### PR DESCRIPTION
This patch significantly improves the parallel compilation performance for compiling triton kernels
by using ProcessPoolExecutor to create persistent pool of compilation workers.

Previously os.fork overhead and GIL contention limited the achieved parallelism. This patch replaces
the worker threads with a pool of processes to do the raw compilation, and does serial work on the main thread
for everything else. This other work couldn't be parallelized anyway since it is mostly in python.

In cold start situations, the time to get the worker threads started can be significant portion of the time.
This patch starts the workers earlier so they are ready to perform compilation (see code comments) when dynamo
gets to that point.

Just tested this on one example benchmark (tf_efficientnet_b0), but the results are significant, almost eliminating the difference between a warm and cold compilation.

```
39.613s - warm
41.290s - cold, this patch

2m53.197s - cold, single threaded:
1m7.092s - cold, old setup n = 8 (its best config)
```
 (cold compilation is done after running `rm -rf /tmp/torchinductor_$USER`).