### PR TITLE
include numels in divisible_by_16 descriptor tuple

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4088,7 +4088,7 @@ if HAS_CUDA:
             from torchinductor.graph import GraphLowering
             from torchinductor.virtualized import V
 
-            cxt = TritonTests.SaveGraph()
+            cxt = TritonCodeGenTests.SaveGraph()
             torchdynamo.optimize(cxt.fx_extractor)(fn)(*args)
             fx_graph = cxt.model
             graph = GraphLowering(fx_graph)

--- a/torchinductor/codegen/triton.py
+++ b/torchinductor/codegen/triton.py
@@ -946,14 +946,15 @@ class TritonKernel(Kernel):
         triton_meta = {
             "signature": dict(enumerate(map(signature_of, signature))),
             "device": V.graph.scheduler.current_device.index,
-            "configs": [config_of(signature)],
             "constants": {},
         }
 
         for tree in self.range_trees:
             if tree.prefix != "r" or self.inside_reduction:
+                sizearg = SizeArg(f"{tree.prefix}numel", tree.numel)
+                signature.append(sizearg)
                 triton_meta["signature"][len(argdefs)] = signature_of(
-                    SizeArg(f"{tree.prefix}numel", tree.numel)
+                    sizearg
                 )
                 argdefs.append(f"{tree.prefix}numel")
                 # constexpr version causes issues, see
@@ -962,6 +963,7 @@ class TritonKernel(Kernel):
                 #     tree.numel
                 # )
                 # argdefs.append(f"{tree.prefix}numel: tl.constexpr")
+        triton_meta["configs"] = [config_of(signature)]
 
         for tree in self.range_trees:
             if tree.prefix != "r" or self.inside_reduction:


### PR DESCRIPTION
I am not sure how Triton code generation is tested so I added a class that extracts the kernels from inductor so I can check the descriptor given a function and inputs. @Chillee what is the preferred way to test?

Also I'm not sure what guards need to be added along with this because I'm not sure how this annotation is used yet (TODO: autotune.py contains the decorators that accept these arguments)