### PR TITLE
Revert "Update installation instructions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,18 @@ To use GPU back ends (and in particular Triton), please make sure that the cuda
 that you have installed locally matches the PyTorch version you are running. For
 the command below, you will need CUDA 11.7.
 
-`pip3 install --pre pytorch_triton --extra-index-url https://download.pytorch.org/whl/nightly/cu117`
+```shell
+pip install --pre torch==1.14.0.dev20221014+cu117 --extra-index-url https://download.pytorch.org/whl/nightly/cu117
+pip install -U "git+https://github.com/openai/triton@af76c989eb4799b015f8b288ccd8421558772e56#subdirectory=python"
+pip install -U "git+https://github.com/pytorch/torchdynamo"
+```
 
 #### CPU version
 
-`pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu`
+```shell
+pip install --pre torch==1.13.0.dev20221006 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+pip install -U "git+https://github.com/pytorch/torchdynamo"
+```
 
 ### Install from local source
 


### PR DESCRIPTION
Reverts pytorch/torchdynamo#1710 - package was renamed as `torchtriton` and also it would be better to revamp the whole README first