### PR TITLE
Don't only apply DDP optimizer on forward frames

### DIFF
--- a/torchdynamo/eval_frame.py
+++ b/torchdynamo/eval_frame.py
@@ -230,7 +230,7 @@ def catch_errors_wrapper(callback):
                 return None
             if config.optimize_ddp:
                 ddp_module = DistributedDataParallel._get_active_ddp_module()
-                if ddp_module and frame.f_code.co_name == "forward":
+                if ddp_module:
                     with compile_lock:
                         ddp_optimizer = DDPOptimizer(
                             bucket_bytes_cap=ddp_module.bucket_bytes_cap,


### PR DESCRIPTION
Previously a check would only apply DDP optimizer on frames named "forward".

But on hf_T5_large, a graph break causes some frames like:
```
<graph break in _shift_right>
<graph break in forward>
```

So instead, apply DDP optimizer on all frames.